### PR TITLE
Fjerner "px" i argument ved bruk av px-to-rem.

### DIFF
--- a/src/components/_common/card/LargeCard.less
+++ b/src/components/_common/card/LargeCard.less
@@ -24,8 +24,8 @@
         }
 
         .card__illustration {
-            height: #px-to-rem(96px) [];
-            width: #px-to-rem(96px) [];
+            height: #px-to-rem(96) [];
+            width: #px-to-rem(96) [];
             align-self: center;
             margin-top: 0;
             margin-bottom: 2.3rem;
@@ -40,8 +40,8 @@
 
         .illustration__lottie-container {
             display: block;
-            width: #px-to-rem(96px) [];
-            height: #px-to-rem(96px) [];
+            width: #px-to-rem(96) [];
+            height: #px-to-rem(96) [];
         }
 
         .card__description {
@@ -62,7 +62,7 @@
         /* Card type specific styling */
         &.card__product,
         &.card__situation {
-            min-height: #px-to-rem(400px) [];
+            min-height: #px-to-rem(400) [];
 
             &:not(:focus-visible)&:not(:hover) {
                 box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.14),

--- a/src/components/_common/card/MiniCard.less
+++ b/src/components/_common/card/MiniCard.less
@@ -5,7 +5,7 @@
         border-radius: 4px;
         display: inline-flex; // Ensures margins don't collapse
         align-items: center;
-        padding: #px-to-rem(12px) [];
+        padding: #px-to-rem(12) [];
         text-decoration: none;
         width: 100%;
         box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.14),
@@ -33,8 +33,8 @@
         }
 
         .card__illustration {
-            width: #px-to-rem(64px) [];
-            height: #px-to-rem(64px) [];
+            width: #px-to-rem(64) [];
+            height: #px-to-rem(64) [];
             margin-right: 1rem;
         }
 

--- a/src/components/_common/filter-bar/FilterExplanation.less
+++ b/src/components/_common/filter-bar/FilterExplanation.less
@@ -8,7 +8,7 @@
     transition: all 0.8s linear;
     border-radius: 3px;
     width: calc(100% + 0.5rem);
-    font-size: #px-to-rem(14px) [];
+    font-size: #px-to-rem(14) [];
     border: 1px solid transparent;
 
     &--highlight {

--- a/src/components/_common/headers/Header.less
+++ b/src/components/_common/headers/Header.less
@@ -20,7 +20,7 @@
 
     &__copy-link {
         text-decoration: none;
-        font-size: #px-to-rem(14px) [];
+        font-size: #px-to-rem(14) [];
 
         &:hover {
             font-weight: 600;

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -19,8 +19,8 @@
     }
 
     &__illustration {
-        width: #px-to-rem(80px) [];
-        height: #px-to-rem(80px) [];
+        width: #px-to-rem(80) [];
+        height: #px-to-rem(80) [];
         margin-right: 2rem;
         pointer-events: none;
     }


### PR DESCRIPTION
px-to-rem-utregning blir feil hvis man sender inn argument "14px" feks. Skal kun sende inn number, uten enhet.