### PR TITLE
Issue197-Kapittel peker til avpublisert artikkel

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,6 @@
+ADMIN_ORIGIN=http://localhost:8080
+APP_ORIGIN=http://localhost:3000
+DECORATOR_URL=http://localhost:8100/dekoratoren
+XP_ORIGIN=http://localhost:8080
+SERVICE_SECRET=dummyToken
+REVALIDATOR_PROXY_ORIGIN=http://localhost:3002


### PR DESCRIPTION
Denne måten å løse det på gir ikke 500 eller 401, men returnerer en tom artikkel så kapittel-navigasjonen fortsatt vises.
Alternativet er å løse dette backend, slik at kapittelet ikke vises hvis det peker til ikke finnes.