### PR TITLE
Implementerer seksjoner i produktside

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,16 +334,16 @@
             "integrity": "sha512-rs7D/+89wBb20f+m01pHzcqnGfHo8KiSGjmmpx/FSsDA1UVuMy3P7FdJde8ICoKj02bYId/58oUu1qwNepItng=="
         },
         "@navikt/ds-icons": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-0.2.1.tgz",
-            "integrity": "sha512-AYIlCVLcJpH+IJKhr2nZUEOcCcKYL+LgwZuWP2fnR/y00Tw2y4ccCM/bs+h5r5VlB7GOVyzIVBSyesdDhdbwQQ=="
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-icons/-/ds-icons-0.2.2.tgz",
+            "integrity": "sha512-r2UVHOVzxGk6wLBbRtMFBAYI5XD+lqHAktNuSmly6cre7PXgVfar+JcVHqEc1r1HSZxkC4Kl4EjlU/laOPSr0Q=="
         },
         "@navikt/ds-react": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-0.2.13.tgz",
-            "integrity": "sha512-Fo233ijBcAKS5MF3L0rli3Q9GpUmwaBXt+hxvnaOpgPzRXvvVplP0+AwYW/2j7zcBDDgMKJqhgHnveUpD4X8yw==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-0.3.2.tgz",
+            "integrity": "sha512-iOjHOkvdbRdxgAMNUpVZ6hl3ISNGrzyMtkBetLkP4Z4qkYEWc0VCLfGSmJ5C5/i2ODFoxMxoYCs5PfQ57rkUWw==",
             "requires": {
-                "@navikt/ds-icons": "^0.2.1",
+                "@navikt/ds-icons": "^0.2.2",
                 "@popperjs/core": "^2.5.4",
                 "classnames": "^2.2.6",
                 "copy-to-clipboard": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@navikt/ds-css": "^0.2.8",
-        "@navikt/ds-react": "^0.2.13",
+        "@navikt/ds-react": "^0.3.2",
         "@navikt/ds-tokens": "^0.2.1-beta.9",
         "@navikt/fnrvalidator": "^1.1.4",
         "@navikt/nav-dekoratoren-moduler": "^1.2.10",

--- a/src/components/_common/header/Header.less
+++ b/src/components/_common/header/Header.less
@@ -6,34 +6,31 @@
     align-items: center;
     justify-content: center;
     position: relative;
-    text-align: center;
 
-    &:hover,
-    &:focus {
-        .header__anchor-icon {
-            visibility: visible;
-            opacity: 0.75;
-            filter: invert();
+    &__text {
+        margin-right: 2rem;
+    }
+
+    .header__copy-link {
+        position: absolute;
+        right: 0;
+        margin-left: 1rem;
+        transition-property: transform;
+        transition-timing-function: linear;
+        transition-duration: 0.15s;
+
+        &:hover {
+            transform: scale(1.2);
         }
     }
 
     &__anchor-icon {
-        @height: #round-rem(1.25rem) [];
-        visibility: hidden;
-        opacity: 0;
-        position: absolute;
-        margin-left: 1rem;
-        height: @height;
-        top: calc((100% - @height) / 2);
-        cursor: pointer;
-        transition-property: visibility, opacity;
-        transition-timing-function: linear;
-        transition-duration: 0.15s;
+        height: #round-rem(1.5rem) [];
     }
 
     &__copy-tooltip {
         position: absolute;
-        right: 0;
+        right: 2rem;
         visibility: hidden;
         background-color: black;
         color: white;

--- a/src/components/_common/header/Header.less
+++ b/src/components/_common/header/Header.less
@@ -15,9 +15,11 @@
         position: absolute;
         right: 0;
         margin-left: 1rem;
+        margin-top: 0.25rem;
         transition-property: transform;
         transition-timing-function: linear;
         transition-duration: 0.15s;
+        align-self: flex-start;
 
         &:hover {
             transform: scale(1.2);

--- a/src/components/_common/header/Header.tsx
+++ b/src/components/_common/header/Header.tsx
@@ -66,10 +66,16 @@ export const Header = ({
             )}
             id={id}
         >
-            <TypoComponent tag={tag}>{children}</TypoComponent>
+            <TypoComponent tag={tag} className={bem('text')}>
+                {children}
+            </TypoComponent>
             {anchor && (
                 <>
-                    <a href={anchor} onClick={copyLinkToClipboard}>
+                    <a
+                        href={anchor}
+                        onClick={copyLinkToClipboard}
+                        className={bem('copy-link')}
+                    >
                         <PublicImage
                             imagePath={'/gfx/link.svg'}
                             className={bem('anchor-icon')}

--- a/src/components/layouts/LayoutContainer.tsx
+++ b/src/components/layouts/LayoutContainer.tsx
@@ -9,6 +9,7 @@ type Props = {
     pageProps: ContentProps;
     layoutProps: LayoutProps;
     layoutStyle?: React.CSSProperties;
+    modifiers?: string[];
     children: React.ReactNode;
 };
 
@@ -16,6 +17,7 @@ export const LayoutContainer = ({
     pageProps,
     layoutProps,
     layoutStyle,
+    modifiers,
     children,
 }: Props) => {
     const { descriptor, path, type, config } = layoutProps;
@@ -38,6 +40,9 @@ export const LayoutContainer = ({
             className={classNames(
                 bem(),
                 bem(layoutName),
+                ...(modifiers
+                    ? modifiers.map((mod) => bem(layoutName, mod))
+                    : []),
                 paddingConfig === 'fullWidth' && bem('fullwidth'),
                 paddingConfig === 'standard' && bem('standard'),
                 config.bgColor?.color && bem('bg')

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.less
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.less
@@ -7,5 +7,6 @@
 
     .navds-layout__body > .navds-content-container {
         padding: 0;
+        margin-top: 1.5rem;
     }
 }

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -5,6 +5,7 @@ import { LeftMenuSection } from './left-menu-section/LeftMenuSection';
 import { RightMenuSection } from './right-menu-section/RightMenuSection';
 import { MainContentSection } from './main-content-section/MainContentSection';
 import { ProductPageLayout } from '@navikt/ds-react';
+import { ProductPageSection } from '@navikt/ds-react/esm/layouts';
 import { LayoutContainer } from '../LayoutContainer';
 import './PageWithSideMenus.less';
 
@@ -35,7 +36,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
         <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
             <ProductPageLayout title={title}>
                 {leftMenuToggle && (
-                    <ProductPageLayout.Section
+                    <ProductPageSection
                         left
                         sticky={leftMenuSticky}
                         whiteBackground={false}
@@ -47,24 +48,21 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                             internalLinks={showInternalNav && anchorLinks}
                             menuHeader={leftMenuHeader}
                         />
-                    </ProductPageLayout.Section>
+                    </ProductPageSection>
                 )}
-                <ProductPageLayout.Section
-                    whiteBackground={false}
-                    withPadding={false}
-                >
+                <ProductPageSection whiteBackground={false} withPadding={false}>
                     <MainContentSection
                         pageProps={pageProps}
                         regionProps={regions.pageContent}
                     />
-                </ProductPageLayout.Section>
+                </ProductPageSection>
                 {rightMenuToggle && (
-                    <ProductPageLayout.Section right sticky={rightMenuSticky}>
+                    <ProductPageSection right sticky={rightMenuSticky}>
                         <RightMenuSection
                             pageProps={pageProps}
                             regionProps={regions.rightMenu}
                         />
-                    </ProductPageLayout.Section>
+                    </ProductPageSection>
                 )}
             </ProductPageLayout>
         </LayoutContainer>

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
@@ -8,7 +8,6 @@
     top: @topOffset;
 
     .navds-accordion-anchor-menu {
-        margin-bottom: 1rem;
         background-color: white;
     }
 
@@ -21,6 +20,11 @@
 .region__leftMenu > * {
     padding: 1rem;
     background-color: white;
+
+    &:first-child {
+        margin-top: 1rem;
+    }
+
     &:not(:last-child) {
         margin-bottom: 1rem;
     }

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
@@ -1,8 +1,11 @@
 @import (reference) '../../../../global';
 
 .left-menu {
+    @topOffset: calc(var(--decorator-sticky-offset) + 1rem);
+    @bottomOffset: 2rem;
     overflow: auto;
-    max-height: calc(100vh);
+    max-height: calc(100vh - @topOffset - @bottomOffset);
+    top: @topOffset;
 
     .navds-accordion-anchor-menu {
         margin-bottom: 1rem;
@@ -10,8 +13,8 @@
     }
 
     @media @mq-screen-mobile {
-        max-height: none;
         overflow: visible;
+        max-height: none;
     }
 }
 

--- a/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
+++ b/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
@@ -1,6 +1,9 @@
 @import (reference) '../../../../global';
 
 .region__pageContent {
+    display: flex;
+    flex-direction: column;
+
     & > :not(:last-child) {
         margin-bottom: 1.5rem;
     }

--- a/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
+++ b/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
@@ -2,6 +2,6 @@
 
 .region__pageContent {
     & > :not(:last-child) {
-        margin-bottom: 1rem;
+        margin-bottom: 1.5rem;
     }
 }

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -1,22 +1,73 @@
 @import (reference) '../../../global';
 
 .layout__section-with-header {
-    padding: 2.5rem;
-    background-color: white;
+    @paddingDesktop: 2.5rem;
+    @paddingTablet: 1.5rem;
+    @paddingMobile: 1rem;
+
+    @iconContainerRadius: 2.25rem;
+    @iconContainerSize: @iconContainerRadius * 2;
+
+    @defaultBgColor: white;
+
+    display: flex;
+    flex-direction: column;
+    padding: @paddingDesktop;
+    background-color: @defaultBgColor;
 
     @media @mq-screen-tablet {
-        padding: 1.5rem;
+        padding: @paddingTablet;
     }
 
     @media @mq-screen-mobile {
-        padding: 1rem;
+        padding: @paddingMobile;
+    }
+
+    &--with-icon {
+        margin-top: @iconContainerRadius;
     }
 
     .region__content {
         margin-top: 1.5rem;
 
-        & > * {
+        & > :not(:first-child) {
             margin-top: 1rem;
+        }
+    }
+
+    .icon-container {
+        .adjust-for-padding(@sectionPadding) {
+            @marginActual: 1rem;
+            top: calc(-@sectionPadding - @iconContainerRadius);
+            margin-bottom: -@iconContainerRadius - (@sectionPadding -
+                        @marginActual);
+        }
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        align-self: center;
+        width: @iconContainerSize;
+        height: @iconContainerSize;
+        position: relative;
+        border-radius: 50%;
+        background-color: @defaultBgColor;
+
+        .adjust-for-padding(@paddingDesktop);
+
+        @media @mq-screen-tablet {
+            .adjust-for-padding(@paddingTablet);
+        }
+
+        @media @mq-screen-mobile {
+            .adjust-for-padding(@paddingMobile);
+        }
+
+        img {
+            @iconSize: @iconContainerRadius / sqrt(@iconContainerRadius) * 2;
+
+            height: #round-rem(@iconSize) [];
+            width: #round-rem(@iconSize) [];
         }
     }
 }

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -1,7 +1,7 @@
 @import (reference) '../../../global';
 
 .layout__section-with-header {
-    padding: 2rem 2.5rem;
+    padding: 2.5rem;
     background-color: white;
 
     @media @mq-screen-tablet {

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -1,4 +1,22 @@
 @import (reference) '../../../global';
 
 .layout__section-with-header {
+    padding: 2rem 2.5rem;
+    background-color: white;
+
+    @media @mq-screen-tablet {
+        padding: 1.5rem;
+    }
+
+    @media @mq-screen-mobile {
+        padding: 1rem;
+    }
+
+    .region__content {
+        margin-top: 1rem;
+
+        & > * {
+            margin-top: 1rem;
+        }
+    }
 }

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -13,7 +13,7 @@
     }
 
     .region__content {
-        margin-top: 1rem;
+        margin-top: 1.5rem;
 
         & > * {
             margin-top: 1rem;

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -60,4 +60,3 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
         </LayoutContainer>
     );
 };
-//

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -8,9 +8,18 @@ import { TypoStyle } from '../../../types/typo-style';
 import { XpImage } from '../../_common/image/XpImage';
 import './SectionWithHeaderLayout.less';
 
+const getBorderStyle = ({
+    color = '#ffffff',
+    width = 3,
+    rounded,
+}: SectionWithHeaderProps['config']['border']) => ({
+    boxShadow: `0 0 0 ${width}px ${color} inset`,
+    ...(rounded && { borderRadius: `${width * 3}px` }),
+});
+
 type Props = {
     pageProps: ContentProps;
-    layoutProps?: SectionWithHeaderProps;
+    layoutProps: SectionWithHeaderProps;
 };
 
 export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
@@ -20,14 +29,25 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
         return null;
     }
 
-    const { title, anchorId, icon, highlight } = config;
+    const { title, anchorId, icon, border } = config;
 
-    const iconElement = icon?.mediaUrl && (
-        <XpImage imageProps={icon} alt={''} />
-    );
+    const iconImgProps = icon?.icon;
 
     return (
-        <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
+        <LayoutContainer
+            pageProps={pageProps}
+            layoutProps={layoutProps}
+            layoutStyle={border && getBorderStyle(border)}
+            modifiers={icon && ['with-icon']}
+        >
+            {iconImgProps && (
+                <div
+                    className={'icon-container'}
+                    style={icon.color && { backgroundColor: icon.color }}
+                >
+                    <XpImage imageProps={iconImgProps} alt={''} />
+                </div>
+            )}
             <Header
                 typoStyle={TypoStyle.Innholdstittel}
                 tag={'h2'}
@@ -40,3 +60,4 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
         </LayoutContainer>
     );
 };
+//

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { SectionWithHeaderProps } from '../../../types/component-props/layouts/section-with-header';
 import { ContentProps } from '../../../types/content-props/_content-common';
 import Region from '../Region';
-import { ProductPageLayout } from '@navikt/ds-react';
+import { ProductPagePanel } from '@navikt/ds-react/esm/layouts';
 import { LayoutContainer } from '../LayoutContainer';
 import { XpImage } from '../../_common/image/XpImage';
 import './SectionWithHeaderLayout.less';
@@ -27,14 +27,19 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
 
     return (
         <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
-            <ProductPageLayout.Panel
-                title={title}
-                anchor={anchorId}
-                highlight={highlight}
-                icon={iconElement}
-            >
-                <Region pageProps={pageProps} regionProps={regions.content} />
-            </ProductPageLayout.Panel>
+            {typeof window !== 'undefined' && (
+                <ProductPagePanel
+                    title={title}
+                    anchor={anchorId}
+                    highlight={highlight}
+                    icon={iconElement}
+                >
+                    <Region
+                        pageProps={pageProps}
+                        regionProps={regions.content}
+                    />
+                </ProductPagePanel>
+            )}
         </LayoutContainer>
     );
 };

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { SectionWithHeaderProps } from '../../../types/component-props/layouts/section-with-header';
 import { ContentProps } from '../../../types/content-props/_content-common';
-import Region from '../Region';
-import { ProductPagePanel } from '@navikt/ds-react/esm/layouts';
 import { LayoutContainer } from '../LayoutContainer';
+import Region from '../Region';
+import { Header } from '../../_common/header/Header';
+import { TypoStyle } from '../../../types/typo-style';
 import { XpImage } from '../../_common/image/XpImage';
 import './SectionWithHeaderLayout.less';
 
@@ -27,19 +28,15 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
 
     return (
         <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
-            {typeof window !== 'undefined' && (
-                <ProductPagePanel
-                    title={title}
-                    anchor={anchorId}
-                    highlight={highlight}
-                    icon={iconElement}
-                >
-                    <Region
-                        pageProps={pageProps}
-                        regionProps={regions.content}
-                    />
-                </ProductPagePanel>
-            )}
+            <Header
+                typoStyle={TypoStyle.Innholdstittel}
+                tag={'h2'}
+                justify={'left'}
+                id={anchorId}
+            >
+                {title}
+            </Header>
+            <Region pageProps={pageProps} regionProps={regions.content} />
         </LayoutContainer>
     );
 };

--- a/src/components/parts/_dynamic/html-area/HtmlArea.less
+++ b/src/components/parts/_dynamic/html-area/HtmlArea.less
@@ -3,6 +3,8 @@
 @import (reference) '~nav-frontend-tabell-style/src/index';
 
 .html-area {
+    word-break: break-word;
+
     & > *:not(:last-child) {
         margin-bottom: 0.875rem;
     }

--- a/src/global.less
+++ b/src/global.less
@@ -62,7 +62,7 @@ html {
     }
 
     @media @mq-screen-tablet {
-        padding: 2rem @padding-sides-mobile;
+        padding: 2rem @padding-sides-tablet;
     }
 
     @media @mq-screen-desktop {
@@ -74,7 +74,7 @@ html {
     min-height: 88px;
 }
 
-@media (min-width: 48em) {
+@media @mq-screen-mobile {
     #decorator-header {
         min-height: 106px;
     }
@@ -108,11 +108,7 @@ html {
 // the current pixel size, taking global font-size into account
 #round-rem(@value: 0) {
     @valueUpper: @value + @pixel-size-rem / 2;
-    @result: if(
-        isunit(@value, rem),
-        @valueUpper - mod(@valueUpper, @pixel-size-rem),
-        0
-    );
+    @result: @valueUpper - mod(@valueUpper, @pixel-size-rem);
 }
 
 // Makes the element cover the entire screen-width

--- a/src/types/component-props/layouts/section-with-header.ts
+++ b/src/types/component-props/layouts/section-with-header.ts
@@ -15,7 +15,11 @@ export interface SectionWithHeaderProps extends LayoutCommonProps {
     config: {
         title: string;
         anchorId: string;
-        icon?: XpImageProps;
-        highlight?: boolean;
+        icon?: { icon: XpImageProps; color?: string };
+        border?: {
+            color: string;
+            rounded: boolean;
+            width: number;
+        };
     } & Pick<LayoutCommonConfigMixin, 'bgColor'>;
 }


### PR DESCRIPTION
Tilsvarende backend-endringer: https://github.com/navikt/nav-enonicxp/pull/898

- Bytter ut designsystemets komponent for section-layout (ProductPageLayout.Panel) med egen implementasjon
- Oppdaterer ds-react (fikser bug med frem/tilbake navigering etter bruk av navigasjonsmeny)
- Tweaker visning av "kopier lenke" knapp
- Fikser høyde på sticky left-meny slik at den ikke "forsvinner" ut av skjermen
- Støtte for tilpasset border (egentlig box-shadow :) på section-layout

![productpage-panels](https://user-images.githubusercontent.com/18137669/116974376-55e88e80-acbe-11eb-8d2b-0ff1878bdbc0.png)