### PR TITLE
legger til margin for filterbar

### DIFF
--- a/src/components/_common/filter-bar/FilterBar.less
+++ b/src/components/_common/filter-bar/FilterBar.less
@@ -3,7 +3,7 @@
         align-items: flex-start;
         display: flex;
         flex-direction: column;
-        margin-top: 1.5rem;
+        margin-top: 1.5rem 0;
     }
 
     &__header {


### PR DESCRIPTION
Feil bruk av html-area gjør at filterbar iblant ikke får avstand til tekst.