### PR TITLE
Fjerner overflødig tittel når ikke ekspanderbar filtermeny

### DIFF
--- a/src/components/parts/filters-menu/FiltersMenu.tsx
+++ b/src/components/parts/filters-menu/FiltersMenu.tsx
@@ -80,11 +80,6 @@ export const FiltersMenu = ({ config }: FilterMenuProps) => {
                 {...config}
                 expandableTitle={expandableTitle || defaultExpandableTitle}
             >
-                {!expandable && (
-                    <Title level={3} size="l" className={bem('title')}>
-                        {title || defaultExpandableTitle}
-                    </Title>
-                )}
                 {categories.map((category, categoryIndex) => {
                     return (
                         <CheckboxGruppe


### PR DESCRIPTION
Dersom filtermenyen ikke er ekspanderbar vises tittel 2 ganger. Utsikker på hvorfor dette ble introdusert, men tror det er en kombinasjon av en feil og ønske om fleksibilitet på titler. Foreslår å fjerne.

![filtermenu](https://user-images.githubusercontent.com/1443997/125577197-dfdbfa51-50d0-43fe-876b-6eb52a24bd64.png)
