### PR TITLE
Error 400 content

### DIFF
--- a/src/components/_common/lenke/LenkeBase.tsx
+++ b/src/components/_common/lenke/LenkeBase.tsx
@@ -25,7 +25,7 @@ export const LenkeBase = ({
     component,
     linkGroup,
     analyticsLabel,
-    prefetch = true,
+    prefetch,
     children,
     ...rest
 }: Props) => {

--- a/src/components/pages/error-page/ErrorPage.tsx
+++ b/src/components/pages/error-page/ErrorPage.tsx
@@ -7,6 +7,7 @@ import { ErrorContentDefault } from './errorcode-content/ErrorContentDefault';
 import { ErrorContent408 } from './errorcode-content/ErrorContent408';
 import { BEM } from '../../../utils/classnames';
 import Head from 'next/head';
+import { ErrorContent400 } from './errorcode-content/ErrorContent400';
 import './ErrorPage.less';
 
 const bem = BEM('error-page');
@@ -14,6 +15,7 @@ const bem = BEM('error-page');
 const errorContentByCode: {
     [key: number]: React.FunctionComponent<ErrorProps>;
 } = {
+    400: ErrorContent400,
     404: ErrorContent404,
     408: ErrorContent408,
     1337: ErrorContent1337,

--- a/src/components/pages/error-page/errorcode-content/ErrorContent400.tsx
+++ b/src/components/pages/error-page/errorcode-content/ErrorContent400.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { BodyLong } from '@navikt/ds-react';
+import { ErrorProps } from '../../../../types/content-props/error-props';
+import { ErrorFeedbackLink } from './feedback-link/ErrorFeedbackLink';
+import { LenkeInline } from '../../../_common/lenke/LenkeInline';
+import Config from '../../../../config';
+import { appOrigin } from '../../../../utils/urls';
+
+export const paramDecodeErrorMsgExternal = 'Ugyldig adresseformat';
+
+export const ErrorContent400 = (props: ErrorProps) => {
+    if (props.data.errorMessage === paramDecodeErrorMsgExternal) {
+        return (
+            <>
+                <BodyLong>{'Den forespurte adressen er ikke gyldig:'}</BodyLong>
+                <BodyLong spacing={true} size={'s'}>
+                    {`${appOrigin}${props._path}`}
+                </BodyLong>
+                <BodyLong spacing={true}>
+                    {
+                        'Dersom du fulgte en lenke på nav.no for å komme hit kan du '
+                    }
+                    <LenkeInline href={Config.urls.errorFeedback}>
+                        {'melde fra om teknisk feil'}
+                    </LenkeInline>
+                    {' for den aktuelle lenken.'}
+                </BodyLong>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <BodyLong spacing={true}>
+                {
+                    'Siden kunne ikke lastes på grunn av en ugyldig forespørsel. Du kan forsøke å laste inn siden på nytt.'
+                }
+            </BodyLong>
+            <ErrorFeedbackLink errorId={props.data.errorId} />
+        </>
+    );
+};

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -3,6 +3,9 @@ import PageBase from '../components/PageBase';
 import { ContentProps } from '../types/content-props/_content-common';
 import { v4 as uuid } from 'uuid';
 import { logPageLoadError } from '../utils/errors';
+import { paramDecodeErrorMsgExternal } from '../components/pages/error-page/errorcode-content/ErrorContent400';
+
+const paramDecodeErrorMsg = 'failed to decode param';
 
 const Error = (props: ContentProps) => <PageBase content={props} />;
 
@@ -16,8 +19,19 @@ Error.getInitialProps = ({ res, err, asPath }): ContentProps => {
 
     logPageLoadError(
         errorId,
-        `Unhandled error on path ${asPath} - ${err.toString()}`
+        `Unhandled error on path ${asPath} - ${
+            err ? err.toString() : 'Empty error message'
+        }`
     );
+
+    if (err?.includes(paramDecodeErrorMsg)) {
+        return makeErrorProps(
+            asPath,
+            paramDecodeErrorMsgExternal,
+            400,
+            errorId
+        );
+    }
 
     return makeErrorProps(asPath, undefined, res.statusCode, errorId);
 };

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -16,15 +16,14 @@ Error.getInitialProps = ({ res, err, asPath }): ContentProps => {
     }
 
     const errorId = uuid();
+    const errorMsg = err?.toString() || 'Empty error message';
 
     logPageLoadError(
         errorId,
-        `Unhandled error on path ${asPath} - ${
-            err ? err.toString() : 'Empty error message'
-        }`
+        `Unhandled error on path ${asPath} - ${errorMsg}`
     );
 
-    if (err?.includes(paramDecodeErrorMsg)) {
+    if (errorMsg.includes(paramDecodeErrorMsg)) {
         return makeErrorProps(
             asPath,
             paramDecodeErrorMsgExternal,

--- a/src/utils/make-error-props.ts
+++ b/src/utils/make-error-props.ts
@@ -4,6 +4,9 @@ import { ErrorProps } from '../types/content-props/error-props';
 const errorMessageDefault = 'Ukjent feil';
 
 const errorMessageByCode = {
+    400: 'Ugyldig forespørsel',
+    401: 'Ingen tilgang',
+    403: 'Ingen tilgang',
     404: 'Fant ikke siden',
     408: 'Tidsavbrudd',
 };


### PR DESCRIPTION
- Custom feilmeldinger for 400-feil
- Fjerner bruk av prefetch = true på next/link (denne settes som default og å sette den eksplisitt er deprecated av next/link)