### PR TITLE
Fikser forhandsvisning av ikoner i CS

### DIFF
--- a/src/components/_common/card/LargeCard.tsx
+++ b/src/components/_common/card/LargeCard.tsx
@@ -10,6 +10,7 @@ import { AnimatedIconsProps } from '../../../types/content-props/animated-icons'
 
 import { useCardState } from './useCard';
 import { Interaction } from 'types/interaction';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 
 export type StortKortProps = {
     link: LinkProps;
@@ -30,6 +31,7 @@ export const LargeCard = (props: StortKortProps) => {
         (type === CardType.Product || type === CardType.Situation);
 
     const { isHovering, isPressed, cardInteractionHandler } = useCardState();
+    const { pageConfig } = usePageConfig();
 
     return (
         <Card
@@ -48,6 +50,9 @@ export const LargeCard = (props: StortKortProps) => {
                         className={bem('illustration')}
                         isHovering={isHovering}
                         isPressed={isPressed}
+                        preferStaticIllustration={
+                            pageConfig.editorView === 'edit'
+                        }
                     />
                 )}
                 <Undertittel tag="h3" className={bem('title')}>

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -10,6 +10,7 @@ import { IllustrationPlacements } from 'types/illustrationPlacements';
 import { AnimatedIconsProps } from '../../../types/content-props/animated-icons';
 import { useCardState } from './useCard';
 import { Interaction } from 'types/interaction';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 
 export type MiniKortProps = {
     link: LinkProps;
@@ -24,6 +25,7 @@ export const MiniCard = (props: MiniKortProps) => {
     const { text } = link;
 
     const { isHovering, isPressed, cardInteractionHandler } = useCardState();
+    const { pageConfig } = usePageConfig();
 
     return (
         <Card
@@ -41,6 +43,7 @@ export const MiniCard = (props: MiniKortProps) => {
                     className="card__illustration"
                     isHovering={isHovering}
                     isPressed={isPressed}
+                    preferStaticIllustration={pageConfig.editorView === 'edit'}
                 />
                 <Normaltekst className={bem('title')}>{text}</Normaltekst>
             </>

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -24,11 +24,33 @@ export const Illustration = ({
         return null;
     }
 
-    const isAnimated =
-        illustration.data?.lottieActive?.mediaText &&
-        illustration.data?.lottieHover?.mediaText;
+    const hasStaticIllustration = () => {
+        const { icons } = illustration.data;
+        if (!icons) {
+            return false;
+        }
 
-    if (isAnimated && !preferStaticIllustration) {
+        const icon1 = icons[0] && icons[0].icon;
+        const icon2 = icons[1] && icons[1].icon;
+
+        return !!(icon1 && icon2);
+    };
+
+    const isAnimated = !!(
+        illustration.data?.lottieActive?.mediaText &&
+        illustration.data?.lottieHover?.mediaText
+    );
+
+    if (hasStaticIllustration() && (!isAnimated || preferStaticIllustration)) {
+        return (
+            <IllustrationStatic
+                illustration={illustration}
+                className={className}
+            />
+        );
+    }
+
+    if (isAnimated) {
         return (
             <IllustrationAnimated
                 illustration={illustration}
@@ -39,7 +61,5 @@ export const Illustration = ({
         );
     }
 
-    return (
-        <IllustrationStatic illustration={illustration} className={className} />
-    );
+    return null;
 };

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -10,6 +10,7 @@ interface IllustrationProps {
     className: string;
     isHovering?: boolean;
     isPressed?: boolean;
+    preferStaticIllustration?: boolean;
 }
 
 export const Illustration = ({
@@ -17,6 +18,7 @@ export const Illustration = ({
     illustration,
     isHovering,
     isPressed,
+    preferStaticIllustration,
 }: IllustrationProps) => {
     if (!illustration) {
         return null;
@@ -26,7 +28,7 @@ export const Illustration = ({
         illustration.data?.lottieActive?.mediaText &&
         illustration.data?.lottieHover?.mediaText;
 
-    if (isAnimated) {
+    if (isAnimated && !preferStaticIllustration) {
         return (
             <IllustrationAnimated
                 illustration={illustration}

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -10,6 +10,8 @@ import {
 } from '../../types/content-props/_content-common';
 import globalState from '../../globalState';
 
+import { setPageConfigAction } from '../../store/slices/pageConfig';
+
 const dummyPageProps: ContentProps = {
     __typename: ContentType.Site,
     _id: '',
@@ -36,6 +38,14 @@ const postHandler = async (req, res) => {
     globalState.isDraft = true;
 
     const props = req.body.props as PartComponentProps;
+
+    store.dispatch(
+        setPageConfigAction({
+            pageId: dummyPageProps._id,
+            language: dummyPageProps.language,
+            editorView: 'edit',
+        })
+    );
 
     const html = ReactDOMServer.renderToStaticMarkup(
         <Provider store={store}>

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -3,7 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import { PartComponentProps } from '../../types/component-props/_component-common';
 import { ComponentMapper } from '../../components/ComponentMapper';
 import { Provider } from 'react-redux';
-import { store } from '../../store/store';
+import { mockStore } from '../../store/store';
 import {
     ContentProps,
     ContentType,
@@ -39,7 +39,7 @@ const postHandler = async (req, res) => {
 
     const props = req.body.props as PartComponentProps;
 
-    store.dispatch(
+    mockStore.dispatch(
         setPageConfigAction({
             pageId: dummyPageProps._id,
             language: dummyPageProps.language,
@@ -48,7 +48,7 @@ const postHandler = async (req, res) => {
     );
 
     const html = ReactDOMServer.renderToStaticMarkup(
-        <Provider store={store}>
+        <Provider store={mockStore}>
             <ComponentMapper
                 componentProps={props}
                 pageProps={dummyPageProps}

--- a/src/store/hooks/usePageConfig.ts
+++ b/src/store/hooks/usePageConfig.ts
@@ -17,13 +17,13 @@ type PageConfig = {
     editorView: ContentProps['editorView'];
 };
 
-type UseFilterState = {
+type UsePageConfig = {
     pageConfig: PageConfig;
     setPageConfig: (payload: any) => void;
     language: Language;
 };
 
-export const usePageConfig = (): UseFilterState => {
+export const usePageConfig = (): UsePageConfig => {
     const dispatch = useAppDispatch();
 
     const pageId = useAppSelector<string>((state) => currentPageId(state));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -14,6 +14,18 @@ export const store = configureStore({
     },
 });
 
+// MockStore is used by component-preview etc in order to be able to
+// provide a store to the underlying components to get them to work on a basic level,
+// without affecting the entire pages store.
+export const mockStore = configureStore({
+    reducer: {
+        contentFilters,
+        pageConfig,
+        pathMap,
+        gvEditorState,
+    },
+});
+
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 


### PR DESCRIPTION
- Illustration støtter propertyen preferStaticIllustration som gjør at den statiske - ikke den animerte - illustrasjonen faktisk er synlig i CS. Lottie files rendres i klienten og denne rendringen kjører ikke i CS.