### PR TITLE
Endrer inndeling av svg til forgrunn og bakgrunnsikoner

### DIFF
--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -52,8 +52,7 @@
             text-decoration: none;
         }
 
-        .illustration__icon--icon2,
-        .illustration__icon--icon3 {
+        .illustration__icon--icon2 {
             filter: brightness(0) invert(1);
         }
 

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -52,12 +52,12 @@
             text-decoration: none;
         }
 
-        .illustration__icon--icon1,
+        .illustration__icon--icon2,
         .illustration__icon--icon3 {
             filter: brightness(0) invert(1);
         }
 
-        .illustration__icon--icon2 {
+        .illustration__icon--icon1 {
             filter: invert(49%) sepia(37%) saturate(3786%) hue-rotate(192deg)
                 brightness(92%) contrast(90%);
         }

--- a/src/components/_common/card/LargeCard.less
+++ b/src/components/_common/card/LargeCard.less
@@ -17,10 +17,10 @@
         }
 
         .card__illustration {
-            width: 6rem;
-            height: 6rem;
+            width: 5.4rem;
+            height: 5.4rem;
             align-self: center;
-            margin-top: -0.5rem;
+            margin-top: 0;
             margin-bottom: 2rem;
         }
 

--- a/src/components/_common/card/MiniCard.less
+++ b/src/components/_common/card/MiniCard.less
@@ -33,8 +33,8 @@
         }
 
         .card__illustration {
-            width: 4rem;
-            height: 4rem;
+            width: 3rem;
+            height: 3rem;
             margin-right: 1rem;
         }
 

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -20,9 +20,9 @@
     }
 
     &__illustration {
-        width: 5.5rem;
-        height: 5.5rem;
-        margin-right: 1rem;
+        width: 5rem;
+        height: 5rem;
+        margin-right: 1.5rem;
     }
 
     &__text {

--- a/src/components/_common/illustration/Illustration.less
+++ b/src/components/_common/illustration/Illustration.less
@@ -11,8 +11,8 @@
         background-repeat: no-repeat;
         position: absolute;
         background-size: contain;
-        width: 50%;
-        height: 50%;
+        width: 100%;
+        height: 100%;
 
         &--icon1 {
             transform: translateX(-40%) translateY(30%);

--- a/src/components/_common/illustration/Illustration.less
+++ b/src/components/_common/illustration/Illustration.less
@@ -13,17 +13,7 @@
         background-size: contain;
         width: 100%;
         height: 100%;
-
-        &--icon1 {
-            transform: translateX(-40%) translateY(30%);
-        }
-        &--icon2 {
-            align-self: center;
-            justify-self: center;
-        }
-
-        &--icon3 {
-            transform: translateX(40%) translateY(-30%);
-        }
+        top: 0;
+        left: 0;
     }
 }

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -31,7 +31,7 @@ export const Illustration = ({
 
     const { icons } = illustration?.data;
 
-    const [icon1, icon2, icon3] = icons;
+    const [icon1, icon2] = icons;
 
     return (
         <div
@@ -51,14 +51,6 @@ export const Illustration = ({
                 style={{
                     backgroundImage: `url(${icon2.icon?.mediaUrl})`,
                     transform: buildTransformStyling(icon2, 'none'),
-                }}
-            />
-
-            <div
-                className={classNames(bem('icon'), bem('icon', 'icon3'))}
-                style={{
-                    backgroundImage: `url(${icon3.icon?.mediaUrl})`,
-                    transform: buildTransformStyling(icon3, 'none'),
                 }}
             />
         </div>

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -41,12 +41,15 @@ export const Illustration = ({
         >
             <div
                 className={classNames(bem('icon'), bem('icon', 'icon2'))}
-                style={{ backgroundImage: `url(${icon2.icon.mediaUrl})` }}
+                style={{
+                    backgroundImage: `url(${icon2.icon?.mediaUrl})`,
+                    transform: buildTransformStyling(icon2, ''),
+                }}
             />
             <div
                 className={classNames(bem('icon'), bem('icon', 'icon1'))}
                 style={{
-                    backgroundImage: `url(${icon1.icon.mediaUrl})`,
+                    backgroundImage: `url(${icon1.icon?.mediaUrl})`,
                     transform: buildTransformStyling(
                         icon1,
                         'translateX(-40%) translateY(40%)'
@@ -56,7 +59,7 @@ export const Illustration = ({
             <div
                 className={classNames(bem('icon'), bem('icon', 'icon3'))}
                 style={{
-                    backgroundImage: `url(${icon3.icon.mediaUrl})`,
+                    backgroundImage: `url(${icon3.icon?.mediaUrl})`,
                     transform: buildTransformStyling(
                         icon3,
                         'translateX(40%) translateY(-40%)'

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -40,30 +40,25 @@ export const Illustration = ({
             aria-label={illustration.displayName}
         >
             <div
-                className={classNames(bem('icon'), bem('icon', 'icon2'))}
-                style={{
-                    backgroundImage: `url(${icon2.icon?.mediaUrl})`,
-                    transform: buildTransformStyling(icon2, ''),
-                }}
-            />
-            <div
                 className={classNames(bem('icon'), bem('icon', 'icon1'))}
                 style={{
                     backgroundImage: `url(${icon1.icon?.mediaUrl})`,
-                    transform: buildTransformStyling(
-                        icon1,
-                        'translateX(-40%) translateY(40%)'
-                    ),
+                    transform: buildTransformStyling(icon1, 'none'),
                 }}
             />
+            <div
+                className={classNames(bem('icon'), bem('icon', 'icon2'))}
+                style={{
+                    backgroundImage: `url(${icon2.icon?.mediaUrl})`,
+                    transform: buildTransformStyling(icon2, 'none'),
+                }}
+            />
+
             <div
                 className={classNames(bem('icon'), bem('icon', 'icon3'))}
                 style={{
                     backgroundImage: `url(${icon3.icon?.mediaUrl})`,
-                    transform: buildTransformStyling(
-                        icon3,
-                        'translateX(40%) translateY(-40%)'
-                    ),
+                    transform: buildTransformStyling(icon3, 'none'),
                 }}
             />
         </div>


### PR DESCRIPTION
Midlertidig fiks for å få vist ikoner korrekt til testen hvor forgrunn består av selve 2 ikonene mens bakgrunn som separat svg inneholder shape (hjerte, pil etc)