### PR TITLE
Fiks bredde og margin produktkort i flex cols

### DIFF
--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -93,11 +93,4 @@
             }
         }
     }
-
-    &__provider-card {
-        .card {
-            // Margin is handled by general FlexColsLayout
-            margin-bottom: 0;
-        }
-    }
 }

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -93,4 +93,11 @@
             }
         }
     }
+
+    &__provider-card {
+        .card {
+            // Margin is handled by general FlexColsLayout
+            margin-bottom: 0;
+        }
+    }
 }

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -10,9 +10,11 @@
         text-decoration: none;
         display: block;
         margin-bottom: 1.75rem;
+        width: 100%;
 
         &__inline {
             display: inline-block;
+            width: auto;
         }
 
         &__inline:not(:last-child) {

--- a/src/components/layouts/flex-cols/FlexColsLayout.less
+++ b/src/components/layouts/flex-cols/FlexColsLayout.less
@@ -121,6 +121,13 @@
     &:last-of-type {
         padding-bottom: 0;
     }
+
+    .part {
+        .card {
+            // Margins between parts are handled in general above.
+            margin-bottom: 0;
+        }
+    }
 }
 
 .region__flexcols {


### PR DESCRIPTION
- Flex-cols (utfallende seksjon i livssituasjonsmal) setter margin på elementene selv, så produktkort skal ikke ha margin selv.
- Produktkort med veldig liten tekst fyller nå ut i 100% bredde. Edge-case siden alle produktkort har minst én full linje med beskrivende tekst, men ok å få fikset.