### PR TITLE
Støtte for størrelse på ikon i section-layout

### DIFF
--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -70,7 +70,6 @@ const parsedHtmlLegacy = (content: string) => {
 
             if (tag === 'a' && attribs?.href && children) {
                 const href = attribs.href.replace('https://www.nav.no', '');
-                const className = attribs?.class;
 
                 if (
                     className.includes('macroButton') ||
@@ -80,8 +79,8 @@ const parsedHtmlLegacy = (content: string) => {
                         <Button
                             href={href}
                             type={
-                                attribs.class.includes('macroButtonBlue') ||
-                                attribs.class.includes('btn-primary')
+                                className.includes('macroButtonBlue') ||
+                                className.includes('btn-primary')
                                     ? 'hoved'
                                     : 'standard'
                             }

--- a/src/components/_common/image/XpImage.tsx
+++ b/src/components/_common/image/XpImage.tsx
@@ -7,7 +7,7 @@ type Props = {
     alt: string;
     scale?: string;
     className?: string;
-};
+} & React.ImgHTMLAttributes<HTMLImageElement>;
 
 export const getImageUrl = (image: XpImageProps, scale?: string) => {
     if (!image) {
@@ -22,11 +22,19 @@ export const getImageUrl = (image: XpImageProps, scale?: string) => {
     return getMediaUrl(url);
 };
 
-export const XpImage = ({ imageProps, alt, scale, className }: Props) => {
+export const XpImage = ({
+    imageProps,
+    alt,
+    scale,
+    className,
+    ...imgAttribs
+}: Props) => {
     const imageUrl = getImageUrl(imageProps, scale);
     if (!imageUrl) {
         return null;
     }
 
-    return <img src={imageUrl} alt={alt} className={className} />;
+    return (
+        <img src={imageUrl} alt={alt} className={className} {...imgAttribs} />
+    );
 };

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -52,6 +52,7 @@
         position: relative;
         border-radius: 50%;
         background-color: @defaultBgColor;
+        overflow: hidden;
 
         .adjust-for-padding(@paddingDesktop);
 

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -43,9 +43,22 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
             {iconImgProps && (
                 <div
                     className={'icon-container'}
-                    style={icon.color && { backgroundColor: icon.color }}
+                    style={
+                        icon.color ? { backgroundColor: icon.color } : undefined
+                    }
                 >
-                    <XpImage imageProps={iconImgProps} alt={''} />
+                    <XpImage
+                        imageProps={iconImgProps}
+                        alt={''}
+                        style={
+                            icon.size
+                                ? {
+                                      height: `${icon.size}%`,
+                                      width: `${icon.size}%`,
+                                  }
+                                : undefined
+                        }
+                    />
                 </div>
             )}
             <Header

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -43,21 +43,19 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
             {iconImgProps && (
                 <div
                     className={'icon-container'}
-                    style={
-                        icon.color ? { backgroundColor: icon.color } : undefined
-                    }
+                    style={{
+                        ...(icon.color && { backgroundColor: icon.color }),
+                    }}
                 >
                     <XpImage
                         imageProps={iconImgProps}
                         alt={''}
-                        style={
-                            icon.size
-                                ? {
-                                      height: `${icon.size}%`,
-                                      width: `${icon.size}%`,
-                                  }
-                                : undefined
-                        }
+                        style={{
+                            ...(icon.size && {
+                                height: `${icon.size}%`,
+                                width: `${icon.size}%`,
+                            }),
+                        }}
                     />
                 </div>
             )}

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -6,6 +6,7 @@ import {
     ContentProps,
     ContentType,
 } from '../../types/content-props/_content-common';
+import globalState from '../../globalState';
 
 const dummyPageProps: ContentProps = {
     __typename: ContentType.Site,
@@ -29,6 +30,8 @@ const postHandler = async (req, res) => {
 
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/html');
+
+    globalState.isDraft = true;
 
     const props = req.body.props as PartComponentProps;
 

--- a/src/types/component-props/layouts/section-with-header.ts
+++ b/src/types/component-props/layouts/section-with-header.ts
@@ -16,7 +16,11 @@ export interface SectionWithHeaderProps extends LayoutCommonProps {
         title: string;
         anchorId: string;
         hideCopyButton: boolean;
-        icon?: { icon: XpImageProps; color?: string };
+        icon?: {
+            icon: XpImageProps;
+            color?: string;
+            size?: number;
+        };
         border?: {
             color: string;
             rounded: boolean;


### PR DESCRIPTION
https://github.com/navikt/nav-enonicxp/pull/921

- Støtter size-feltet på ikoner
- Setter state for draft-modus i component preview (fikser problem med feil asset-urler)