### PR TITLE
Fikser feil i content-studio editor ved tomme komponenter

### DIFF
--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -6,6 +6,7 @@ import { FlexColsLayout } from './flex-cols/FlexColsLayout';
 import { LegacyLayout } from './legacy/LegacyLayout';
 import { PageWithSideMenus } from './page-with-side-menus/PageWithSideMenus';
 import { SectionWithHeaderLayout } from './section-with-header/SectionWithHeaderLayout';
+import { ComponentType } from '../../types/component-props/_component-common';
 
 type Props = {
     pageProps: ContentProps;
@@ -28,12 +29,25 @@ const layoutComponents: {
 };
 
 export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
-    const { descriptor } = layoutProps;
+    const { descriptor, path } = layoutProps;
+
+    const editorProps = {
+        'data-portal-component-type': ComponentType.Layout,
+        'data-portal-component': path,
+    };
+
+    if (!descriptor) {
+        return <div {...editorProps} />;
+    }
 
     const LayoutComponent = layoutComponents[descriptor];
 
     if (!LayoutComponent) {
-        return <div>{`Unimplemented layout type: ${descriptor}`}</div>;
+        return (
+            <div
+                {...editorProps}
+            >{`Unimplemented layout type: ${descriptor}`}</div>
+        );
     }
 
     return <LayoutComponent pageProps={pageProps} layoutProps={layoutProps} />;

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -30,6 +30,7 @@ const layoutComponents: {
 
 export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
     const { descriptor, path } = layoutProps;
+    const isEditView = pageProps.editorView === 'edit';
 
     const editorProps = {
         'data-portal-component-type': ComponentType.Layout,
@@ -37,7 +38,7 @@ export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
     };
 
     if (!descriptor) {
-        return <div {...editorProps} />;
+        return isEditView ? <div {...editorProps} /> : null;
     }
 
     const LayoutComponent = layoutComponents[descriptor];

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -87,29 +87,22 @@ const PartComponent = ({ partProps, pageProps }: Props) => {
 
 export const PartsMapper = ({ pageProps, partProps }: Props) => {
     const { path, descriptor } = partProps;
+    const isEditView = pageProps.editorView === 'edit';
 
-    if (!descriptor) {
-        return null;
-    }
-
-    const bem = BEM(ComponentType.Part);
-    const partName = descriptor.split(':')[1];
-
-    const editorProps = pageProps.editMode
+    const editorProps = isEditView
         ? {
               'data-portal-component-type': ComponentType.Part,
               'data-portal-component': path,
           }
         : undefined;
 
-    if (partsDeprecated[descriptor]) {
+    if (!descriptor || partsDeprecated[descriptor]) {
         // Prevents content-studio editor crash due to missing component props
-        if (pageProps.editMode) {
-            return <div {...editorProps} />;
-        }
-
-        return null;
+        return isEditView ? <div {...editorProps} /> : null;
     }
+
+    const bem = BEM(ComponentType.Part);
+    const partName = descriptor.split(':')[1];
 
     return (
         <div className={classNames(bem(), bem(partName))} {...editorProps}>


### PR DESCRIPTION
Tomme komponenter må rendres i editoren for å unngå null-feil, samt kunne sette type på komponenter etter en page-refresh i editoren. Denne state'en kan oppstå dersom en setter inn en komponent uten å velge noe.