### PR TITLE
Mindre twitter-bilde ved deling

### DIFF
--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -52,7 +52,7 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
             <meta property={'og:image'} content={imageUrl} />
             <meta property={'og:image:width'} content={'200'} />
             <meta property={'og:image:height'} content={'200'} />
-            <meta name="twitter:card" content={'summary_large_image'} />
+            <meta name="twitter:card" content={'summary'} />
             <meta name="twitter:domain" content={'nav.no'} />
             <meta name="twitter:title" content={title} />
             <meta name="twitter:description" content={description} />


### PR DESCRIPTION
- Bytter fra `twitter:card=summary_large_image` til `summary` for å få riktig størrelse iht nytt bilde.