### PR TITLE
SSR for statistikk

### DIFF
--- a/src/components/parts/notifications/GlobalNotifications.less
+++ b/src/components/parts/notifications/GlobalNotifications.less
@@ -6,7 +6,6 @@
 
     display: flex;
     justify-content: center;
-    align-items: center;
     padding: 0 @padding-sides-desktop;
 
     @media @screen-desktop {
@@ -27,6 +26,7 @@
     @media @screen-mobile {
         padding: 1rem @padding-sides-mobile;
         flex-direction: column;
+        align-items: center;
 
         .notification {
             width: 100%;

--- a/src/pages/no/nav-og-samfunn/kunnskap/[[...kunnskapRouter]].tsx
+++ b/src/pages/no/nav-og-samfunn/kunnskap/[[...kunnskapRouter]].tsx
@@ -1,0 +1,11 @@
+import { GetServerSideProps } from 'next';
+import PageBase, { fetchPageProps } from '../../../../components/PageBase';
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const secret = process.env.SERVICE_SECRET as string;
+    const pathSegments = context?.resolvedUrl.split('/').slice(1) || '';
+    console.log('ssr', pathSegments);
+    return await fetchPageProps(pathSegments, false, secret);
+};
+
+export default PageBase;

--- a/src/pages/no/nav-og-samfunn/statistikk/[[...statistikkRouter]].tsx
+++ b/src/pages/no/nav-og-samfunn/statistikk/[[...statistikkRouter]].tsx
@@ -1,0 +1,11 @@
+import { GetServerSideProps } from 'next';
+import PageBase, { fetchPageProps } from '../../../../components/PageBase';
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const secret = process.env.SERVICE_SECRET as string;
+    const pathSegments = context?.resolvedUrl.split('/').slice(1) || '';
+    console.log('ssr', pathSegments);
+    return await fetchPageProps(pathSegments, false, secret);
+};
+
+export default PageBase;

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -32,9 +32,6 @@ export enum ContentType {
     OfficeInformation = 'no_nav_navno_OfficeInformation',
 }
 
-export const contentTypeIsImplemented = (type: ContentType) =>
-    Object.values(ContentType).includes(type);
-
 export type ContentProps = {
     __typename: ContentType;
     _id: XpContentRef;


### PR DESCRIPTION
- /no/nav-og-samfunn/statistikk/* og /no/nav-og-samfunn/kunnskap/* benytter SSR uten statisk html

(- fikser høyde på globale varsler i desktop-visning)
(- fjerner ubrukt funksjon contentTypeIsImplemented )