### PR TITLE
Støtter id som router query, fikser edit-view i content studio

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,7 @@ const configWithAllTheThings = (config) =>
     withTranspileModules(withLess(withImages(config)));
 
 module.exports = configWithAllTheThings({
+    assetPrefix: process.env.APP_ORIGIN,
     env: {
         XP_ORIGIN: process.env.XP_ORIGIN,
     },
@@ -29,6 +30,10 @@ module.exports = configWithAllTheThings({
                         directives: { frameAncestors: '*' },
                     },
                 }),
+            },
+            {
+                source: '/(.*)',
+                headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
             },
         ];
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2624,6 +2624,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -7165,6 +7174,11 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "@navikt/nav-dekoratoren-moduler": "^1.0.21",
         "classnames": "^2.2.6",
+        "cors": "^2.8.5",
         "html-react-parser": "^0.13.0",
         "jsdom": "^16.4.0",
         "nav-frontend-alertstriper": "^3.0.23",

--- a/src/pages/[[...pathRouter]].tsx
+++ b/src/pages/[[...pathRouter]].tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { routerQueryToEnonicPath } from '../utils/paths';
+import { routerQueryToEnonicPathOrId } from '../utils/paths';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import ContentToComponentMapper from '../components/ContentToComponentMapper';
 import {
@@ -44,7 +44,7 @@ const PathRouter = (props: Props) => {
 };
 
 export const getStaticProps: GetStaticProps = async (context) => {
-    const enonicPath = routerQueryToEnonicPath(
+    const enonicPath = routerQueryToEnonicPathOrId(
         context?.params?.pathRouter || ''
     );
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -6,6 +6,12 @@ export type EnonicContentRef = string;
 export const isEnonicPath = (path: string) =>
     /(www.*.nav.no|^nav.no|^)($|\/$|\/no|\/en|\/se|\/nav.no)/.test(path);
 
+export const isUUID = (id: string) =>
+    id &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        id
+    );
+
 export const enonicPathToAppPath = (path: string) =>
     isEnonicPath(path) ? path.split(enonicContentBasePath)[1] : null;
 
@@ -14,10 +20,17 @@ export const enonicPathToUrl = (path: string) =>
         ? `${process.env.APP_ORIGIN}${enonicPathToAppPath(path)}`
         : null;
 
-export const routerQueryToEnonicPath = (routerQuery: string | string[]) => {
-    const queryPath = `/${
+export const routerQueryToEnonicPathOrId = (routerQuery: string | string[]) => {
+    const possibleId =
+        typeof routerQuery === 'string' ? routerQuery : routerQuery[0];
+
+    if (isUUID(possibleId)) {
+        return possibleId;
+    }
+
+    const path = `/${
         typeof routerQuery === 'string' ? routerQuery : routerQuery.join('/')
     }`;
 
-    return `${enonicContentBasePath}${queryPath}`;
+    return `${enonicContentBasePath}${path}`;
 };


### PR DESCRIPTION
Dette må inn i vhosts for at content-studio skal fungere:
```
mapping.next.host = localhost 
mapping.next.source = /_next
mapping.next.target = /_/service/no.nav.navno/nextJsonProxy
mapping.next.idProvider.system = default
```
I miljøene våre er det ulike vhosts oppsett for admin-panelet tror jeg, må høre med noen som har greie på det. :)