### PR TITLE
Setter viewet som requesten kom fra i draftrouter

### DIFF
--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -83,6 +83,7 @@ export const PageWrapper = (props: Props) => {
             setPageConfigAction({
                 pageId: content._id,
                 language: content.language,
+                editorView: content.editorView,
             })
         );
 

--- a/src/pages/draft/[[...draftRouter]].tsx
+++ b/src/pages/draft/[[...draftRouter]].tsx
@@ -1,5 +1,7 @@
 import { GetServerSideProps } from 'next';
 import PageBase, { fetchPageProps } from '../../components/PageBase';
+import { ContentProps } from '../../types/content-props/_content-common';
+import { isPropsWithContent } from '../../types/_type-guards';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const secret = context.req.headers.secret as string;
@@ -11,7 +13,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         };
     }
 
-    return await fetchPageProps(pathSegments, true, secret);
+    const pageProps = await fetchPageProps(pathSegments, true, secret);
+
+    if (isPropsWithContent(pageProps.props)) {
+        pageProps.props.content.editorView =
+            (context.query.mode as ContentProps['editorView']) || 'preview';
+    }
+
+    return pageProps;
 };
 
 export default PageBase;

--- a/src/store/hooks/usePageConfig.ts
+++ b/src/store/hooks/usePageConfig.ts
@@ -4,14 +4,17 @@ import {
     setPageConfigAction,
     currentPageId,
     currentLanguage,
+    currentEditorView,
 } from '../slices/pageConfig';
 import { Language } from 'translations';
+import { ContentProps } from '../../types/content-props/_content-common';
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 type PageConfig = {
     pageId: string;
+    editorView: ContentProps['editorView'];
 };
 
 type UseFilterState = {
@@ -27,6 +30,7 @@ export const usePageConfig = (): UseFilterState => {
     const language = useAppSelector<Language>((state) =>
         currentLanguage(state)
     );
+    const editorView = useAppSelector((state) => currentEditorView(state));
 
     const setPageConfig = (payload) => {
         dispatch(setPageConfigAction(payload));
@@ -34,6 +38,7 @@ export const usePageConfig = (): UseFilterState => {
 
     const pageConfig = {
         pageId,
+        editorView,
     };
 
     return { pageConfig, setPageConfig, language };

--- a/src/store/slices/pageConfig.ts
+++ b/src/store/slices/pageConfig.ts
@@ -1,15 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Language } from 'translations';
 import type { RootState } from '../store';
+import { ContentProps } from '../../types/content-props/_content-common';
+
+type EditorView = ContentProps['editorView'];
 
 interface PageConfigState {
     pageId: string | null;
     language: Language;
+    editorView?: EditorView;
 }
 
 interface CurrentPageIdPayload {
     pageId: string;
     language: Language;
+    editorView?: EditorView;
 }
 
 const initialState: PageConfigState = {
@@ -24,6 +29,7 @@ export const pageConfigSlice = createSlice({
         setPageConfig: (state, action: PayloadAction<CurrentPageIdPayload>) => {
             state.pageId = action.payload.pageId;
             state.language = action.payload.language;
+            state.editorView = action.payload.editorView;
         },
     },
 });
@@ -36,6 +42,10 @@ export const currentPageId = (state: RootState): string => {
 
 export const currentLanguage = (state: RootState): Language => {
     return state.pageConfig.language;
+};
+
+export const currentEditorView = (state: RootState): EditorView => {
+    return state.pageConfig.editorView;
 };
 
 export default pageConfigSlice.reducer;

--- a/src/types/_type-guards.ts
+++ b/src/types/_type-guards.ts
@@ -43,5 +43,5 @@ export const hasCanonicalUrl = (
 export const isPropsWithContent = (
     props: any
 ): props is { content: ContentProps } => {
-    return !!props.content;
+    return !!props?.content;
 };

--- a/src/types/_type-guards.ts
+++ b/src/types/_type-guards.ts
@@ -1,3 +1,5 @@
+import { ContentProps } from './content-props/_content-common';
+
 export const hasDescription = (
     content: any
 ): content is {
@@ -36,4 +38,10 @@ export const hasCanonicalUrl = (
     };
 } => {
     return typeof content?.data?.canonicalUrl === 'string';
+};
+
+export const isPropsWithContent = (
+    props: any
+): props is { content: ContentProps } => {
+    return !!props.content;
 };

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -58,6 +58,7 @@ export type ContentProps = {
     data?: ContentData;
     page?: LayoutProps;
     editMode?: boolean;
+    editorView?: 'inline' | 'preview' | 'edit';
     breadcrumbs?: DecoratorParams['breadcrumbs'];
     notifications?: NotificationProps[];
     pathMap?: PathMap;


### PR DESCRIPTION
Tanken er å kunne bruke parameteret for å vise hjelpetekster/dokumentasjon til redaktørene når de står i editor-viewet

Se også https://github.com/navikt/nav-enonicxp/pull/951