### PR TITLE
Fjerner utdatert kode for håndtering av root font-size

### DIFF
--- a/src/components/layouts/flex-cols/FlexColsLayout.less
+++ b/src/components/layouts/flex-cols/FlexColsLayout.less
@@ -70,11 +70,11 @@
 
 .layout__situation-flex-cols {
     @singleColMaxWidth: (
-            @situationPageSectionMaxWidth + 2 * @padding-sides-mobile
-        ) * @font-size-factor;
+        @situationPageSectionMaxWidth + 2 * @padding-sides-mobile
+    );
     @doubleColMaxWidth: (
-            @situationPageContentMaxWidth + 2 * @padding-sides-tablet
-        ) * @font-size-factor;
+        @situationPageContentMaxWidth + 2 * @padding-sides-tablet
+    );
 
     @mqSingleCol: ~'only screen and (max-width: @{singleColMaxWidth})';
     @mqDoubleCol: ~'only screen and (max-width: @{doubleColMaxWidth})';

--- a/src/global.less
+++ b/src/global.less
@@ -2,33 +2,21 @@
 @import '~nav-frontend-core/less/core';
 @import '~@navikt/ds-css/dist/index.css';
 
-@font-size-factor: 1;
-@pixel-size-rem: 1 / (16 * @font-size-factor);
-@regular-font-size: unit(@font-size-factor * 1.125, rem);
+@pixel-size-rem: 1 / 16;
+@regular-font-size: 1.125rem;
 
 // Screen size breakpoints
-//
-// Relative units does not take CSS font-size into account when used in media queries,
-// but they do when used as CSS attribute values. We use separate variable sets to ensure
-// width and breakpoints scale consistently with browser font-size without being affected
-// by CSS font-size.
-@_MQ_mobileMaxWidth: 48em; // 768px
-@_MQ_tabletMinWidth: @_MQ_mobileMaxWidth;
-@_MQ_tabletMaxWidth: 64em; // 1024px
-@_MQ_desktopMinWidth: @_MQ_tabletMaxWidth;
-@_MQ_desktopMaxWidth: 90em; // 1440px
-
-@mobileMaxWidth: calc(@_MQ_mobileMaxWidth / @font-size-factor);
+@mobileMaxWidth: 48rem; // 768px
 @tabletMinWidth: @mobileMaxWidth;
-@tabletMaxWidth: calc(@_MQ_tabletMaxWidth / @font-size-factor);
+@tabletMaxWidth: 64rem; // 1024px
 @desktopMinWidth: @tabletMaxWidth;
-@desktopMaxWidth: calc(@_MQ_desktopMaxWidth / @font-size-factor);
+@desktopMaxWidth: 90rem; // 1440px
 
-@mq-screen-mobile: ~'only screen and (max-width: @{_MQ_mobileMaxWidth})';
-@mq-screen-tablet: ~'only screen and (min-width: @{_MQ_tabletMinWidth}) and (max-width: @{_MQ_tabletMaxWidth})';
-@mq-screen-tablet-and-desktop: ~'only screen and (min-width: @{_MQ_tabletMinWidth}) ';
-@mq-screen-desktop: ~'only screen and (min-width: @{_MQ_desktopMinWidth}) ';
-@mq-screen-desktop-large: ~'only screen and (min-width: @{_MQ_desktopMaxWidth}) ';
+@mq-screen-mobile: ~'only screen and (max-width: @{mobileMaxWidth})';
+@mq-screen-tablet: ~'only screen and (min-width: @{tabletMinWidth}) and (max-width: @{tabletMaxWidth})';
+@mq-screen-tablet-and-desktop: ~'only screen and (min-width: @{tabletMinWidth}) ';
+@mq-screen-desktop: ~'only screen and (min-width: @{desktopMinWidth}) ';
+@mq-screen-desktop-large: ~'only screen and (min-width: @{desktopMaxWidth}) ';
 
 @padding-sides-desktop: 3rem;
 @padding-sides-tablet: 1rem;
@@ -39,8 +27,6 @@
 @sectionPaddingMobile: 1rem;
 
 html {
-    font-size: @font-size-factor * 100%;
-
     // override ds-css scroll behaviour
     animation: none;
     scroll-behavior: auto;


### PR DESCRIPTION
Fjerner kode som ikke lengre er nødvendig etter at vi gikk tilbake til 100% root font-size + fikser screen-width breakpoints