### PR TITLE
Håndtere edge-case når URL slutter på "#" på forsiden

### DIFF
--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -40,13 +40,13 @@ export const PageBase = (props: PageProps) => {
         return <FallbackPage />;
     }
 
-    // A redirect quirk will cause "/no/person#" to return 500 when a link tries to redirect to
+    // A redirect bug in Next will cause "/no/person#" to return 500 when a link tries to redirect to
     // "/no/person" (without the hash). This will send the data through to BasePage even though
     // a redirect directive was returned from getStaticProps. Therefore check for the __N_REDIRECT
     // below and force a push and reload to finally end user up at NAV the redirect location.
     // This issue does not apply to other URL's ending with a hash as redirecting seems to work properly there.
     // Todo: Find the underlying problem why the "#" prevents proper redirect and instead passes through to PageBase component.
-    if (!props?.content && props.__N_REDIRECT === '/no/person') {
+    if (!props?.content && props.__N_REDIRECT) {
         router.reload();
         return;
     }

--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -24,6 +24,7 @@ import globalState from '../globalState';
 
 type PageProps = {
     content: ContentProps;
+    __N_REDIRECT?: string;
 };
 
 type StaticProps = {
@@ -34,8 +35,20 @@ type StaticProps = {
 
 export const PageBase = (props: PageProps) => {
     const router = useRouter();
+
     if (router.isFallback) {
         return <FallbackPage />;
+    }
+
+    // A redirect quirk will cause "/no/person#" to return 500 when a link tries to redirect to
+    // "/no/person" (without the hash). This will send the data through to BasePage even though
+    // a redirect directive was returned from getStaticProps. Therefore check for the __N_REDIRECT
+    // below and force a push and reload to finally end user up at NAV the redirect location.
+    // This issue does not apply to other URL's ending with a hash as redirecting seems to work properly there.
+    // Todo: Find the underlying problem why the "#" prevents proper redirect and instead passes through to PageBase component.
+    if (!props?.content && props.__N_REDIRECT === '/no/person') {
+        router.reload();
+        return;
     }
 
     if (!props?.content) {


### PR DESCRIPTION
Dersom en tom lenke eller liknende har sendt brukeren til "/no/person#", altså med # så oppstår en feil når man klikker NAV-logoen. Se beskrivelse i kodeendringer.

Dette er en quick fix som håndterer case hvor en redirect har sluppet igjennom til PageBase-komponenten.