### PR TITLE
Release 2021-05-25

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -26,7 +26,6 @@ const contentToReactComponent: Partial<
     [ContentType.OfficeInformation]: DynamicPage,
     [ContentType.PageList]: DynamicPage,
     [ContentType.SectionPage]: DynamicPage,
-    [ContentType.TemplatePage]: DynamicPage,
     [ContentType.TransportPage]: DynamicPage,
     [ContentType.PublishingCalendar]: DynamicPage,
     [ContentType.Melding]: DynamicPage,

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -70,7 +70,6 @@ const parsedHtmlLegacy = (content: string) => {
 
             if (tag === 'a' && attribs?.href && children) {
                 const href = attribs.href.replace('https://www.nav.no', '');
-                const className = attribs?.class;
 
                 if (
                     className.includes('macroButton') ||
@@ -80,8 +79,8 @@ const parsedHtmlLegacy = (content: string) => {
                         <Button
                             href={href}
                             type={
-                                attribs.class.includes('macroButtonBlue') ||
-                                attribs.class.includes('btn-primary')
+                                className.includes('macroButtonBlue') ||
+                                className.includes('btn-primary')
                                     ? 'hoved'
                                     : 'standard'
                             }

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -22,7 +22,27 @@ const parsedHtmlLegacy = (content: string) => {
 
     const replaceElements = {
         replace: ({ name, attribs, children }: DomElement) => {
-            if (name?.toLowerCase() === 'img' && attribs?.src) {
+            const tag = name?.toLowerCase();
+            const className = attribs?.class || '';
+
+            if (className.includes('macroChatbotLink')) {
+                return (
+                    <LenkeInline
+                        href={'/'}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            const chatButton = document.getElementById(
+                                'chatbot-frida-knapp'
+                            );
+                            chatButton?.click?.();
+                        }}
+                    >
+                        {domToReact(children)}
+                    </LenkeInline>
+                );
+            }
+
+            if (tag === 'img' && attribs?.src) {
                 return (
                     <img
                         {...attributesToProps(attribs)}
@@ -32,7 +52,7 @@ const parsedHtmlLegacy = (content: string) => {
                 );
             }
 
-            if (name?.toLowerCase() === 'h1' && children) {
+            if (tag === 'h1' && children) {
                 return (
                     <Innholdstittel>
                         {domToReact(children, replaceElements)}
@@ -40,7 +60,7 @@ const parsedHtmlLegacy = (content: string) => {
                 );
             }
 
-            if (name?.toLowerCase() === 'p' && children) {
+            if (tag === 'p' && children) {
                 return (
                     <Normaltekst>
                         {domToReact(children, replaceElements)}
@@ -48,14 +68,13 @@ const parsedHtmlLegacy = (content: string) => {
                 );
             }
 
-            if (name?.toLowerCase() === 'a' && attribs?.href && children) {
+            if (tag === 'a' && attribs?.href && children) {
                 const href = attribs.href.replace('https://www.nav.no', '');
                 const className = attribs?.class;
 
                 if (
-                    className &&
-                    (className.includes('macroButton') ||
-                        className.includes('btn-link'))
+                    className.includes('macroButton') ||
+                    className.includes('btn-link')
                 ) {
                     return (
                         <Button
@@ -74,7 +93,7 @@ const parsedHtmlLegacy = (content: string) => {
 
                 const props = attributesToProps(attribs);
 
-                if (className && className.includes('chevron')) {
+                if (className.includes('chevron')) {
                     return (
                         <LenkeStandalone
                             {...props}

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -1,21 +1,21 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Innholdstittel, Normaltekst } from 'nav-frontend-typografi';
 import htmlReactParser, { DomElement, domToReact } from 'html-react-parser';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import { LenkeInline } from './_common/lenke/LenkeInline';
 import { getMediaUrl } from '../utils/urls';
+import {
+    getProcessedHtmlPropsWithBackwardsCompatibility,
+    processedHtmlMacroTag,
+    ProcessedHtmlProps,
+} from '../types/processed-html-props';
+import { MacroMapper } from './macros/MacroMapper';
 import { Button } from './_common/button/Button';
-import '../components/macros/Quote.less';
-import '../components/macros/Video.less';
 import { LenkeStandalone } from './_common/lenke/LenkeStandalone';
+import './macros/Quote.less';
+import './macros/Video.less';
 
-interface Props {
-    content?: string;
-}
-
-export const ParsedHtml = (props: Props) => {
-    const { content } = props;
-
+const parsedHtmlLegacy = (content: string) => {
     if (!content) {
         return null;
     }
@@ -98,6 +98,92 @@ export const ParsedHtml = (props: Props) => {
     // htmlReactParser does not always handle linebreaks well...
     const htmlParsed = htmlReactParser(
         content
+            .replace(/(\r\n|\n|\r)/gm, ' ')
+            .replace(/(<table)/gm, '<table class="tabell tabell--stripet"'),
+        replaceElements
+    );
+
+    return <>{htmlParsed}</>;
+};
+
+type Props = {
+    htmlProps: ProcessedHtmlProps;
+};
+
+export const ParsedHtml = (props: Props) => {
+    const htmlProps = getProcessedHtmlPropsWithBackwardsCompatibility(
+        props.htmlProps
+    );
+
+    if (htmlProps.isLegacy) {
+        return parsedHtmlLegacy(htmlProps.processedHtml);
+    }
+
+    const { processedHtml, macros } = htmlProps;
+
+    if (!processedHtml) {
+        return null;
+    }
+
+    const replaceElements = {
+        replace: ({ name, attribs, children }: DomElement) => {
+            const tag = name?.toLowerCase();
+
+            if (tag === processedHtmlMacroTag) {
+                return (
+                    <MacroMapper
+                        macros={macros}
+                        macroRef={attribs?.['data-macro-ref']}
+                    />
+                );
+            }
+
+            if (tag === 'img' && attribs?.src) {
+                return (
+                    <img
+                        {...attributesToProps(attribs)}
+                        alt={attribs.alt || ''}
+                        src={getMediaUrl(attribs.src)}
+                    />
+                );
+            }
+
+            if (tag === 'h1') {
+                return children ? (
+                    <Innholdstittel>
+                        {domToReact(children, replaceElements)}
+                    </Innholdstittel>
+                ) : (
+                    <Fragment />
+                );
+            }
+
+            if (tag === 'p' && children) {
+                return (
+                    <Normaltekst>
+                        {domToReact(children, replaceElements)}
+                    </Normaltekst>
+                );
+            }
+
+            if (tag === 'a') {
+                const href = attribs?.href?.replace('https://www.nav.no', '');
+                const props = attributesToProps(attribs);
+
+                return children ? (
+                    <LenkeInline {...props} href={href}>
+                        {domToReact(children)}
+                    </LenkeInline>
+                ) : (
+                    <Fragment />
+                );
+            }
+        },
+    };
+
+    // htmlReactParser does not always handle linebreaks well...
+    const htmlParsed = htmlReactParser(
+        processedHtml
             .replace(/(\r\n|\n|\r)/gm, ' ')
             .replace(/(<table)/gm, '<table class="tabell tabell--stripet"'),
         replaceElements

--- a/src/components/_common/image/XpImage.tsx
+++ b/src/components/_common/image/XpImage.tsx
@@ -7,7 +7,7 @@ type Props = {
     alt: string;
     scale?: string;
     className?: string;
-};
+} & React.ImgHTMLAttributes<HTMLImageElement>;
 
 export const getImageUrl = (image: XpImageProps, scale?: string) => {
     if (!image) {
@@ -22,11 +22,19 @@ export const getImageUrl = (image: XpImageProps, scale?: string) => {
     return getMediaUrl(url);
 };
 
-export const XpImage = ({ imageProps, alt, scale, className }: Props) => {
+export const XpImage = ({
+    imageProps,
+    alt,
+    scale,
+    className,
+    ...imgAttribs
+}: Props) => {
     const imageUrl = getImageUrl(imageProps, scale);
     if (!imageUrl) {
         return null;
     }
 
-    return <img src={imageUrl} alt={alt} className={className} />;
+    return (
+        <img src={imageUrl} alt={alt} className={className} {...imgAttribs} />
+    );
 };

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -52,6 +52,7 @@
         position: relative;
         border-radius: 50%;
         background-color: @defaultBgColor;
+        overflow: hidden;
 
         .adjust-for-padding(@paddingDesktop);
 

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -31,21 +31,32 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
 
     const { title, anchorId, icon, border, hideCopyButton } = config;
 
-    const hasIcon = !!icon?.icon;
+    const iconImgProps = icon?.icon;
 
     return (
         <LayoutContainer
             pageProps={pageProps}
             layoutProps={layoutProps}
             layoutStyle={border && getBorderStyle(border)}
-            modifiers={hasIcon && ['with-icon']}
+            modifiers={!!iconImgProps && ['with-icon']}
         >
-            {hasIcon && (
+            {iconImgProps && (
                 <div
                     className={'icon-container'}
-                    style={icon.color && { backgroundColor: icon.color }}
+                    style={{
+                        ...(icon.color && { backgroundColor: icon.color }),
+                    }}
                 >
-                    <XpImage imageProps={icon.icon} alt={''} />
+                    <XpImage
+                        imageProps={iconImgProps}
+                        alt={''}
+                        style={{
+                            ...(icon.size && {
+                                height: `${icon.size}%`,
+                                width: `${icon.size}%`,
+                            }),
+                        }}
+                    />
                 </div>
             )}
             <Header

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -31,21 +31,21 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
 
     const { title, anchorId, icon, border, hideCopyButton } = config;
 
-    const iconImgProps = icon?.icon;
+    const hasIcon = !!icon?.icon;
 
     return (
         <LayoutContainer
             pageProps={pageProps}
             layoutProps={layoutProps}
             layoutStyle={border && getBorderStyle(border)}
-            modifiers={icon && ['with-icon']}
+            modifiers={hasIcon && ['with-icon']}
         >
-            {iconImgProps && (
+            {hasIcon && (
                 <div
                     className={'icon-container'}
                     style={icon.color && { backgroundColor: icon.color }}
                 >
-                    <XpImage imageProps={iconImgProps} alt={''} />
+                    <XpImage imageProps={icon.icon} alt={''} />
                 </div>
             )}
             <Header

--- a/src/components/macros/MacroMapper.tsx
+++ b/src/components/macros/MacroMapper.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+    MacroPropsCommon,
+    MacroType,
+} from '../../types/macro-props/_macros-common';
+import { MacroButton } from './button/MacroButton';
+import { MacroButtonBlue } from './button-blue/MacroButtonBlue';
+import { MacroChevronLinkExternal } from './chevron-link-external/MacroChevronLinkExternal';
+import { MacroChevronLinkInternal } from './chevron-link-internal/MacroChevronLinkInternal';
+import { MacroChatbotLink } from './chatbot-link/MacroChatbotLink';
+import { MacroFotnote } from './fotnote/MacroFotnote';
+import { MacroInfoBoks } from './infoboks/MacroInfoBoks';
+import { MacroLenkeFiler } from './lenke-filer/MacroLenkeFiler';
+import { MacroPhoneLink } from './phone-link/MacroPhoneLink';
+import { MacroQuote } from './quote/MacroQuote';
+import { MacroTankestrek } from './tankestrek/MacroTankestrek';
+import { MacroVarselBoks } from './varselboks/MacroVarselBoks';
+import { MacroVideo } from './Video/MacroVideo';
+
+const macroComponents: {
+    [key in MacroType]: React.FunctionComponent<MacroPropsCommon>;
+} = {
+    [MacroType.Button]: MacroButton,
+    [MacroType.ButtonBlue]: MacroButtonBlue,
+    [MacroType.ChatbotLink]: MacroChatbotLink,
+    [MacroType.ChevronLinkExternal]: MacroChevronLinkExternal,
+    [MacroType.ChevronLinkInternal]: MacroChevronLinkInternal,
+    [MacroType.Fotnote]: MacroFotnote,
+    [MacroType.InfoBoks]: MacroInfoBoks,
+    [MacroType.LenkeFiler]: MacroLenkeFiler,
+    [MacroType.PhoneLink]: MacroPhoneLink,
+    [MacroType.Quote]: MacroQuote,
+    [MacroType.Tankestrek]: MacroTankestrek,
+    [MacroType.VarselBoks]: MacroVarselBoks,
+    [MacroType.Video]: MacroVideo,
+};
+
+type Props = {
+    macros: MacroPropsCommon[];
+    macroRef: string;
+};
+
+export const MacroMapper = ({ macros, macroRef }: Props) => {
+    if (!macroRef) {
+        return null;
+    }
+
+    const macroProps = macros?.find((macro) => macro.ref === macroRef);
+
+    if (!macroProps) {
+        console.log(`Invalid macro ref: ${macroRef}`);
+        return <>{`Error: macro with ref ${macroRef} not found!`}</>;
+    }
+
+    const { name } = macroProps;
+
+    const MacroComponent = macroComponents[name];
+    if (MacroComponent) {
+        return <MacroComponent {...macroProps} ref={undefined} />;
+    }
+
+    return <>{`Unimplemented macro: ${name}`}</>;
+};

--- a/src/components/macros/Video/MacroVideo.less
+++ b/src/components/macros/Video/MacroVideo.less
@@ -1,0 +1,15 @@
+.macro-video {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 1.5rem;
+    height: 0;
+    overflow: hidden;
+
+    iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/src/components/macros/Video/MacroVideo.tsx
+++ b/src/components/macros/Video/MacroVideo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { MacroVideoProps } from '../../../types/macro-props/video';
+import './MacroVideo.less';
+
+export const MacroVideo = ({ config }: MacroVideoProps) => {
+    if (!config?.video) {
+        return null;
+    }
+
+    const { video, title } = config.video;
+
+    return (
+        <div className={'macro-video'}>
+            <iframe
+                title={`Video: ${title}`}
+                src={video}
+                allow={'fullscreen'}
+            />
+        </div>
+    );
+};

--- a/src/components/macros/button-blue/MacroButtonBlue.tsx
+++ b/src/components/macros/button-blue/MacroButtonBlue.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Button } from '../../_common/button/Button';
+import { MacroButtonBlueProps } from '../../../types/macro-props/button-blue';
+
+export const MacroButtonBlue = ({ config }: MacroButtonBlueProps) => {
+    if (!config) {
+        return null;
+    }
+
+    const { content, text, url } = config.button_blue;
+
+    const href = content?._path || url;
+
+    return (
+        <Button type={'hoved'} href={href}>
+            {text}
+        </Button>
+    );
+};

--- a/src/components/macros/button/MacroButton.tsx
+++ b/src/components/macros/button/MacroButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MacroButtonProps } from '../../../types/macro-props/button';
+import { Button } from '../../_common/button/Button';
+
+export const MacroButton = ({ config }: MacroButtonProps) => {
+    if (!config?.button) {
+        return null;
+    }
+
+    const { content, text, url } = config?.button;
+
+    const href = content?._path || url;
+
+    return (
+        <Button type={'standard'} href={href}>
+            {text}
+        </Button>
+    );
+};

--- a/src/components/macros/chatbot-link/MacroChatbotLink.tsx
+++ b/src/components/macros/chatbot-link/MacroChatbotLink.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { MacroChatbotLinkProps } from '../../../types/macro-props/chatbot-link';
+import { LenkeInline } from '../../_common/lenke/LenkeInline';
+
+const openChatbot = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const chatButton = document.getElementById('chatbot-frida-knapp');
+    chatButton?.click?.();
+};
+
+export const MacroChatbotLink = ({ config }: MacroChatbotLinkProps) => {
+    if (!config?.chatbot_link) {
+        return null;
+    }
+
+    const { text } = config.chatbot_link;
+
+    return (
+        <LenkeInline href={'/'} onClick={openChatbot}>
+            {text}
+        </LenkeInline>
+    );
+};

--- a/src/components/macros/chevron-link-external/MacroChevronLinkExternal.tsx
+++ b/src/components/macros/chevron-link-external/MacroChevronLinkExternal.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
+import { MacroChevronLinkExternalProps } from '../../../types/macro-props/chevron-link-external';
+
+export const MacroChevronLinkExternal = ({
+    config,
+}: MacroChevronLinkExternalProps) => {
+    if (!config?.chevron_link_external) {
+        return null;
+    }
+
+    const { url, text } = config.chevron_link_external;
+
+    return <LenkeStandalone href={url}>{text}</LenkeStandalone>;
+};

--- a/src/components/macros/chevron-link-internal/MacroChevronLinkInternal.tsx
+++ b/src/components/macros/chevron-link-internal/MacroChevronLinkInternal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MacroChevronLinkInternalProps } from '../../../types/macro-props/chevron-link-internal';
+import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
+
+export const MacroChevronLinkInternal = ({
+    config,
+}: MacroChevronLinkInternalProps) => {
+    if (!config?.chevron_link_internal) {
+        return null;
+    }
+
+    const { target, text } = config.chevron_link_internal;
+
+    return (
+        <LenkeStandalone href={target?._path}>
+            {text || target?.displayName}
+        </LenkeStandalone>
+    );
+};

--- a/src/components/macros/fotnote/MacroFotnote.less
+++ b/src/components/macros/fotnote/MacroFotnote.less
@@ -1,0 +1,5 @@
+@import (reference) '~nav-frontend-typografi-style/src/index';
+
+.macro-fotnote {
+    .typo-undertekst;
+}

--- a/src/components/macros/fotnote/MacroFotnote.tsx
+++ b/src/components/macros/fotnote/MacroFotnote.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { MacroFotnoteProps } from '../../../types/macro-props/fotnote';
+import './MacroFotnote.less';
+
+export const MacroFotnote = ({ config }: MacroFotnoteProps) => {
+    if (!config?.fotnote) {
+        return null;
+    }
+
+    const { fotnote } = config.fotnote;
+
+    return <sup className={'macro-fotnote'}>{fotnote}</sup>;
+};

--- a/src/components/macros/infoboks/MacroInfoBoks.tsx
+++ b/src/components/macros/infoboks/MacroInfoBoks.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { MacroInfoBoksProps } from '../../../types/macro-props/infoBoks';
+import AlertStripe from 'nav-frontend-alertstriper';
+
+export const MacroInfoBoks = ({ config }: MacroInfoBoksProps) => {
+    if (!config?.infoBoks) {
+        return null;
+    }
+
+    const { infoBoks } = config.infoBoks;
+
+    return <AlertStripe type={'info'}>{infoBoks}</AlertStripe>;
+};

--- a/src/components/macros/lenke-filer/MacroLenkeFiler.tsx
+++ b/src/components/macros/lenke-filer/MacroLenkeFiler.tsx
@@ -1,0 +1,34 @@
+import React, { Fragment } from 'react';
+import { MacroLenkeFilerProps } from '../../../types/macro-props/lenkeFiler';
+import { LenkeInline } from '../../_common/lenke/LenkeInline';
+
+export const MacroLenkeFiler = ({ config }: MacroLenkeFilerProps) => {
+    if (!config?.lenkeFiler) {
+        return null;
+    }
+
+    const { text, files } = config.lenkeFiler;
+
+    return (
+        <>
+            {text}
+            {files.map((file, index) => {
+                const filePath = file?._path;
+                if (!filePath) {
+                    return null;
+                }
+
+                const fileExt = filePath.split('.').slice(-1);
+                return (
+                    <Fragment key={index}>
+                        {' '}
+                        <LenkeInline
+                            href={filePath}
+                            aria-label={`${text} ${fileExt}`}
+                        >{`[${fileExt}]`}</LenkeInline>
+                    </Fragment>
+                );
+            })}
+        </>
+    );
+};

--- a/src/components/macros/phone-link/MacroPhoneLink.tsx
+++ b/src/components/macros/phone-link/MacroPhoneLink.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { MacroPhoneLinkProps } from '../../../types/macro-props/phone-link';
+import { LenkeInline } from '../../_common/lenke/LenkeInline';
+import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
+
+export const MacroPhoneLink = ({ config }: MacroPhoneLinkProps) => {
+    if (!config?.phone_link) {
+        return null;
+    }
+
+    const { text, phoneNumber, chevron } = config.phone_link;
+
+    const href = `tel:${phoneNumber}`;
+
+    return chevron ? (
+        <LenkeStandalone withChevron={true} href={href}>
+            {text}
+        </LenkeStandalone>
+    ) : (
+        <LenkeInline href={href}>{text}</LenkeInline>
+    );
+};

--- a/src/components/macros/quote/MacroQuote.less
+++ b/src/components/macros/quote/MacroQuote.less
@@ -1,0 +1,22 @@
+@import (reference) '../../../global';
+
+.macro-quote {
+    font-weight: normal;
+    margin: 1.5rem 0;
+    padding: 0 2.5rem;
+    position: relative;
+
+    p:last-of-type {
+        margin-bottom: 0;
+    }
+
+    :before {
+        content: '\201C';
+        font-size: 4rem;
+        color: @navRod;
+        font-family: 'Times new roman', serif;
+        position: absolute;
+        left: 0;
+        top: 0.75rem;
+    }
+}

--- a/src/components/macros/quote/MacroQuote.tsx
+++ b/src/components/macros/quote/MacroQuote.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { MacroQuoteProps } from '../../../types/macro-props/quote';
+import { Normaltekst } from 'nav-frontend-typografi';
+import './MacroQuote.less';
+
+export const MacroQuote = ({ config }: MacroQuoteProps) => {
+    if (!config?.quote) {
+        return null;
+    }
+
+    const { quote } = config.quote;
+
+    return (
+        <blockquote className={'macro-quote'}>
+            <Normaltekst>{quote}</Normaltekst>
+        </blockquote>
+    );
+};

--- a/src/components/macros/tankestrek/MacroTankestrek.tsx
+++ b/src/components/macros/tankestrek/MacroTankestrek.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const MacroTankestrek = () => {
+    return <>{' – '}</>;
+};

--- a/src/components/macros/varselboks/MacroVarselBoks.tsx
+++ b/src/components/macros/varselboks/MacroVarselBoks.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import AlertStripe from 'nav-frontend-alertstriper';
+import { MacroVarselBoksProps } from '../../../types/macro-props/varselBoks';
+
+export const MacroVarselBoks = ({ config }: MacroVarselBoksProps) => {
+    if (!config?.varselBoks) {
+        return null;
+    }
+
+    const { varselBoks } = config.varselBoks;
+
+    return <AlertStripe type={'advarsel'}>{varselBoks}</AlertStripe>;
+};

--- a/src/components/pages/large-table-page/LargeTablePage.tsx
+++ b/src/components/pages/large-table-page/LargeTablePage.tsx
@@ -4,6 +4,7 @@ import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import { LargeTableProps } from '../../../types/content-props/large-table-props';
 import { makeErrorProps } from '../../../utils/make-error-props';
 import { ErrorPage } from '../error-page/ErrorPage';
+import { getProcessedHtmlPropsWithBackwardsCompatibility } from '../../../types/processed-html-props';
 import './LargeTablePage.less';
 
 const parseHtml = (htmlString: string) => {
@@ -48,9 +49,13 @@ const parseHtml = (htmlString: string) => {
 };
 
 export const LargeTablePage = (contentData: LargeTableProps) => {
-    return contentData.data?.text || contentData.editMode ? (
+    const html = getProcessedHtmlPropsWithBackwardsCompatibility(
+        contentData.data.text
+    );
+
+    return html || contentData.editMode ? (
         <div className={'large-table-page'}>
-            {contentData.data?.text ? parseHtml(contentData.data.text) : ''}
+            {html ? parseHtml(html.processedHtml) : ''}
         </div>
     ) : (
         <ErrorPage

--- a/src/components/pages/template-page/TemplatePage.tsx
+++ b/src/components/pages/template-page/TemplatePage.tsx
@@ -14,6 +14,6 @@ const mockData = {
 };
 
 export const TemplatePage = (props: ContentProps) => {
-    const propsWithMocks = { ...props, data: { ...props.data, ...mockData } };
+    const propsWithMocks = { ...props, data: { ...mockData, ...props?.data } };
     return <DynamicPage {...propsWithMocks} />;
 };

--- a/src/components/pages/template-page/mocks/mainArticleDataMock.tsx
+++ b/src/components/pages/template-page/mocks/mainArticleDataMock.tsx
@@ -1,9 +1,10 @@
 import { MainArticleData } from '../../../../types/content-props/main-article-props';
+import { getProcessedHtmlPropsWithBackwardsCompatibility } from '../../../../types/processed-html-props';
 
 export const mainArticleDataMock: MainArticleData = {
     ingress: '',
-    text: { processedHtml: '', macros: [] },
+    text: getProcessedHtmlPropsWithBackwardsCompatibility(''),
     hasTableOfContents: 'none',
-    fact: { processedHtml: '', macros: [] },
+    fact: getProcessedHtmlPropsWithBackwardsCompatibility(''),
     social: [],
 };

--- a/src/components/pages/template-page/mocks/mainArticleDataMock.tsx
+++ b/src/components/pages/template-page/mocks/mainArticleDataMock.tsx
@@ -2,8 +2,8 @@ import { MainArticleData } from '../../../../types/content-props/main-article-pr
 
 export const mainArticleDataMock: MainArticleData = {
     ingress: '',
-    text: '',
+    text: { processedHtml: '', macros: [] },
     hasTableOfContents: 'none',
-    fact: '',
+    fact: { processedHtml: '', macros: [] },
     social: [],
 };

--- a/src/components/parts/_dynamic/alert/Alert.tsx
+++ b/src/components/parts/_dynamic/alert/Alert.tsx
@@ -24,7 +24,7 @@ const Alert = (props: DynamicAlert) => {
             form={inline === 'true' ? 'inline' : undefined}
             style={style}
         >
-            <ParsedHtml content={content} />
+            <ParsedHtml htmlProps={content} />
         </AlertStripe>
     );
 };

--- a/src/components/parts/_dynamic/html-area/HtmlArea.tsx
+++ b/src/components/parts/_dynamic/html-area/HtmlArea.tsx
@@ -12,7 +12,7 @@ export const HtmlArea = ({ config }: HtmlAreaProps) => {
     return (
         <Expandable {...config}>
             <div className={'html-area'}>
-                <ParsedHtml content={config.html} />
+                <ParsedHtml htmlProps={config.html} />
             </div>
         </Expandable>
     );

--- a/src/components/parts/_dynamic/les-mer-panel/LesMerPanel.tsx
+++ b/src/components/parts/_dynamic/les-mer-panel/LesMerPanel.tsx
@@ -20,9 +20,9 @@ const LesMerPanel = (props: DynamicReadMorePanel) => {
         <div className={'lesMerPanel__container'} style={style}>
             <LesmerpanelModul
                 border={border === 'true'}
-                intro={<ParsedHtml content={ingress} />}
+                intro={<ParsedHtml htmlProps={ingress} />}
             >
-                <ParsedHtml content={content} />
+                <ParsedHtml htmlProps={content} />
             </LesmerpanelModul>
         </div>
     );

--- a/src/components/parts/_dynamic/text/Text.tsx
+++ b/src/components/parts/_dynamic/text/Text.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ParsedHtml } from '../../../ParsedHtml';
 import {
     ComponentType,
     TextComponentProps,
@@ -33,7 +32,7 @@ export const Text = ({ textProps, editMode }: Props) => {
 
     return (
         <div className={'typo-normal'} {...editorProps}>
-            <ParsedHtml content={text} />
+            {text}
         </div>
     );
 };

--- a/src/components/parts/_dynamic/veilederpanel/Veilederpanel.tsx
+++ b/src/components/parts/_dynamic/veilederpanel/Veilederpanel.tsx
@@ -20,7 +20,7 @@ const Veilederpanel = (props: DynamicSupervisorPanel) => {
     return (
         <div className={'nav-veilederpanel__container'} style={style}>
             <VeilederPanelModul svg={<Veileder />}>
-                <ParsedHtml content={content} />
+                <ParsedHtml htmlProps={content} />
             </VeilederPanelModul>
         </div>
     );

--- a/src/components/parts/main-article/Faktaboks.tsx
+++ b/src/components/parts/main-article/Faktaboks.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
 import { ParsedHtml } from '../../ParsedHtml';
 import { PublicImage } from '../../_common/image/PublicImage';
+import {
+    getProcessedHtmlPropsWithBackwardsCompatibility,
+    ProcessedHtmlProps,
+} from '../../../types/processed-html-props';
 
 interface Props {
     label: string;
-    fakta: string;
+    fakta: ProcessedHtmlProps;
     className: string;
 }
 
 const Faktaboks = (props: Props) => {
-    if (!props.fakta) {
+    const html = getProcessedHtmlPropsWithBackwardsCompatibility(props?.fakta);
+    if (!html.processedHtml) {
         return null;
     }
 
@@ -17,7 +22,7 @@ const Faktaboks = (props: Props) => {
         <div className={props.className}>
             <PublicImage imagePath={'/gfx/info-sirkel-fyll.svg'} alt={''} />
             <h3 className="decorated">{props.label}</h3>
-            <ParsedHtml content={props.fakta} />
+            <ParsedHtml htmlProps={props.fakta} />
         </div>
     );
 };

--- a/src/components/parts/main-article/MainArticle.tsx
+++ b/src/components/parts/main-article/MainArticle.tsx
@@ -12,8 +12,9 @@ import {
     ContentType,
     ContentProps,
 } from '../../../types/content-props/_content-common';
-import './MainArticle.less';
 import { Innholdstittel, Normaltekst } from 'nav-frontend-typografi';
+import { getProcessedHtmlPropsWithBackwardsCompatibility } from '../../../types/processed-html-props';
+import './MainArticle.less';
 
 export const MainArticle = (propsInitial: ContentProps) => {
     const props =
@@ -26,8 +27,10 @@ export const MainArticle = (propsInitial: ContentProps) => {
     const getLabel = translator('mainArticle', props.language);
     const hasTableOfContest =
         data?.hasTableOfContents && data?.hasTableOfContents !== 'none';
+
+    const html = getProcessedHtmlPropsWithBackwardsCompatibility(data.text);
     const innholdsfortegnelse = parseInnholdsfortegnelse(
-        data.text,
+        html.processedHtml,
         hasTableOfContest
     );
     const headerClassName =
@@ -48,16 +51,18 @@ export const MainArticle = (propsInitial: ContentProps) => {
                 <Innholdstittel className={bem('title')}>
                     {props.displayName}
                 </Innholdstittel>
-                <Normaltekst className={bem('preface')}>
-                    {data.ingress}
-                </Normaltekst>
+                {data.ingress && (
+                    <Normaltekst className={bem('preface')}>
+                        {data.ingress}
+                    </Normaltekst>
+                )}
                 <Innholdsfortegnelse
                     innholdsfortegnelse={innholdsfortegnelse}
                     label={getLabel('tableOfContents')}
                 />
             </header>
             <MainArticleText
-                text={data.text}
+                htmlProps={data.text}
                 className={bem('text')}
                 hasTableOfContents={hasTableOfContest}
             />

--- a/src/components/parts/main-article/MainArticleText.tsx
+++ b/src/components/parts/main-article/MainArticleText.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
 import { ParsedHtml } from '../../ParsedHtml';
+import {
+    getProcessedHtmlPropsWithBackwardsCompatibility,
+    ProcessedHtmlProps,
+} from '../../../types/processed-html-props';
 
 const modifyHtml = (htmlText: string, hasTableOfContent: boolean) => {
     // Fjern tomme headings og br-tagger fra HTML
@@ -20,17 +24,22 @@ const modifyHtml = (htmlText: string, hasTableOfContent: boolean) => {
 };
 
 interface Props {
-    text: string;
+    htmlProps: ProcessedHtmlProps;
     className: string;
     hasTableOfContents: boolean;
 }
 
-const MainArticleText = (props: Props) => {
-    const modifiedHtml = modifyHtml(props.text, props.hasTableOfContents);
+const MainArticleText = ({
+    htmlProps,
+    className,
+    hasTableOfContents,
+}: Props) => {
+    const html = getProcessedHtmlPropsWithBackwardsCompatibility(htmlProps);
+    const modifiedHtml = modifyHtml(html.processedHtml, hasTableOfContents);
 
     return (
-        <div className={props.className}>
-            <ParsedHtml content={modifiedHtml} />
+        <div className={className}>
+            <ParsedHtml htmlProps={{ ...html, processedHtml: modifiedHtml }} />
         </div>
     );
 };

--- a/src/components/parts/office-information/SpecialInfo.tsx
+++ b/src/components/parts/office-information/SpecialInfo.tsx
@@ -53,6 +53,7 @@ const parseSpecialInfo = (infoContent: string) => {
 
     return parsedString;
 };
+
 interface Props {
     info: string;
 }
@@ -64,7 +65,7 @@ export const SpecialInformation = (props: Props) => {
         <div>
             <Element tag="h2">Opplysninger</Element>
             <Normaltekst>
-                <ParsedHtml content={specialInfo} />
+                <ParsedHtml htmlProps={specialInfo} />
             </Normaltekst>
         </div>
     ) : null;

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -6,6 +6,7 @@ import {
     ContentProps,
     ContentType,
 } from '../../types/content-props/_content-common';
+import globalState from '../../globalState';
 
 const dummyPageProps: ContentProps = {
     __typename: ContentType.Site,
@@ -29,6 +30,8 @@ const postHandler = async (req, res) => {
 
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/html');
+
+    globalState.isDraft = true;
 
     const props = req.body.props as PartComponentProps;
 

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -2,18 +2,24 @@ import { DeepPartial } from '../types/util-types';
 import { MenuListItemKey } from '../types/menu-list-items';
 
 const relatedContent: { [key in MenuListItemKey]: string } = {
-    appealRights: 'Klagerettigheter',
-    formAndApplication: 'Skjema og søknad',
-    international: 'Internasjonalt',
-    membership: 'Medlemsskap i folketrygden',
-    processTimes: 'Saksbehandlingstider',
-    rates: 'Satser',
-    relatedInformation: 'Relatert innhold',
-    reportChanges: 'Meld fra om endringer',
-    rulesAndRegulations: 'Regelverk',
-    saksbehandling: 'Saksbehandling',
-    selfservice: 'Selvbetjening',
-    shortcuts: 'Snarveier',
+    [MenuListItemKey.AppealRights]: 'Klagerettigheter',
+    [MenuListItemKey.FormAndApplication]: 'Skjema og søknad',
+    [MenuListItemKey.International]: 'Internasjonalt',
+    [MenuListItemKey.Membership]: 'Medlemsskap i folketrygden',
+    [MenuListItemKey.ProcessTimes]: 'Saksbehandlingstider',
+    [MenuListItemKey.Rates]: 'Satser',
+    [MenuListItemKey.RelatedInformation]: 'Relatert innhold',
+    [MenuListItemKey.ReportChanges]: 'Meld fra om endringer',
+    [MenuListItemKey.RulesAndRegulations]: 'Regelverk',
+    [MenuListItemKey.Saksbehandling]: 'Saksbehandling',
+    [MenuListItemKey.Selfservice]: 'Selvbetjening',
+    [MenuListItemKey.Shortcuts]: 'Snarveier',
+    [MenuListItemKey.AppealRightsLegacy]: 'Klagerettigheter',
+    [MenuListItemKey.FormAndApplicationLegacy]: 'Skjema og søknad',
+    [MenuListItemKey.ProcessTimesLegacy]: 'Saksbehandlingstider',
+    [MenuListItemKey.RelatedInformationLegacy]: 'Relatert innhold',
+    [MenuListItemKey.ReportChangesLegacy]: 'Meld fra om endringer',
+    [MenuListItemKey.RulesAndRegulationsLegacy]: 'Regelverk',
 };
 
 export const bundle = {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,4 +1,5 @@
 import { Translations } from './default';
+import { MenuListItemKey } from '../types/menu-list-items';
 
 export const bundle: Translations = {
     dates: {
@@ -29,18 +30,24 @@ export const bundle: Translations = {
         label: 'Urgent notifications',
     },
     relatedContent: {
-        appealRights: 'Appeal rights',
-        formAndApplication: 'Form and application',
-        international: 'International',
-        membership: 'Membership',
-        processTimes: 'Processing times',
-        rates: 'Rates',
-        relatedInformation: 'Related information',
-        reportChanges: 'Report changes',
-        rulesAndRegulations: 'Laws and regulations',
-        saksbehandling: 'Procedural',
-        selfservice: 'Selfservice',
-        shortcuts: 'Shortcuts',
+        [MenuListItemKey.AppealRights]: 'Appeal rights',
+        [MenuListItemKey.FormAndApplication]: 'Form and application',
+        [MenuListItemKey.International]: 'International',
+        [MenuListItemKey.Membership]: 'Membership',
+        [MenuListItemKey.ProcessTimes]: 'Processing times',
+        [MenuListItemKey.Rates]: 'Rates',
+        [MenuListItemKey.RelatedInformation]: 'Related information',
+        [MenuListItemKey.ReportChanges]: 'Report changes',
+        [MenuListItemKey.RulesAndRegulations]: 'Laws and regulations',
+        [MenuListItemKey.Saksbehandling]: 'Procedural',
+        [MenuListItemKey.Selfservice]: 'Selfservice',
+        [MenuListItemKey.Shortcuts]: 'Shortcuts',
+        [MenuListItemKey.AppealRightsLegacy]: 'Appeal rights',
+        [MenuListItemKey.FormAndApplicationLegacy]: 'Form and application',
+        [MenuListItemKey.ProcessTimesLegacy]: 'Processing times',
+        [MenuListItemKey.RelatedInformationLegacy]: 'Related information',
+        [MenuListItemKey.ReportChangesLegacy]: 'Report changes',
+        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Laws and regulations',
     },
     header: {
         copyLink: 'Copy link',

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -1,16 +1,23 @@
 import { Translations } from './default';
+import { MenuListItemKey } from '../types/menu-list-items';
 
 export const bundle: Translations = {
     relatedContent: {
-        appealRights: 'Prawo do złożenia odwołania',
-        formAndApplication: 'Formularze i wnioski',
-        international: 'Międzynarodowy',
-        membership: 'Członkostwo w funduszu ubezpieczeń',
-        processTimes: 'Czas rozpatrywania spraw',
-        rates: 'Stawki',
-        relatedInformation: 'Powiązane informacje',
-        reportChanges: 'Zgłoś zmiany',
-        rulesAndRegulations: 'Przepisy',
-        selfservice: 'Samoobsługa',
+        [MenuListItemKey.AppealRights]: 'Prawo do złożenia odwołania',
+        [MenuListItemKey.FormAndApplication]: 'Formularze i wnioski',
+        [MenuListItemKey.International]: 'Międzynarodowy',
+        [MenuListItemKey.Membership]: 'Członkostwo w funduszu ubezpieczeń',
+        [MenuListItemKey.ProcessTimes]: 'Czas rozpatrywania spraw',
+        [MenuListItemKey.Rates]: 'Stawki',
+        [MenuListItemKey.RelatedInformation]: 'Powiązane informacje',
+        [MenuListItemKey.ReportChanges]: 'Zgłoś zmiany',
+        [MenuListItemKey.RulesAndRegulations]: 'Przepisy',
+        [MenuListItemKey.Selfservice]: 'Samoobsługa',
+        [MenuListItemKey.AppealRightsLegacy]: 'Prawo do złożenia odwołania',
+        [MenuListItemKey.FormAndApplicationLegacy]: 'Formularze i wnioski',
+        [MenuListItemKey.ProcessTimesLegacy]: 'Czas rozpatrywania spraw',
+        [MenuListItemKey.RelatedInformationLegacy]: 'Powiązane informacje',
+        [MenuListItemKey.ReportChangesLegacy]: 'Zgłoś zmiany',
+        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Przepisy',
     },
 };

--- a/src/translations/se.ts
+++ b/src/translations/se.ts
@@ -1,18 +1,26 @@
 import { Translations } from './default';
+import { MenuListItemKey } from '../types/menu-list-items';
 
 export const bundle: Translations = {
     relatedContent: {
-        appealRights: 'Váidinvuoigatvuođat',
-        formAndApplication: 'Skovit',
-        international: 'Riikkaidgaskasaš',
-        membership: 'Álbmotoaju miellahttovuohta',
-        processTimes: 'Áššemeannudanáiggit',
-        rates: 'Máksomearit',
-        relatedInformation: 'Dehálaš dieđutdehálaš dieđut',
-        reportChanges: 'Dieđit daid rievdadusaid',
-        rulesAndRegulations: 'Njuolggadusat',
-        saksbehandling: 'NAV áššemeannudanáiggit',
-        selfservice: 'Ieš-bálvaleapmi',
-        shortcuts: 'Njuolggobálgát',
+        [MenuListItemKey.AppealRights]: 'Váidinvuoigatvuođat',
+        [MenuListItemKey.FormAndApplication]: 'Skovit',
+        [MenuListItemKey.International]: 'Riikkaidgaskasaš',
+        [MenuListItemKey.Membership]: 'Álbmotoaju miellahttovuohta',
+        [MenuListItemKey.ProcessTimes]: 'Áššemeannudanáiggit',
+        [MenuListItemKey.Rates]: 'Máksomearit',
+        [MenuListItemKey.RelatedInformation]: 'Dehálaš dieđutdehálaš dieđut',
+        [MenuListItemKey.ReportChanges]: 'Dieđit daid rievdadusaid',
+        [MenuListItemKey.RulesAndRegulations]: 'Njuolggadusat',
+        [MenuListItemKey.Saksbehandling]: 'NAV áššemeannudanáiggit',
+        [MenuListItemKey.Selfservice]: 'Ieš-bálvaleapmi',
+        [MenuListItemKey.Shortcuts]: 'Njuolggobálgát',
+        [MenuListItemKey.AppealRightsLegacy]: 'Váidinvuoigatvuođat',
+        [MenuListItemKey.FormAndApplicationLegacy]: 'Skovit',
+        [MenuListItemKey.ProcessTimesLegacy]: 'Áššemeannudanáiggit',
+        [MenuListItemKey.RelatedInformationLegacy]:
+            'Dehálaš dieđutdehálaš dieđut',
+        [MenuListItemKey.ReportChangesLegacy]: 'Dieđit daid rievdadusaid',
+        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Njuolggadusat',
     },
 };

--- a/src/types/component-props/layouts/section-with-header.ts
+++ b/src/types/component-props/layouts/section-with-header.ts
@@ -16,7 +16,11 @@ export interface SectionWithHeaderProps extends LayoutCommonProps {
         title: string;
         anchorId: string;
         hideCopyButton: boolean;
-        icon?: { icon: XpImageProps; color?: string };
+        icon?: {
+            icon: XpImageProps;
+            color?: string;
+            size?: number;
+        };
         border?: {
             color: string;
             rounded: boolean;

--- a/src/types/component-props/parts/alert.ts
+++ b/src/types/component-props/parts/alert.ts
@@ -1,12 +1,13 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
+import { ProcessedHtmlProps } from '../../processed-html-props';
 
 export interface DynamicAlert extends PartComponentProps {
     descriptor: PartType.Alert;
     config: {
         type: 'info' | 'suksess' | 'advarsel' | 'feil';
         inline: string;
-        content: string;
+        content: ProcessedHtmlProps;
         margin: string;
     };
 }

--- a/src/types/component-props/parts/html-area.ts
+++ b/src/types/component-props/parts/html-area.ts
@@ -1,10 +1,11 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
 import { ExpandableMixin } from '../_mixins';
+import { ProcessedHtmlProps } from '../../processed-html-props';
 
 export interface HtmlAreaProps extends PartComponentProps {
     descriptor: PartType.HtmlArea;
     config: {
-        html: string;
+        html: ProcessedHtmlProps;
     } & ExpandableMixin;
 }

--- a/src/types/component-props/parts/read-more-panel.ts
+++ b/src/types/component-props/parts/read-more-panel.ts
@@ -1,11 +1,12 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
+import { ProcessedHtmlProps } from '../../processed-html-props';
 
 export interface DynamicReadMorePanel extends PartComponentProps {
     descriptor: PartType.ReadMorePanel;
     config: {
-        ingress: string;
-        content: string;
+        ingress: ProcessedHtmlProps;
+        content: ProcessedHtmlProps;
         border: string;
         margin: string;
     };

--- a/src/types/component-props/parts/supervisor-panel.ts
+++ b/src/types/component-props/parts/supervisor-panel.ts
@@ -1,10 +1,11 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
+import { ProcessedHtmlProps } from '../../processed-html-props';
 
 export interface DynamicSupervisorPanel extends PartComponentProps {
     descriptor: PartType.SupervisorPanel;
     config: {
-        content: string;
+        content: ProcessedHtmlProps;
         margin: string;
     };
 }

--- a/src/types/content-props/large-table-props.ts
+++ b/src/types/content-props/large-table-props.ts
@@ -1,7 +1,8 @@
 import { ContentType, ContentProps } from './_content-common';
+import { ProcessedHtmlProps } from '../processed-html-props';
 
 export type LargeTableData = {
-    text?: string;
+    text?: ProcessedHtmlProps;
 };
 
 export interface LargeTableProps extends ContentProps {

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -8,6 +8,7 @@ import {
 import { MenuListItem } from '../menu-list-items';
 import { LanguageProps } from '../language';
 import { XpImageProps } from '../media';
+import { ProcessedHtmlProps } from '../processed-html-props';
 
 export type Picture = Partial<{
     target: XpImageProps;
@@ -19,9 +20,9 @@ export type Picture = Partial<{
 export type MainArticleData = Partial<{
     languages: LanguageProps[];
     ingress: string;
-    text: string;
+    text: ProcessedHtmlProps;
     hasTableOfContents: string;
-    fact: string;
+    fact: ProcessedHtmlProps;
     social: string[];
     picture: Picture;
     menuListItems: MenuListItem;

--- a/src/types/macro-props/_macros-common.ts
+++ b/src/types/macro-props/_macros-common.ts
@@ -1,0 +1,20 @@
+export enum MacroType {
+    Button = 'button',
+    ButtonBlue = 'button-blue',
+    ChatbotLink = 'chatbot-link',
+    ChevronLinkInternal = 'chevron-link-internal',
+    ChevronLinkExternal = 'chevron-link-external',
+    Fotnote = 'fotnote',
+    InfoBoks = 'infoBoks',
+    LenkeFiler = 'lenkeFiler',
+    PhoneLink = 'phone-link',
+    Quote = 'quote',
+    Tankestrek = 'tankestrek',
+    VarselBoks = 'varselBoks',
+    Video = 'video',
+}
+
+export type MacroPropsCommon = {
+    ref: string;
+    name: MacroType;
+};

--- a/src/types/macro-props/button-blue.ts
+++ b/src/types/macro-props/button-blue.ts
@@ -1,0 +1,14 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroButtonBlueProps extends MacroPropsCommon {
+    name: MacroType.ButtonBlue;
+    config: {
+        button_blue: {
+            url: string;
+            text: string;
+            content: {
+                _path: string;
+            };
+        };
+    };
+}

--- a/src/types/macro-props/button.ts
+++ b/src/types/macro-props/button.ts
@@ -1,0 +1,14 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroButtonProps extends MacroPropsCommon {
+    name: MacroType.Button;
+    config: {
+        button: {
+            url: string;
+            text: string;
+            content: {
+                _path: string;
+            };
+        };
+    };
+}

--- a/src/types/macro-props/chatbot-link.ts
+++ b/src/types/macro-props/chatbot-link.ts
@@ -1,0 +1,10 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroChatbotLinkProps extends MacroPropsCommon {
+    name: MacroType.ChevronLinkExternal;
+    config: {
+        chatbot_link: {
+            text: string;
+        };
+    };
+}

--- a/src/types/macro-props/chevron-link-external.ts
+++ b/src/types/macro-props/chevron-link-external.ts
@@ -1,0 +1,9 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+import { ExternalLinkMixin } from '../component-props/_mixins';
+
+export interface MacroChevronLinkExternalProps extends MacroPropsCommon {
+    name: MacroType.ChevronLinkExternal;
+    config: {
+        chevron_link_external: ExternalLinkMixin;
+    };
+}

--- a/src/types/macro-props/chevron-link-internal.ts
+++ b/src/types/macro-props/chevron-link-internal.ts
@@ -1,0 +1,9 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+import { InternalLinkMixin } from '../component-props/_mixins';
+
+export interface MacroChevronLinkInternalProps extends MacroPropsCommon {
+    name: MacroType.ChevronLinkInternal;
+    config: {
+        chevron_link_internal: InternalLinkMixin;
+    };
+}

--- a/src/types/macro-props/fotnote.ts
+++ b/src/types/macro-props/fotnote.ts
@@ -1,0 +1,10 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroFotnoteProps extends MacroPropsCommon {
+    name: MacroType.Fotnote;
+    config: {
+        fotnote: {
+            fotnote: string;
+        };
+    };
+}

--- a/src/types/macro-props/infoBoks.ts
+++ b/src/types/macro-props/infoBoks.ts
@@ -1,0 +1,10 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroInfoBoksProps extends MacroPropsCommon {
+    name: MacroType.InfoBoks;
+    config: {
+        infoBoks: {
+            infoBoks: string;
+        };
+    };
+}

--- a/src/types/macro-props/lenkeFiler.ts
+++ b/src/types/macro-props/lenkeFiler.ts
@@ -1,0 +1,11 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroLenkeFilerProps extends MacroPropsCommon {
+    name: MacroType.LenkeFiler;
+    config: {
+        lenkeFiler: {
+            text: string;
+            files: { _path: string }[];
+        };
+    };
+}

--- a/src/types/macro-props/phone-link.ts
+++ b/src/types/macro-props/phone-link.ts
@@ -1,0 +1,12 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroPhoneLinkProps extends MacroPropsCommon {
+    name: MacroType.PhoneLink;
+    config: {
+        phone_link: {
+            text: string;
+            phoneNumber: string;
+            chevron: boolean;
+        };
+    };
+}

--- a/src/types/macro-props/quote.ts
+++ b/src/types/macro-props/quote.ts
@@ -1,0 +1,10 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroQuoteProps extends MacroPropsCommon {
+    name: MacroType.Quote;
+    config: {
+        quote: {
+            quote: string;
+        };
+    };
+}

--- a/src/types/macro-props/tankestrek.ts
+++ b/src/types/macro-props/tankestrek.ts
@@ -1,0 +1,5 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroTankestrekProps extends MacroPropsCommon {
+    name: MacroType.Tankestrek;
+}

--- a/src/types/macro-props/varselBoks.ts
+++ b/src/types/macro-props/varselBoks.ts
@@ -1,0 +1,10 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroVarselBoksProps extends MacroPropsCommon {
+    name: MacroType.VarselBoks;
+    config: {
+        varselBoks: {
+            varselBoks: string;
+        };
+    };
+}

--- a/src/types/macro-props/video.ts
+++ b/src/types/macro-props/video.ts
@@ -1,0 +1,11 @@
+import { MacroPropsCommon, MacroType } from './_macros-common';
+
+export interface MacroVideoProps extends MacroPropsCommon {
+    name: MacroType.Video;
+    config: {
+        video: {
+            video: string;
+            title: string;
+        };
+    };
+}

--- a/src/types/menu-list-items.ts
+++ b/src/types/menu-list-items.ts
@@ -5,19 +5,26 @@ export interface LinkItem {
     }[];
 }
 
+// TODO: fjern legacy når XP er oppdatert
 export enum MenuListItemKey {
     Selfservice = 'selfservice',
-    FormAndApplication = 'formAndApplication',
-    ProcessTimes = 'processTimes',
-    RelatedInformation = 'relatedInformation',
+    FormAndApplication = 'form_and_application',
+    ProcessTimes = 'process_times',
+    RelatedInformation = 'related_information',
     International = 'international',
-    ReportChanges = 'reportChanges',
+    ReportChanges = 'report_changes',
     Rates = 'rates',
-    AppealRights = 'appealRights',
+    AppealRights = 'appeal_rights',
     Membership = 'membership',
-    RulesAndRegulations = 'rulesAndRegulations',
+    RulesAndRegulations = 'rules_and_regulations',
     Saksbehandling = 'saksbehandling',
     Shortcuts = 'shortcuts',
+    FormAndApplicationLegacy = 'formAndApplication',
+    ProcessTimesLegacy = 'processTimes',
+    RelatedInformationLegacy = 'relatedInformation',
+    ReportChangesLegacy = 'reportChanges',
+    AppealRightsLegacy = 'appealRights',
+    RulesAndRegulationsLegacy = 'rulesAndRegulations',
 }
 
 export type MenuListItem = {

--- a/src/types/processed-html-props.ts
+++ b/src/types/processed-html-props.ts
@@ -1,0 +1,19 @@
+import { MacroPropsCommon } from './macro-props/_macros-common';
+
+export const processedHtmlMacroTag = 'editor-macro';
+
+export type ProcessedHtmlProps =
+    | {
+          processedHtml: string;
+          macros: MacroPropsCommon[];
+          isLegacy?: boolean;
+      }
+    | string;
+
+// TODO: fjern når backend er oppgradert til Guillotine 5
+export const getProcessedHtmlPropsWithBackwardsCompatibility = (
+    html: ProcessedHtmlProps
+) =>
+    typeof html === 'string'
+        ? { processedHtml: html, macros: [], isLegacy: true }
+        : html;


### PR DESCRIPTION
Tilsvarer https://github.com/navikt/nav-enonicxp/pull/922
Inkluderer også støtte for fremtidig Guillotine 5 oppgradering

- Støtter tilpasning av ikon-størrelse på section-with-header layout (https://github.com/navikt/nav-enonicxp-frontend/pull/411)
- Kompatibilitet for Guillotine 5 (https://github.com/navikt/nav-enonicxp-frontend/pull/410)
- Parser chatbot-link macro (https://github.com/navikt/nav-enonicxp-frontend/pull/406)
- Fikser visning av templates