### PR TITLE
Fikser typeerror på root av kunnskap og statistikk

### DIFF
--- a/src/pages/no/nav-og-samfunn/kunnskap/[[...kunnskap]].tsx
+++ b/src/pages/no/nav-og-samfunn/kunnskap/[[...kunnskap]].tsx
@@ -4,8 +4,12 @@ import PageBase, { fetchPageProps } from '../../../../components/PageBase';
 const prefixSegments = ['no', 'nav-og-samfunn', 'kunnskap'];
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+    const segmentParams = context.params?.kunnskap || [];
+    const segmentsArray =
+        typeof segmentParams === 'string' ? [segmentParams] : segmentParams;
+
     return await fetchPageProps(
-        [...prefixSegments, ...(context.params?.kunnskap as string[])],
+        [...prefixSegments, ...segmentsArray],
         false,
         process.env.SERVICE_SECRET
     );

--- a/src/pages/no/nav-og-samfunn/statistikk/[[...statistikk]].tsx
+++ b/src/pages/no/nav-og-samfunn/statistikk/[[...statistikk]].tsx
@@ -4,8 +4,12 @@ import PageBase, { fetchPageProps } from '../../../../components/PageBase';
 const prefixSegments = ['no', 'nav-og-samfunn', 'statistikk'];
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+    const segmentParams = context.params?.statistikk || [];
+    const segmentsArray =
+        typeof segmentParams === 'string' ? [segmentParams] : segmentParams;
+
     return await fetchPageProps(
-        [...prefixSegments, ...(context.params?.statistikk as string[])],
+        [...prefixSegments, ...segmentsArray],
         false,
         process.env.SERVICE_SECRET
     );


### PR DESCRIPTION
Har liten praktisk konsekvens ettersom begge er mapper uten eget innhold som skal gi 404, men hindrer log-støy og uønsket 500-feil