### PR TITLE
Fikse margin ved html area

### DIFF
--- a/src/components/_common/card/MicroCard.less
+++ b/src/components/_common/card/MicroCard.less
@@ -6,7 +6,7 @@
         color: @navMorkGra;
         display: inline-flex;
         font-size: 0.875rem;
-        margin: 0.2rem 0.5rem 0.2rem 0;
+        margin: 0.2rem 0.5rem 0 0;
         padding: 0.2rem 0.5rem;
         text-decoration: none;
 

--- a/src/components/_common/card/MiniCard.less
+++ b/src/components/_common/card/MiniCard.less
@@ -12,7 +12,7 @@
         box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.14),
             0px 2px 1px rgba(38, 38, 38, 0.12),
             0px 1px 3px rgba(38, 38, 38, 0.2);
-        margin-bottom: 2.75rem;
+        margin-bottom: 2.44rem;
 
         &.card__situation {
             background-color: @navOransjeLighten60;

--- a/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
+++ b/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.less
@@ -7,7 +7,7 @@
         flex-direction: column;
 
         & > :not(:last-child) {
-            margin-bottom: 2rem;
+            margin-bottom: 1.33rem;
         }
 
         &:empty {

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.less
@@ -1,13 +1,7 @@
 @import (reference) '../../../global';
 
-.part-specific-mixins() {
-    .part__product-card-mini {
-        margin-top: 0.75rem;
-    }
-}
-
 .layout__section-with-header {
-    @iconContainerRadius: 2rem;
+    @iconContainerRadius: 1.77rem;
     @iconContainerSize: @iconContainerRadius * 2;
 
     @defaultBgColor: white;
@@ -19,7 +13,7 @@
     .section-padding-mixin();
 
     &:not(:last-child) {
-        margin-bottom: 2rem;
+        margin-bottom: 1.33rem;
     }
 
     &--with-icon {
@@ -33,8 +27,10 @@
         & > :not(:first-child) {
             margin-top: 1rem;
         }
+    }
 
-        .part-specific-mixins();
+    .header {
+        margin-top: 0.61rem;
     }
 
     .icon-container {

--- a/src/components/pages/shared-mixins.less
+++ b/src/components/pages/shared-mixins.less
@@ -12,7 +12,14 @@
 
             > .typo-normal,
             ul {
-                margin-bottom: 2.25rem;
+                margin-bottom: 1.55rem;
+            }
+        }
+
+        // The very final paragraph in a section to have no margin-bottom.
+        &:last-of-type {
+            .typo-normal:last-of-type {
+                margin-bottom: 0;
             }
         }
     }
@@ -21,12 +28,17 @@
     // have less distance to text above. Counteract with negative margin-top.
     .part__html-area + .part__product-card-mini {
         .card {
-            margin-top: -1.25rem;
+            margin-top: -0.9rem;
         }
     }
 
     .part__product-card-micro {
         margin-bottom: 2.25rem;
+    }
+
+    // Correct spacing for multiple mini cards.
+    .part__product-card-mini + .part__product-card-mini {
+        margin-top: 0;
     }
 
     // Microcards should have less distance to header if used, so

--- a/src/components/pages/shared-mixins.less
+++ b/src/components/pages/shared-mixins.less
@@ -2,16 +2,35 @@
 // To be removed when DS has updated design packages.
 
 .product-mixins() {
-    .part__html-area:not(:first-child) {
-        margin-top: 2.27rem;
-    }
-    .html-area .typo-normal {
-        margin-bottom: 2.25rem;
-        &:last-child {
-            margin-bottom: 0.75rem;
+    .part__html-area {
+        &:not(:first-child) {
+            margin-top: 0;
+        }
+
+        .html-area {
+            margin-top: 0;
+
+            > .typo-normal,
+            ul {
+                margin-bottom: 2.25rem;
+            }
         }
     }
 
+    // Cards that immediately follows a html-area should
+    // have less distance to text above. Counteract with negative margin-top.
+    .part__html-area + .part__product-card-mini {
+        .card {
+            margin-top: -1.25rem;
+        }
+    }
+
+    .part__product-card-micro {
+        margin-bottom: 2.25rem;
+    }
+
+    // Microcards should have less distance to header if used, so
+    // counteract with negative margin-top.
     .part__dynamic-header + .part__product-card-micro {
         margin-top: -0.5rem;
     }

--- a/src/components/parts/product-card-micro/ProductCardMicro.tsx
+++ b/src/components/parts/product-card-micro/ProductCardMicro.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../types/component-props/parts/product-card';
 
 export const ProductCardMicroPart = ({ config }: ProductCardMicroProps) => {
-    if (config?.card_list?.length === 0) {
+    if (config?.card_list?.length === 0 || !config?.card_list) {
         return (
             <div>
                 Velg minst én produktside eller livssituasjon for å aktivere


### PR DESCRIPTION
Inneholder unntak for kombinasjoner av parts hvor enkelte komboer skal ha mindre marginer etc. Samle-mixin for alle overrides frem til pilot-testen. Bør diskuteres for en bedre og mer robust løsning på sikt?