### PR TITLE
Fikser contact option manglende implementering

### DIFF
--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -3,6 +3,9 @@ import { Undertittel } from 'nav-frontend-typografi';
 import React from 'react';
 import { BEM, classNames } from 'utils/classnames';
 
+import { usePageConfig } from '../../../store/hooks/usePageConfig';
+import { translator } from 'translations';
+
 import {
     ChannelData,
     ContactOption,
@@ -10,16 +13,13 @@ import {
 } from '../../../types/component-props/parts/contact-option';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 
-import { usePageConfig } from '../../../store/hooks/usePageConfig';
-import { translator } from 'translations';
-
 import './ContactOptionPart.less';
 
 const bem = BEM('contactOption');
 
 export const ContactOptionPart = ({ config }: ContactOptionProps) => {
     const { language } = usePageConfig();
-    const getLabels = translator('contactPoint', language);
+    const getTranslations = translator('contactPoint', language);
 
     if (!config?.contactOptions?._selected) {
         return <div>Velg kanal fra listen til høyre.</div>;
@@ -28,18 +28,60 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
     const { contactOptions } = config;
     const selectedChannel = contactOptions._selected;
     const channelData = contactOptions[selectedChannel];
+    const translations = getTranslations(selectedChannel);
+
+    const openChatbot = (e: React.MouseEvent) => {
+        e.preventDefault();
+        const chatButton = document.getElementById('chatbot-frida-knapp');
+        chatButton?.click?.();
+    };
 
     const getTitle = (channel: ContactOption, data: ChannelData) => {
-        if (channel === ContactOption.CALL && data.phoneNumber) {
-            return data.phoneNumber;
+        const abroadPrefix = language !== 'no' ? '+47' : '';
+
+        if (!translations) {
+            return '';
         }
-        const labels = getLabels(channel);
-        return labels && labels.title;
+
+        if (channel !== ContactOption.CALL) {
+            // Only CALL section is allowed to change title.
+            return translations.title;
+        }
+
+        return `${translations.title} ${abroadPrefix} ${
+            data.phoneNumber || '55 55 33 33'
+        }`;
     };
 
     const getIngress = (channel: ContactOption, data: ChannelData) => {
-        const labels = getLabels(channel);
-        return data.ingress || (labels && labels.ingress);
+        return data.ingress || (translations && translations.ingress);
+    };
+
+    // In order to open chatbot, onClick is needed instead of href. Therefore
+    // return an object which is destructed into Lenkebase with the proper props (href | onClick)
+    const getUrlOrClickHandler = (
+        channel: ContactOption,
+        data: ChannelData
+    ) => {
+        if (channel === ContactOption.CALL) {
+            return {
+                href: `tel:+47${data?.phoneNumber || '55553333'}`,
+            };
+        }
+
+        if (channel === ContactOption.WRITE) {
+            return {
+                href: 'https://www.nav.no/person/kontakt-oss/nb/skriv-til-oss',
+            };
+        }
+
+        if (channel === ContactOption.CHAT) {
+            return {
+                onClick: openChatbot,
+            };
+        }
+
+        return { href: '/' };
     };
 
     return (
@@ -51,8 +93,9 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
                 )}
             />
             <LenkeBase
-                href="http://www.nav.no"
                 className={classNames(bem('link'))}
+                href="/"
+                {...getUrlOrClickHandler(selectedChannel, channelData)}
             >
                 <Undertittel tag="h3" className={classNames(bem('title'))}>
                     {getTitle(selectedChannel, channelData)}

--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -65,7 +65,9 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
     ) => {
         if (channel === ContactOption.CALL) {
             return {
-                href: `tel:+47${data?.phoneNumber || '55553333'}`,
+                href: `tel:+47${
+                    data?.phoneNumber?.replace(/ /g, '') || '55553333'
+                }`,
             };
         }
 

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -81,7 +81,7 @@ export const bundle = {
     },
     contactPoint: {
         chat: {
-            title: 'Chat med Frida',
+            title: 'Chat med oss',
             ingress:
                 'Du møter først en chatbot, men kan gå videre og chatte med en veileder uten å logge inn (hverdager 09.00–14.30).',
         },
@@ -91,7 +91,7 @@ export const bundle = {
                 'Skal du sende oss nye opplysninger i saken din? "Skriv til oss" er et sikkert alternativ til e-post.',
         },
         call: {
-            title: 'Ring oss på 55 55 33 33',
+            title: 'Ring oss på',
             ingress:
                 'Åpningstider: hverdager 09:00–15:00. Dersom åpningstidene er midlertidig endret, får du beskjed via automatisk svarer.',
         },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -82,7 +82,7 @@ export const bundle: Translations = {
                 'Need to send us updated information about your case? "Write to us" is a secure alternative to e-mail.',
         },
         call: {
-            title: 'Call us at (+47) 55 55 33 33',
+            title: 'Call us at',
             ingress:
                 'Opening hours: weekdays 09:00–15:00. If the opening hours are changed, you will be notified by voice message.',
         },


### PR DESCRIPTION
- Fikser lenker korrekt
- Telefon-seksjon begynner med tittelen "Ring oss på"... etterfulgt av angitt telefonnr eller standard nr 55 55 33 33.
- Tel:-attribute legger på +47 uansett og fjerner evt mellomrom.