### PR TITLE
replace newline with space instead of empty string

### DIFF
--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -58,7 +58,7 @@ export const ParsedHtml = (props: Props) => {
 
     // htmlReactParser does not always handle linebreaks well...
     const htmlParsed = htmlReactParser(
-        content.replace(/(\r\n|\n|\r)/gm, ''),
+        content.replace(/(\r\n|\n|\r)/gm, ' '),
         replaceElements
     );
 


### PR DESCRIPTION
Fikser at newline ikke blir til mellomrom på sider som denne http://www-q1.nav.no/no/lokalt/hjelpemiddelsentraler/nav-hjelpemiddelsentral-telemark/relatert-informasjon/ofte-stilte-sporsmal-pa-tolkeomradet