### PR TITLE
Fikser problemer med skrivetilgang i dockerimage

### DIFF
--- a/.nais/config.yaml
+++ b/.nais/config.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{namespace}}
   labels:
     team: personbruker
+  annotations:
+    nais.io/read-only-file-system: "false"
 spec:
   image: {{image}}:{{version}}
   team: personbruker

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN npm ci
 COPY .next /app/.next/
 COPY public /app/public/
 
-# Copy necesarry files
+# Copy necessary files
 COPY next.config.js /app/
 COPY .env  /app/
+
+RUN chown -R 1069 /app/.next
 
 # Start app
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY public /app/public/
 COPY next.config.js /app/
 COPY .env  /app/
 
+# Set permission/ownership needed for nextjs html/json cache
 RUN chown -R 1069 /app/.next
 
 # Start app

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY next.config.js /app/
 COPY .env  /app/
 
 # Set permission/ownership needed for nextjs html/json cache
+# (1069 is the uid for the app process in containers on nais)
 RUN chown -R 1069 /app/.next
 
 # Start app


### PR DESCRIPTION
Tilganger i containerne i dev-clusterne har blitt strengere, appen har nå ikke lengre root-tilgang, og filsystemet er default satt til read-only. Dette vil etterhvert rulles ut i prod også.

- Setter root filsystem til å være skrivbart
- Setter ownership på .next mappa slik at appen har tilgang til å skrive til cache