### PR TITLE
Midlertidig fiks for redirects

### DIFF
--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -66,7 +66,7 @@ const redirectProps = (destination: string, isTemporary: boolean) => ({
         // Decode then (re)encode to ensure the destination is not double-encoded
         destination: encodeURI(decodeURI(destination).trim()),
         // Negate IsTemporary (if not valid/null, permanent will be true)
-        permanent: !isTemporary,
+        permanent: false,
     },
 });
 


### PR DESCRIPTION
Når en permanent redirect erstattes av kort-url så kan brukere havne i en state der det enten blir en redirect loop (dersom redirect'en peker til samme innhold som kort-url), eller redirect'en vil peke til feil innhold. Dette kan skje ettersom permanente redirects caches i browser. Ruller tilbake bruk av permanente redirects foreløpig for å hindre slike problemer, som kan være spesielt aktuelle nå som vi vil erstatte en del av redirectene med kort-url'er for nye situasjons- og produktsider.