### PR TITLE
Klikkbare hjelpefunksjoner i editoren for FragmentPage

### DIFF
--- a/src/components/_common/editor-utils/editor-help/EditorHelp.less
+++ b/src/components/_common/editor-utils/editor-help/EditorHelp.less
@@ -1,4 +1,4 @@
-@import (reference) '../../../global';
+@import (reference) '../../../../global';
 
 .editor-help {
     @navGronnLighten40Filter: invert(98%) sepia(83%) saturate(920%)

--- a/src/components/_common/editor-utils/editor-help/EditorHelp.tsx
+++ b/src/components/_common/editor-utils/editor-help/EditorHelp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { usePageConfig } from '../../../store/hooks/usePageConfig';
-import { PublicImage } from '../image/PublicImage';
-import { BEM, classNames } from '../../../utils/classnames';
+import { usePageConfig } from '../../../../store/hooks/usePageConfig';
+import { PublicImage } from '../../image/PublicImage';
+import { BEM, classNames } from '../../../../utils/classnames';
 import { BodyShort } from '@navikt/ds-react';
 import './EditorHelp.less';
 

--- a/src/components/_common/editor-utils/editor-link-wrapper/EditorLinkWrapper.tsx
+++ b/src/components/_common/editor-utils/editor-link-wrapper/EditorLinkWrapper.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { usePageConfig } from '../../../../store/hooks/usePageConfig';
+
+//
+// This wrapper component can be used for making links clickable in the Content Studio
+// component editor. The editor captures all <a> element click events, we work around this by
+// passing the relevant props to a <span> element instead.
+//
+
+type Props = {
+    children: React.ReactNode;
+};
+
+export const EditorLinkWrapper = ({ children }: Props) => {
+    const { pageConfig } = usePageConfig();
+    const { editorView } = pageConfig;
+
+    if (editorView !== 'edit') {
+        return <>{children}</>;
+    }
+
+    const child = React.Children.only(children) as React.ReactElement;
+
+    if (!child.props) {
+        return <>{children}</>;
+    }
+
+    const { className, href, onClick, target } =
+        child.props as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+    return (
+        <span
+            className={className}
+            onClick={(e) => {
+                if (onClick) {
+                    // @ts-ignore
+                    onClick(e);
+                }
+                if (href) {
+                    window.open(href, target);
+                }
+            }}
+        >
+            {children}
+        </span>
+    );
+};

--- a/src/components/_common/editor-utils/editor-link-wrapper/EditorLinkWrapper.tsx
+++ b/src/components/_common/editor-utils/editor-link-wrapper/EditorLinkWrapper.tsx
@@ -15,7 +15,7 @@ export const EditorLinkWrapper = ({ children }: Props) => {
     const { pageConfig } = usePageConfig();
     const { editorView } = pageConfig;
 
-    if (editorView !== 'edit') {
+    if (!editorView || editorView === 'preview') {
         return <>{children}</>;
     }
 
@@ -32,12 +32,18 @@ export const EditorLinkWrapper = ({ children }: Props) => {
         <span
             className={className}
             onClick={(e) => {
+                e.stopPropagation();
+
                 if (onClick) {
                     // @ts-ignore
                     onClick(e);
                 }
                 if (href) {
-                    window.open(href, target);
+                    if (target === '_blank') {
+                        window.open(href, target);
+                    } else {
+                        window.location.assign(href);
+                    }
                 }
             }}
         >

--- a/src/components/layouts/Region.tsx
+++ b/src/components/layouts/Region.tsx
@@ -3,7 +3,7 @@ import { ContentProps } from '../../types/content-props/_content-common';
 import { BEM, classNames } from '../../utils/classnames';
 import { ComponentMapper } from '../ComponentMapper';
 import { RegionProps } from '../../types/component-props/layouts';
-import { EditorHelp } from 'components/_common/editor-help/EditorHelp';
+import { EditorHelp } from 'components/_common/editor-utils/editor-help/EditorHelp';
 
 type Props = {
     pageProps: ContentProps;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -6,7 +6,7 @@ import { MainContentSection } from './main-content-section/MainContentSection';
 import { LeftMenuSection } from './left-menu-section/LeftMenuSection';
 import { RightMenuSection } from './right-menu-section/RightMenuSection';
 import { windowMatchMedia } from '../../../utils/match-media';
-import { EditorHelp } from '../../_common/editor-help/EditorHelp';
+import { EditorHelp } from '../../_common/editor-utils/editor-help/EditorHelp';
 import Config from '../../../config';
 import './PageWithSideMenus.less';
 

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
@@ -5,7 +5,7 @@ import { RegionProps } from '../../../../types/component-props/layouts';
 import { ContentProps } from '../../../../types/content-props/_content-common';
 import { PageNavigationMenu } from '../../../_common/page-navigation-menu/PageNavigationMenu';
 import { AnchorLink } from '../../../../types/component-props/parts/page-navigation-menu';
-import { EditorHelp } from '../../../_common/editor-help/EditorHelp';
+import { EditorHelp } from '../../../_common/editor-utils/editor-help/EditorHelp';
 import './LeftMenuSection.less';
 
 const bem = BEM('left-menu');

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -6,7 +6,7 @@ import Region from '../Region';
 import { Header } from '../../_common/headers/Header';
 import { XpImage } from '../../_common/image/XpImage';
 import { FilterBar } from '../../_common/filter-bar/FilterBar';
-import { EditorHelp } from '../../_common/editor-help/EditorHelp';
+import { EditorHelp } from '../../_common/editor-utils/editor-help/EditorHelp';
 import './SectionWithHeaderLayout.less';
 
 const getBorderStyle = ({

--- a/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.less
+++ b/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.less
@@ -16,7 +16,7 @@
         margin-left: 1rem;
     }
 
-    &__page-usage {
+    .fragment-usage-link {
         margin-top: 0.5rem;
     }
 

--- a/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.tsx
+++ b/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.tsx
@@ -1,29 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { fetchWithTimeout } from '../../../../utils/fetch-utils';
-import {
-    editorPathPrefix,
-    xpDraftPathPrefix,
-    xpServicePath,
-} from '../../../../utils/urls';
+import { xpDraftPathPrefix, xpServicePath } from '../../../../utils/urls';
 import { Title } from '@navikt/ds-react';
 import { Button } from '../../../_common/button/Button';
 import { BEM } from '../../../../utils/classnames';
-import { LenkeInline } from '../../../_common/lenke/LenkeInline';
+import { EditorLinkWrapper } from '../../../_common/editor-utils/editor-link-wrapper/EditorLinkWrapper';
+import { FragmentUsageLink } from './FragmentUsageLink';
 import './FragmentUsageCheck.less';
 
 const bem = BEM('fragment-usage');
 
 const serviceUrl = `${xpDraftPathPrefix}${xpServicePath}/htmlFragmentSelector/fragmentUsage`;
 
-type ContentData = {
+export type FragmentUsageData = {
     name: string;
     path: string;
     id: string;
 };
 
 type FragmentUsage = {
-    macroUsage: ContentData[];
-    componentUsage: ContentData[];
+    macroUsage: FragmentUsageData[];
+    componentUsage: FragmentUsageData[];
 };
 
 const fetchMacroUsage = (id: string): Promise<FragmentUsage> =>
@@ -86,15 +83,19 @@ export const FragmentUsageCheck = ({ id }: Props) => {
                                 numUniqueUsages === 1 ? '' : 'e'
                             } side${numUniqueUsages === 1 ? '' : 'r'}`}
                         </Title>
-                        <Button
-                            type={'flat'}
-                            mini={true}
-                            kompakt={true}
-                            className={bem('button')}
-                            onClick={() => setShowUsage(!showUsage)}
-                        >
-                            {showUsage ? 'Skjul' : 'Vis'}
-                        </Button>
+                        <EditorLinkWrapper>
+                            <Button
+                                type={'flat'}
+                                mini={true}
+                                kompakt={true}
+                                className={bem('button')}
+                                onClick={() => {
+                                    setShowUsage(!showUsage);
+                                }}
+                            >
+                                {showUsage ? 'Skjul' : 'Vis'}
+                            </Button>
+                        </EditorLinkWrapper>
                     </>
                 ) : (
                     <Title level={3} size="s">
@@ -113,20 +114,9 @@ export const FragmentUsageCheck = ({ id }: Props) => {
                             >
                                 {'I bruk som komponent:'}
                             </Title>
-                            {componentUsage.map((content) => {
-                                const editorUrl = `${editorPathPrefix}/${content.id}`;
-                                return (
-                                    <div
-                                        className={bem('page-usage')}
-                                        key={content.id}
-                                    >
-                                        {`${content.name} - `}
-                                        <LenkeInline href={editorUrl}>
-                                            {content.path}
-                                        </LenkeInline>
-                                    </div>
-                                );
-                            })}
+                            {componentUsage.map((content) => (
+                                <FragmentUsageLink {...content} />
+                            ))}
                         </>
                     )}
                     {macroUsage.length > 0 && (
@@ -138,20 +128,9 @@ export const FragmentUsageCheck = ({ id }: Props) => {
                             >
                                 {'I bruk som macro:'}
                             </Title>
-                            {macroUsage.map((content) => {
-                                const editorUrl = `${editorPathPrefix}/${content.id}`;
-                                return (
-                                    <div
-                                        className={bem('page-usage')}
-                                        key={content.id}
-                                    >
-                                        {`${content.name} - `}
-                                        <LenkeInline href={editorUrl}>
-                                            {content.path}
-                                        </LenkeInline>
-                                    </div>
-                                );
-                            })}
+                            {macroUsage.map((content) => (
+                                <FragmentUsageLink {...content} />
+                            ))}
                         </>
                     )}
                 </div>

--- a/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.tsx
+++ b/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageCheck.tsx
@@ -89,9 +89,7 @@ export const FragmentUsageCheck = ({ id }: Props) => {
                                 mini={true}
                                 kompakt={true}
                                 className={bem('button')}
-                                onClick={() => {
-                                    setShowUsage(!showUsage);
-                                }}
+                                onClick={() => setShowUsage(!showUsage)}
                             >
                                 {showUsage ? 'Skjul' : 'Vis'}
                             </Button>

--- a/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageLink.tsx
+++ b/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageLink.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FragmentUsageData } from './FragmentUsageCheck';
+import { editorPathPrefix } from '../../../../utils/urls';
+import { LenkeInline } from '../../../_common/lenke/LenkeInline';
+import { EditorLinkWrapper } from '../../../_common/editor-utils/editor-link-wrapper/EditorLinkWrapper';
+
+export const FragmentUsageLink = ({ id, name, path }: FragmentUsageData) => {
+    const editorUrl = `${editorPathPrefix}/${id}`;
+    return (
+        <div className={'fragment-usage-link'} key={id}>
+            {`${name} - `}
+            <EditorLinkWrapper>
+                <LenkeInline href={editorUrl}>{path}</LenkeInline>
+            </EditorLinkWrapper>
+        </div>
+    );
+};

--- a/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageLink.tsx
+++ b/src/components/pages/fragment-page/fragment-usage-check/FragmentUsageLink.tsx
@@ -10,7 +10,9 @@ export const FragmentUsageLink = ({ id, name, path }: FragmentUsageData) => {
         <div className={'fragment-usage-link'} key={id}>
             {`${name} - `}
             <EditorLinkWrapper>
-                <LenkeInline href={editorUrl}>{path}</LenkeInline>
+                <LenkeInline href={editorUrl} target={'_blank'}>
+                    {path}
+                </LenkeInline>
             </EditorLinkWrapper>
         </div>
     );

--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../types/component-props/parts/contact-option';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { openChatbot } from '../../../utils/chatbot';
-import { EditorHelp } from '../../_common/editor-help/EditorHelp';
+import { EditorHelp } from '../../_common/editor-utils/editor-help/EditorHelp';
 
 import './ContactOptionPart.less';
 


### PR DESCRIPTION
Funksjonaliteten som viser hvor et fragment er i bruk kan ikke klikkes på i editor-viewet i CS, ettersom CS fanger click-events på anchor-elementer. Fikser dette ved å wrappe lenker som alltid skal være klikkbare i en span med onClick navigering.