### PR TITLE
Korrigere produkt kort avstander

### DIFF
--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -15,6 +15,10 @@
             display: inline-block;
         }
 
+        &__inline:not(:last-child) {
+            margin-bottom: 0;
+        }
+
         .card__bed {
             transition: all 0.3s;
             height: 100%;

--- a/src/components/pages/shared-mixins.less
+++ b/src/components/pages/shared-mixins.less
@@ -13,8 +13,11 @@
     // should have extra spacing above content, but only if
     // not the topmost element within region. Except first-child.
     .part {
-        h3 {
-            margin-top: 2.75rem;
+        .html-area,
+        &__dynamic-header {
+            h3 {
+                margin-top: 2.75rem;
+            }
         }
     }
 


### PR DESCRIPTION
Kjapp korrigering av stylingfeil for mikrokort som får for stor avstand mellom seg og produktkort hvor tittelen (h3) får margin-bottom samme som andre h3.