### PR TITLE
Oppdaterer HTML-parser

### DIFF
--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -143,8 +143,8 @@ const getNonEmptyChildren = ({ children }: DomElement) => {
             return true;
         }
 
-        const stringData = data.trim();
-        return stringData && stringData !== '&nbsp;';
+        const stringData = data.replaceAll('&nbsp;', ' ').trim();
+        return !!stringData;
     });
     return validChildren?.length > 0 && validChildren;
 };

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -216,7 +216,7 @@ export const ParsedHtml = (props: Props) => {
 
             if (tag === 'p' && children) {
                 return (
-                    <Normaltekst>
+                    <Normaltekst {...props}>
                         {domToReact(children, replaceElements)}
                     </Normaltekst>
                 );

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -143,7 +143,7 @@ const getNonEmptyChildren = ({ children }: DomElement) => {
             return true;
         }
 
-        const stringData = data.replaceAll('&nbsp;', ' ').trim();
+        const stringData = data.replace(/&nbsp;/g, ' ').trim();
         return !!stringData;
     });
     return validChildren?.length > 0 && validChildren;

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -203,7 +203,7 @@ export const ParsedHtml = (props: Props) => {
 
                 return (
                     // H1 tags should only be used for the page title
-                    <TypoComponent tag={tag === 'h1' ? 'h2' : tag}>
+                    <TypoComponent {...props} tag={tag === 'h1' ? 'h2' : tag}>
                         {domToReact(children, replaceElements)}
                     </TypoComponent>
                 );
@@ -211,7 +211,7 @@ export const ParsedHtml = (props: Props) => {
 
             if (tag === 'p' && children) {
                 return (
-                    <Normaltekst>
+                    <Normaltekst {...props}>
                         {domToReact(children, replaceElements)}
                     </Normaltekst>
                 );
@@ -242,7 +242,7 @@ export const ParsedHtml = (props: Props) => {
 
             if (tag === 'table') {
                 return (
-                    <table className={'tabell tabell--stripet'} {...props}>
+                    <table {...props} className={'tabell tabell--stripet'}>
                         {domToReact(children, replaceElements)}
                     </table>
                 );

--- a/src/components/macros/infoboks/MacroInfoBoks.tsx
+++ b/src/components/macros/infoboks/MacroInfoBoks.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import { MacroInfoBoksProps } from '../../../types/macro-props/infoBoks';
 import AlertStripe from 'nav-frontend-alertstriper';
+import { ParsedHtml } from '../../ParsedHtml';
 
 export const MacroInfoBoks = ({ config }: MacroInfoBoksProps) => {
     if (!config?.infoBoks) {
         return null;
     }
 
+    // TODO: this should only be plain text, but it seems to be used
+    // with HTML by some editors
     const { infoBoks } = config.infoBoks;
 
-    return <AlertStripe type={'info'}>{infoBoks}</AlertStripe>;
+    return (
+        <AlertStripe type={'info'}>
+            <ParsedHtml htmlProps={infoBoks} />
+        </AlertStripe>
+    );
 };

--- a/src/components/macros/varselboks/MacroVarselBoks.tsx
+++ b/src/components/macros/varselboks/MacroVarselBoks.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { MacroVarselBoksProps } from '../../../types/macro-props/varselBoks';
+import { ParsedHtml } from '../../ParsedHtml';
 
 export const MacroVarselBoks = ({ config }: MacroVarselBoksProps) => {
     if (!config?.varselBoks) {
         return null;
     }
 
+    // TODO: this should only be plain text, but it seems to be used
+    // with HTML by some editors
     const { varselBoks } = config.varselBoks;
 
-    return <AlertStripe type={'advarsel'}>{varselBoks}</AlertStripe>;
+    return (
+        <AlertStripe type={'advarsel'}>
+            <ParsedHtml htmlProps={varselBoks} />
+        </AlertStripe>
+    );
 };


### PR DESCRIPTION
Legger inn funksjonalitet som i dag ligger i XP, og andre justeringer på html-parseren.
Skal være tilsvarende denne (+ noe ekstra): https://github.com/navikt/nav-enonicxp/blob/f92b138425346d006503e5f48e1961954793255f/src/main/java/tools/HtmlCleaner.java

- Fjerner tomme lister
- Fjerner tomme bilder
- Bytter ut tomme headere med `<p>`
- Bruker designsystemet typografi for headere
- Parser innholdet i infoboks og varselboks-macroer som html (skal egentlig ikke være html, men de brukes på denne måten enkelte steder...)