### PR TITLE
Forbedret invert ved touchstart

### DIFF
--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -4,24 +4,26 @@
     outline: 0;
     transition: all 0.3s;
 
-    &:hover:not(:active) {
-        box-shadow: 0 0 0 2px @navBla;
-        background-color: #ffffff;
-
-        .card__title,
-        .card__description,
-        .card__category {
-            text-decoration: none;
-            color: @navMorkGra;
-        }
-
-        &.card__product,
-        &.card__tool,
-        &.card__situation {
+    @media (hover: hover) {
+        &:hover:not(:active) {
+            box-shadow: 0 0 0 2px @navBla;
             background-color: #ffffff;
 
-            .card__title {
-                color: @navBla;
+            .card__title,
+            .card__description,
+            .card__category {
+                text-decoration: none;
+                color: @navMorkGra;
+            }
+
+            &.card__product,
+            &.card__tool,
+            &.card__situation {
+                background-color: #ffffff;
+
+                .card__title {
+                    color: @navBla;
+                }
             }
         }
     }

--- a/src/components/_common/card/Card.tsx
+++ b/src/components/_common/card/Card.tsx
@@ -21,7 +21,7 @@ export const Card = (props: CardProps) => {
     const { children, link, type, size, interactionHandler } = props;
     const { text, url } = link;
 
-    const handleMouseEvent = (e: React.MouseEvent): void => {
+    const handleMouseEvent = (e: React.MouseEvent | React.TouchEvent): void => {
         const eventType = e.type.toString() as keyof typeof Interaction;
         const type: Interaction = Interaction[eventType];
 
@@ -40,6 +40,10 @@ export const Card = (props: CardProps) => {
             onMouseLeave={handleMouseEvent}
             onMouseDown={handleMouseEvent}
             onMouseUp={handleMouseEvent}
+            onTouchStart={handleMouseEvent}
+            onTouchEnd={handleMouseEvent}
+            onTouchCancel={handleMouseEvent}
+            onTouchMove={handleMouseEvent}
         >
             <div className={classNames(bem('wrapper'))}>{children}</div>
         </LenkeBase>

--- a/src/components/_common/card/Card.tsx
+++ b/src/components/_common/card/Card.tsx
@@ -21,7 +21,7 @@ export const Card = (props: CardProps) => {
     const { children, link, type, size, interactionHandler } = props;
     const { text, url } = link;
 
-    const handleMouseEvent = (e: React.MouseEvent | React.TouchEvent): void => {
+    const handleUserEvent = (e: React.MouseEvent | React.TouchEvent): void => {
         const eventType = e.type.toString() as keyof typeof Interaction;
         const type: Interaction = Interaction[eventType];
 
@@ -36,14 +36,14 @@ export const Card = (props: CardProps) => {
             title={text}
             className={classNames(bem(), bem(type), bem(size))}
             analyticsLabel={link.text}
-            onMouseEnter={handleMouseEvent}
-            onMouseLeave={handleMouseEvent}
-            onMouseDown={handleMouseEvent}
-            onMouseUp={handleMouseEvent}
-            onTouchStart={handleMouseEvent}
-            onTouchEnd={handleMouseEvent}
-            onTouchCancel={handleMouseEvent}
-            onTouchMove={handleMouseEvent}
+            onMouseEnter={handleUserEvent}
+            onMouseLeave={handleUserEvent}
+            onMouseDown={handleUserEvent}
+            onMouseUp={handleUserEvent}
+            onTouchStart={handleUserEvent}
+            onTouchEnd={handleUserEvent}
+            onTouchCancel={handleUserEvent}
+            onTouchMove={handleUserEvent}
         >
             <div className={classNames(bem('wrapper'))}>{children}</div>
         </LenkeBase>

--- a/src/components/_common/card/LargeCard.less
+++ b/src/components/_common/card/LargeCard.less
@@ -62,7 +62,7 @@
         /* Card type specific styling */
         &.card__product,
         &.card__situation {
-            &:not(:focus-visible) {
+            &:not(:focus-visible)&:not(:hover) {
                 box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.14),
                     0px 2px 1px rgba(38, 38, 38, 0.12),
                     0px 1px 3px rgba(38, 38, 38, 0.2);

--- a/src/components/_common/card/useCard.tsx
+++ b/src/components/_common/card/useCard.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useState } from 'react';
 import { Interaction } from 'types/interaction';
 
@@ -25,6 +26,14 @@ export const useCardState = (): UseCardState => {
 
         if (type === Interaction.mousedown || type === Interaction.mouseup) {
             setIsPressed(type === Interaction.mousedown);
+        }
+
+        if (type === Interaction.touchstart) {
+            setIsPressed(true);
+        }
+
+        if (type === Interaction.touchend || type === Interaction.touchcancel) {
+            setIsPressed(false);
         }
     };
 

--- a/src/types/interaction.ts
+++ b/src/types/interaction.ts
@@ -3,4 +3,8 @@ export enum Interaction {
     mouseleave = 'mouseleave',
     mousedown = 'mousedown',
     mouseup = 'mouseup',
+    touchend = 'touchend',
+    touchstart = 'touchstart',
+    touchmove = 'touchmove',
+    touchcancel = 'touchcancel',
 }


### PR DESCRIPTION
På mobil switcher ikke animasjonene til invert. I tillegg skaper :hover problemer med touchstart hvor rammen blir stående.

Denne PR'en fikser disse feilene, men det er også en plan om å se på hvordan kortene skal oppføre seg på touchskjermer (animasjon ved scroll-in feks) som design skal kikke på i første omgang.