### PR TITLE
Fikser styling på dekorativt element i sidebar navigasjonsmeny

### DIFF
--- a/src/components/_common/page-navigation-menu/PageNavigationLink.less
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.less
@@ -11,49 +11,6 @@
         text-decoration: underline;
     }
 
-    &--up {
-        .page-nav-link__decor {
-            transform-origin: top;
-        }
-
-        &.page-nav-link__current {
-            .page-nav-link__decor {
-                transform-origin: bottom;
-            }
-        }
-    }
-
-    &--down {
-        .page-nav-link__decor {
-            transform-origin: bottom;
-        }
-
-        &.page-nav-link__current {
-            .page-nav-link__decor {
-                transform-origin: top;
-            }
-        }
-    }
-
-    &__current {
-        .page-nav-link__decor {
-            transform: scaleY(1);
-        }
-    }
-
-    &__decor {
-        @width: 0.5rem;
-        min-width: @width;
-        margin: -@padding calc(@padding - @width) -@padding -@padding;
-        background-color: @navBla;
-
-        transform: scaleY(0);
-
-        transition-property: transform;
-        transition-duration: 0.12s;
-        transition-timing-function: linear;
-    }
-
     &__text {
         .typo-element;
     }

--- a/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.less
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.less
@@ -15,7 +15,9 @@
     }
 
     .page-nav-link {
-        padding: 0.7rem 1rem;
+        @verticalPadding: 0.7rem;
+        @horizontalPadding: 1rem;
+        padding: @verticalPadding @horizontalPadding;
 
         &:hover {
             background-color: @navGra20;
@@ -30,9 +32,50 @@
             box-shadow: 0 0 0 3px @fokusFarge inset;
         }
 
+        &--up {
+            .page-nav-link__decor {
+                transform-origin: top;
+            }
+
+            &.page-nav-link__current {
+                .page-nav-link__decor {
+                    transform-origin: bottom;
+                }
+            }
+        }
+
+        &--down {
+            .page-nav-link__decor {
+                transform-origin: bottom;
+            }
+
+            &.page-nav-link__current {
+                .page-nav-link__decor {
+                    transform-origin: top;
+                }
+            }
+        }
+
         &__current {
             color: black;
             text-decoration: none;
+
+            .page-nav-link__decor {
+                transform: scaleY(1);
+            }
+        }
+
+        &__decor {
+            @width: 0.5rem;
+            min-width: @width;
+            margin: -@verticalPadding calc(@horizontalPadding - @width) -@verticalPadding -@horizontalPadding;
+            background-color: @navBla;
+
+            transform: scaleY(0);
+
+            transition-property: transform;
+            transition-duration: 0.12s;
+            transition-timing-function: linear;
         }
     }
 }


### PR DESCRIPTION
Størrelsen på "pynt" for current-element ble litt feil etter tidligere padding-endring, fikser dette. Flytter også CSS'en som kun brukes for sidebar-meny inn i sidebar less-fila.

Prod nå: 
![navdecorbad](https://user-images.githubusercontent.com/18137669/122555498-a7fd2d80-d03a-11eb-8137-c87acbb480dc.png)

Skal være: 
![navdecorgood](https://user-images.githubusercontent.com/18137669/122555499-a7fd2d80-d03a-11eb-93be-1ca09ca9c87c.png)
