### PR TITLE
Setter separate breakpoints for situation-page-flexcols

### DIFF
--- a/src/components/layouts/flex-cols/FlexColsLayout.less
+++ b/src/components/layouts/flex-cols/FlexColsLayout.less
@@ -1,4 +1,5 @@
 @import (reference) '../../../global';
+@import (reference) '../../pages/situation-page/SituationPage';
 
 .flex-items(@numCols, @margin-sides: 1.33rem) {
     & > * {
@@ -31,47 +32,6 @@
     &__dynamic-flex-cols {
         display: flex;
         justify-content: center;
-    }
-
-    &__situation-flex-cols {
-        .full-width-mixin();
-        background-color: @navGronnLighten80;
-        padding-top: 4rem;
-        padding-bottom: 4rem;
-
-        .header {
-            margin-bottom: 3rem;
-        }
-
-        .region__flexcols {
-            &--2-cols {
-                .flex-items(2);
-            }
-
-            &--3-cols {
-                @media @mq-screen-desktop {
-                    .flex-items(3);
-                }
-            }
-
-            @media @mq-screen-mobile {
-                .flex-items(1);
-            }
-        }
-
-        &:last-of-type {
-            padding-bottom: 0;
-        }
-    }
-}
-
-.region {
-    &__flexcols {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        align-items: stretch;
-        width: 100%;
 
         &--1-cols {
             .flex-items(1);
@@ -108,6 +68,63 @@
                 .flex-items(2);
             }
         }
+    }
+
+    &__situation-flex-cols {
+        @singleColMaxWidth: (
+                @situationPageSectionMaxWidth + 2 * @padding-sides-mobile
+            ) * @font-size-factor;
+        @doubleColMaxWidth: (
+                @situationPageContentMaxWidth + 2 * @padding-sides-tablet
+            ) * @font-size-factor;
+
+        @mqSingleCol: ~'only screen and (max-width: @{singleColMaxWidth})';
+        @mqDoubleCol: ~'only screen and (max-width: @{doubleColMaxWidth})';
+
+        .full-width-mixin();
+        background-color: @navGronnLighten80;
+        padding-top: 4rem;
+        padding-bottom: 4rem;
+
+        .header {
+            margin-bottom: 3rem;
+        }
+
+        .region__flexcols {
+            &--1-cols {
+                .flex-items(1);
+            }
+
+            &--2-cols {
+                .flex-items(2);
+            }
+
+            &--3-cols {
+                .flex-items(3);
+
+                @media @mqDoubleCol {
+                    .flex-items(2);
+                }
+            }
+
+            @media @mqSingleCol {
+                .flex-items(1);
+            }
+        }
+
+        &:last-of-type {
+            padding-bottom: 0;
+        }
+    }
+}
+
+.region {
+    &__flexcols {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: stretch;
+        width: 100%;
 
         // Fixes for content studio drag and drop placeholders
         .xp-page-editor-region-placeholder:last-child {

--- a/src/components/pages/situation-page/SituationPage.less
+++ b/src/components/pages/situation-page/SituationPage.less
@@ -2,10 +2,10 @@
 @import (reference) '../shared-mixins.less';
 
 @situationPageColor: @navOransjeLighten60;
+@situationPageContentMaxWidth: #px-to-rem(900) [];
+@situationPageSectionMaxWidth: @situationPageContentMaxWidth * 2/3;
 
 .situation-page {
-    @contentMaxWidth: #px-to-rem(900) [];
-
     display: flex;
     flex-direction: column;
 
@@ -27,12 +27,12 @@
         }
 
         & > :not(.layout__situation-flex-cols) {
-            max-width: @contentMaxWidth * 2/3;
+            max-width: @situationPageSectionMaxWidth;
         }
 
         // Prevent margins between adjacent situation-flex-cols layouts
         .layout__situation-flex-cols + .layout__situation-flex-cols {
-            // margin-top: -@margin;
+            margin-top: -@margin;
         }
     }
 
@@ -42,7 +42,7 @@
         justify-content: flex-start;
         align-self: center;
         width: 100%;
-        max-width: @contentMaxWidth;
+        max-width: @situationPageContentMaxWidth;
 
         & > * {
             width: 100%;


### PR DESCRIPTION
- Kollapser fra 3 til 2 kolonner nå skjermbredde er smalere enn max-bredde på situation-page-flexcols ("produktkorthylle"), 900px + padding
- Kollapser til 1 kolonner når skjermbredde er smalere enn max-bredde på section-with-header ("innholdsseksjon"), 600px + padding