### PR TITLE
Fjerner ramme under expandable ved bruk i LinkList

### DIFF
--- a/src/components/parts/link-list/LinkList.less
+++ b/src/components/parts/link-list/LinkList.less
@@ -1,2 +1,10 @@
-.link-list {
+// When used in the left menu, LinkList with Expandable capabilities
+// should not add an underline after the Expandable components, as
+// there's no other content below that needs separation.
+.left-menu {
+    .link-list {
+        .expandable {
+            box-shadow: none;
+        }
+    }
 }

--- a/src/components/parts/link-list/LinkList.tsx
+++ b/src/components/parts/link-list/LinkList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BEM, classNames } from 'utils/classnames';
 import { DynamicLinkListProps } from '../../../types/component-props/parts/link-list';
 import { Lenkeliste } from '../../_common/lenkeliste/Lenkeliste';
 import { ContentList } from '../../_common/content-list/ContentList';
@@ -6,9 +7,13 @@ import { getSelectableLinkProps } from '../../../utils/links-from-content';
 import { Expandable } from '../../_common/expandable/Expandable';
 import './LinkList.less';
 
+const bem = BEM('link-list');
+
 const getListComponent = (config: DynamicLinkListProps['config']) => {
     const { title, list, chevron } = config;
     const { _selected, contentList, linkList } = list;
+
+    console.log(config);
 
     if (_selected === 'contentList') {
         return (
@@ -38,6 +43,8 @@ export const LinkList = ({ config }: DynamicLinkListProps) => {
     const ListComponent = getListComponent(config);
 
     return ListComponent ? (
-        <Expandable {...config}>{ListComponent}</Expandable>
+        <div className={classNames(bem())}>
+            <Expandable {...config}>{ListComponent}</Expandable>
+        </div>
     ) : null;
 };

--- a/src/components/parts/link-list/LinkList.tsx
+++ b/src/components/parts/link-list/LinkList.tsx
@@ -13,8 +13,6 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
     const { title, list, chevron } = config;
     const { _selected, contentList, linkList } = list;
 
-    console.log(config);
-
     if (_selected === 'contentList') {
         return (
             <ContentList


### PR DESCRIPTION
Foreslår å droppe ramme nedenfor Expandable når den brukes i sidemeny som en LinkList siden det da ikke vil være annet innhold nedenfor som det bør skilles fra.

![expandable-linje](https://user-images.githubusercontent.com/1443997/125418015-68b4fa0a-a019-4418-96ae-1b38d5b57e2f.png)