### PR TITLE
Fiks for dekoratør-parametre (nynorsk språkvalg mm)

### DIFF
--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -31,7 +31,7 @@ export const PageWrapper = (props: Props) => {
 
     useEffect(() => {
         onBreadcrumbClick((breadcrumb) => router.push(breadcrumb.url));
-        onLanguageSelect((breadcrumb) => router.push(breadcrumb.url));
+        onLanguageSelect((language) => router.push(language.url));
 
         initAmplitude();
 
@@ -80,24 +80,18 @@ export const PageWrapper = (props: Props) => {
         const language = xpLangToDecoratorLang[content?.language] || 'nb';
 
         setParams({
-            ...(context && {
-                context: context,
-            }),
-            ...(language && {
-                language: language as 'en' | 'se' | 'nb' | 'nn',
-            }),
-            ...(breadcrumbs && {
-                breadcrumbs: breadcrumbs.map((crumb) => ({
+            ...(context && { context }),
+            language: language as 'en' | 'se' | 'nb' | 'nn', // TODO: add 'pl' to decorator-modules!
+            breadcrumbs:
+                breadcrumbs?.map((crumb) => ({
                     handleInApp: true,
                     ...crumb,
-                })),
-            }),
-            ...(languages && {
-                availableLanguages: languages.map((lang) => ({
+                })) || [],
+            availableLanguages:
+                languages?.map((lang) => ({
                     handleInApp: true,
                     ...lang,
-                })),
-            }),
+                })) || [],
         });
 
         document.documentElement.lang = content?.language || 'no';

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -3,13 +3,14 @@ import { bundle as en } from './en';
 import { bundle as pl } from './pl';
 import { bundle as defaultPack, Translations } from './default';
 
-export type Language = 'no' | 'en' | 'se' | 'pl';
+export type Language = 'no' | 'nn' | 'en' | 'se' | 'pl';
 
 const supportedLanguages: { [key in Language]: Translations } = {
     en: en,
     se: se,
     pl: pl,
     no: defaultPack,
+    nn: defaultPack,
 };
 
 export const translator = <Module extends keyof Translations>(

--- a/src/utils/document-utils.tsx
+++ b/src/utils/document-utils.tsx
@@ -43,6 +43,7 @@ export type DocumentParams = {
 export const xpLangToDecoratorLang: { [key in Language]: DecoratorLanguage } = {
     en: 'en',
     no: 'nb',
+    nn: 'nn',
     pl: 'pl',
     se: 'se',
 };


### PR DESCRIPTION
- Håndterer nynorsk i språkvelger
- Fikser bug der språkvelger/brødsmuler henger igjen når en navigerer fra en side med disse til en side uten