### PR TITLE
Handle view when editing a page

### DIFF
--- a/src/components/pages/large-table-page/LargeTablePage.tsx
+++ b/src/components/pages/large-table-page/LargeTablePage.tsx
@@ -51,8 +51,7 @@ const parseHtml = (htmlString: string) => {
 
 export const LargeTablePage = (contentData: LargeTableProps) => {
     const parentPath = contentData._path.split('tabeller')[0];
-
-    return contentData.data?.text ? (
+    return contentData.data?.text || contentData.editMode ? (
         <div className={'large-table-page'}>
             <LenkeStandalone
                 href={parentPath}
@@ -62,7 +61,7 @@ export const LargeTablePage = (contentData: LargeTableProps) => {
                 <VenstreChevron />
                 {'Tilbake'}
             </LenkeStandalone>
-            {parseHtml(contentData.data.text)}
+            {contentData.data?.text ? parseHtml(contentData.data.text) : ''}
         </div>
     ) : (
         <ErrorPage

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -50,6 +50,7 @@ export type ContentProps = {
     parent?: ContentProps;
     data?: ContentData;
     page?: LayoutProps;
+    editMode?: boolean;
 };
 
 type TypeSpecificData = ContentListData &

--- a/src/utils/fetch-content.ts
+++ b/src/utils/fetch-content.ts
@@ -102,8 +102,7 @@ export const fetchPage = async (
     secret: string
 ): Promise<ContentProps> => {
     const content = await fetchContent(idOrPath, isDraft, secret);
-
     return content?.__typename
-        ? content
+        ? { ...content, editMode: isDraft }
         : makeErrorProps(idOrPath, `Ukjent feil`, 500);
 };


### PR DESCRIPTION
When starting to edit a page, since not all the fields are entered yet the errorpage it displayed. This is a bit confusing, so added this to be apply to customize which context one is viewing the page in. 