### PR TITLE
TopLeftMenu region + nav-meny styling tweaks

### DIFF
--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -6,7 +6,6 @@
     display: flex;
     justify-content: center;
     background-color: white;
-    padding-top: 1.5rem;
     padding-bottom: 1.5rem;
 
     .full-width-mixin();

--- a/src/components/_common/page-navigation-menu/PageNavigationLink.less
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.less
@@ -4,6 +4,12 @@
 .page-nav-link {
     @padding: 1rem;
     display: flex;
+    color: @navBla;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
 
     &--up {
         .page-nav-link__decor {

--- a/src/components/_common/page-navigation-menu/views/PageNavigationInContent.less
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationInContent.less
@@ -18,12 +18,6 @@
     .page-nav-link {
         padding: #round-rem(0.66rem) [] 0.5rem;
         margin: 0 -0.5rem;
-        color: @navBla;
-        text-decoration: none;
-
-        &:hover {
-            text-decoration: underline;
-        }
 
         &:focus {
             .panel-inset-focus-mixin();

--- a/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.less
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.less
@@ -16,10 +16,8 @@
 
     .page-nav-link {
         padding: 0.7rem 1rem;
-        color: @navBla;
 
         &:hover {
-            text-decoration: none;
             background-color: @navGra20;
 
             .page-nav-link__decor {

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -85,7 +85,8 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                     >
                         <LeftMenuSection
                             pageProps={pageProps}
-                            regionProps={regions.leftMenu}
+                            topRegionProps={regions.topLeftMenu}
+                            mainRegionProps={regions.leftMenu}
                             internalLinks={showInternalNav && anchorLinks}
                             menuHeader={leftMenuHeader}
                             sticky={leftMenuSticky}

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
@@ -18,15 +18,21 @@
     }
 }
 
-.region__leftMenu > * {
-    padding: 1rem;
+.region__leftMenu,
+.region__topLeftMenu {
     background-color: white;
 
-    &:first-child {
-        margin-top: 1rem;
-    }
+    & > * {
+        padding: 1rem;
 
-    &:not(:last-child) {
-        margin-bottom: 1rem;
+        &:not(:last-child) {
+            margin-bottom: 1rem;
+        }
+    }
+}
+
+.region__leftMenu {
+    & > :first-child {
+        margin-top: 1rem;
     }
 }

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.less
@@ -20,8 +20,6 @@
 
 .region__leftMenu,
 .region__topLeftMenu {
-    background-color: white;
-
     & > * {
         padding: 1rem;
 
@@ -32,7 +30,17 @@
 }
 
 .region__leftMenu {
+    & > * {
+        background-color: white;
+    }
+
     & > :first-child {
         margin-top: 1rem;
     }
+}
+
+// The top region should have a consistent background color behind all components
+// to make it blend in with the navigation-menu
+.region__topLeftMenu {
+    background-color: white;
 }

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
@@ -6,6 +6,7 @@ import { ContentProps } from '../../../../types/content-props/_content-common';
 import { PageNavigationMenu } from '../../../_common/page-navigation-menu/PageNavigationMenu';
 import { AnchorLink } from '../../../../types/component-props/parts/page-navigation-menu';
 import './LeftMenuSection.less';
+import { EditorHelp } from '../../../_common/editor-help/EditorHelp';
 
 const bem = BEM('left-menu');
 
@@ -13,7 +14,8 @@ type Props = {
     internalLinks: AnchorLink[];
     menuHeader: string;
     sticky?: boolean;
-    regionProps: RegionProps;
+    topRegionProps: RegionProps;
+    mainRegionProps: RegionProps;
     pageProps: ContentProps;
 };
 
@@ -21,7 +23,8 @@ export const LeftMenuSection = ({
     internalLinks,
     menuHeader,
     sticky,
-    regionProps,
+    topRegionProps,
+    mainRegionProps,
     pageProps,
 }: Props) => {
     return (
@@ -31,7 +34,13 @@ export const LeftMenuSection = ({
                 anchorLinks={internalLinks}
                 viewStyle={'sidebar'}
             />
-            <Region pageProps={pageProps} regionProps={regionProps} />
+            <Region pageProps={pageProps} regionProps={topRegionProps} />
+            <EditorHelp
+                text={
+                    'Komponenter ovenfor legges inn rett under innholdsmenyen'
+                }
+            />
+            <Region pageProps={pageProps} regionProps={mainRegionProps} />
         </div>
     );
 };

--- a/src/types/component-props/pages/page-with-side-menus.ts
+++ b/src/types/component-props/pages/page-with-side-menus.ts
@@ -2,7 +2,12 @@ import { LayoutCommonProps, LayoutType } from '../layouts';
 import { ComponentProps, ComponentType } from '../_component-common';
 import { AnchorLink } from '../parts/page-navigation-menu';
 
-type Regions = 'leftMenu' | 'pageContent' | 'topPageContent' | 'rightMenu';
+type Regions =
+    | 'topLeftMenu'
+    | 'leftMenu'
+    | 'pageContent'
+    | 'topPageContent'
+    | 'rightMenu';
 
 export interface PageWithSideMenusProps extends LayoutCommonProps {
     type: ComponentType.Page;


### PR DESCRIPTION
- Støtte for topLeftMenu region, for komponenter som skal legges inn under navigasjonsmeny uten margin mellom
- Bytter til hover underline for sidebar-meny (likt in-content meny)
- Fjerner padding-top fra themed-page-header, for mindre avstand til dekoratør-komponenter