### PR TITLE
fjerner logging av sidevisning fra frontend-appen

### DIFF
--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -7,7 +7,7 @@ import { ContentProps } from '../types/content-props/_content-common';
 import { prefetchOnMouseover } from '../utils/links';
 import { hookAndInterceptInternalLink } from '../utils/links';
 import GlobalNotifications from './_common/notifications/GlobalNotifications';
-import { initAmplitude, logPageview } from '../utils/amplitude';
+import { initAmplitude } from '../utils/amplitude';
 import { HeadWithMetatags } from './_common/metatags/HeadWithMetatags';
 import {
     getContentLanguages,
@@ -67,8 +67,6 @@ export const PageWrapper = (props: Props) => {
         if (!content) {
             return;
         }
-
-        logPageview();
 
         // Prevents focus from "sticking" after async-navigation to a new page
         const focusedElement = document.activeElement as HTMLElement;

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -12,8 +12,6 @@ export const initAmplitude = () => {
     });
 };
 
-export const logPageview = () => logAmplitudeEvent('sidevisning');
-
 export const logLinkClick = (
     href: string,
     linkText: string | undefined,


### PR DESCRIPTION
Foreslår å fjerne logging av sidevisning i frontend-appen.

Vi logger dette i dekoratøren allerede så nå får vi dobbelt så mange sidevisninger i Amplitude. Det tar en del av budsjettet vårt.