### PR TITLE
Fikser null-feil og fjerner editor-overlay i global-values editoren

### DIFF
--- a/src/components/pages/global-values-page/GlobalValuesPage.tsx
+++ b/src/components/pages/global-values-page/GlobalValuesPage.tsx
@@ -15,28 +15,38 @@ import './GlobalValuesPage.less';
 
 const bem = BEM('global-values-page');
 
-const removeDistractions = () => {
-    const header = document.getElementById('decorator-header');
-    if (header) {
-        header.remove();
-    }
-
-    const footer = document.getElementById('decorator-footer');
-    if (footer) {
-        footer.remove();
-    }
-
-    const pageEditorOverlays = document.getElementsByClassName(
-        'xp-page-editor-shader'
-    );
-    if (pageEditorOverlays) {
-        Array.from(pageEditorOverlays).forEach((element) => element.remove());
-    }
-};
-
 const GlobalValuesDisplay = ({ displayName }: GlobalValuesProps) => {
     useEffect(() => {
-        removeDistractions();
+        const header = document.getElementById('decorator-header');
+        if (header) {
+            header.style.display = 'none';
+        }
+
+        const footer = document.getElementById('decorator-footer');
+        if (footer) {
+            footer.style.display = 'none';
+        }
+
+        // Hide overlay-elements in the editor
+        const callback = (mutations) => {
+            mutations.forEach((mutation) => {
+                if (
+                    mutation.target.classList.contains('xp-page-editor-shader')
+                ) {
+                    mutation.target.style.display = 'none';
+                }
+            });
+        };
+
+        const observer = new MutationObserver(callback);
+        const config = {
+            childList: true,
+            subtree: true,
+            attributes: true,
+        };
+        observer.observe(window.document, config);
+
+        return () => observer.disconnect();
     }, []);
 
     return (

--- a/src/components/pages/global-values-page/GlobalValuesPage.tsx
+++ b/src/components/pages/global-values-page/GlobalValuesPage.tsx
@@ -15,21 +15,28 @@ import './GlobalValuesPage.less';
 
 const bem = BEM('global-values-page');
 
-const hideDecorator = () => {
+const removeDistractions = () => {
     const header = document.getElementById('decorator-header');
     if (header) {
-        header.style.display = 'none';
+        header.remove();
     }
 
     const footer = document.getElementById('decorator-footer');
     if (footer) {
-        footer.style.display = 'none';
+        footer.remove();
+    }
+
+    const pageEditorOverlays = document.getElementsByClassName(
+        'xp-page-editor-shader'
+    );
+    if (pageEditorOverlays) {
+        Array.from(pageEditorOverlays).forEach((element) => element.remove());
     }
 };
 
 const GlobalValuesDisplay = ({ displayName }: GlobalValuesProps) => {
     useEffect(() => {
-        hideDecorator();
+        removeDistractions();
     }, []);
 
     return (

--- a/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
@@ -22,7 +22,7 @@ type Props = {
 };
 
 export const GVItemEditor = ({
-    item = { itemName: '', textValue: '', key: '' },
+    item = { itemName: '', textValue: '', numberValue: '', key: '' },
     onClose,
 }: Props) => {
     const [inputState, setInputState] = useState(item);
@@ -100,9 +100,9 @@ export const GVItemEditor = ({
         e.preventDefault();
         const inputTrimmed = {
             ...inputState,
-            itemName: inputState.itemName.trim(),
-            numberValue: inputState.numberValue.trim(),
-            textValue: inputState.textValue.trim(),
+            itemName: inputState.itemName?.trim(),
+            numberValue: inputState.numberValue?.trim(),
+            textValue: inputState.textValue?.trim(),
         };
 
         const { itemName, numberValue, textValue } = inputTrimmed;

--- a/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
@@ -101,7 +101,10 @@ export const GVItemEditor = ({
         const inputTrimmed = {
             ...inputState,
             itemName: inputState.itemName?.trim(),
-            numberValue: inputState.numberValue?.trim(),
+            numberValue:
+                typeof inputState.numberValue === 'string'
+                    ? inputState.numberValue.trim()
+                    : inputState.numberValue,
             textValue: inputState.textValue?.trim(),
         };
 

--- a/src/types/content-props/global-values-props.ts
+++ b/src/types/content-props/global-values-props.ts
@@ -4,7 +4,7 @@ export type GlobalValueItem = {
     key: string;
     itemName: string;
     textValue: string;
-    numberValue?: string;
+    numberValue?: string | number;
 };
 
 export type GlobalValuesData = {


### PR DESCRIPTION
- Sjekker at numberValue er string før trim()
- Fjerner overlays for komponent-editing i CS editor-viewet 