### PR TITLE
Tracker opprinnelse for ekspanderbart panel

### DIFF
--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -13,6 +13,7 @@ export const Expandable = ({
     expandableTitle,
     expandableOpenByDefault,
     expandableAnchorId,
+    analyticsOriginTag = '',
     children,
 }: Props) => {
     const [isOpen, setIsOpen] = useState(expandableOpenByDefault);
@@ -20,6 +21,7 @@ export const Expandable = ({
     const onExpandCollapse = () => {
         logAmplitudeEvent(`panel-${isOpen ? 'kollaps' : 'ekspander'}`, {
             tittel: expandableTitle,
+            opprinnelse: analyticsOriginTag,
         });
         setIsOpen(!isOpen);
     };

--- a/src/components/parts/filters-menu/FiltersMenu.tsx
+++ b/src/components/parts/filters-menu/FiltersMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Title, BodyLong } from '@navikt/ds-react';
+import { BodyLong } from '@navikt/ds-react';
 import { CheckboxGruppe } from 'nav-frontend-skjema';
 
 import { logAmplitudeEvent } from 'utils/amplitude';
@@ -20,13 +20,7 @@ import './FiltersMenu.less';
 const bem = BEM('filters-menu');
 
 export const FiltersMenu = ({ config }: FilterMenuProps) => {
-    const {
-        categories,
-        description,
-        expandable,
-        expandableTitle,
-        title,
-    } = config;
+    const { categories, description, expandableTitle, title } = config;
 
     const {
         clearFiltersForPage,
@@ -79,6 +73,7 @@ export const FiltersMenu = ({ config }: FilterMenuProps) => {
             <Expandable
                 {...config}
                 expandableTitle={expandableTitle || defaultExpandableTitle}
+                analyticsOriginTag="filter"
             >
                 {categories.map((category, categoryIndex) => {
                     return (

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -48,6 +48,7 @@ export type ExpandableMixin = {
     expandableOpenByDefault: boolean;
     expandableTitle: string;
     expandableAnchorId?: string;
+    analyticsOriginTag?: string;
 };
 
 export type FiltersMixin = {


### PR DESCRIPTION
Ekspanderbart panel rapporterer allerede ekspander / kollaps, men man kan ikke se hvor den kommer fra utover tittelen på panelet. Denne PR'en gjør at man kan legge på en egen origin-tag, feks 'filter' slik at det er enklere å differensiere utvalg i Amplitude.