### PR TITLE
Ta hensyn til dekoratørhøyde når angitt scrollposisjon

### DIFF
--- a/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
@@ -27,7 +27,7 @@ const getCurrentLinkIndex = (links: AnchorLink[]) => {
         return element ? [...elements, element] : elements;
     }, []);
 
-    const scrollTarget = window.scrollY + pageNavigationAnchorOffsetPx;
+    const scrollTarget = window.scrollY + Config.vars.dekoratorenHeight;
 
     const scrolledToTop = !!(
         targetElements?.length && targetElements[0].offsetTop > scrollTarget

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ const vars = {
     revalidatePeriod: 3600,
     pxPerRem: 16,
     mobileBreakpointPx: 768,
+    dekoratorenHeight: 104,
 };
 
 const urls = {


### PR DESCRIPTION
Pga avvik i et par pixler så vil sidemenyen rapportere feil valgt item ved zoom 110% eller mer. Se bilde:
![image](https://user-images.githubusercontent.com/1443997/135987855-ced75e41-a751-4c37-9f69-87488ee7f64c.png)

Samtidig dersom man scroller litt opp, så trekkes Dekoratøren nedover mens tilsynelatende fortsatt er på samme seksjonsinnhold. Menyen derimot hopper opp på menyelementet ovenfor etter bare 2px scrolling.

Foreslår derfor å legge inn omtrentlig dekoratørøhyde. Det ser ut til å fikse issuen i sidemenyen i tillegg til at det lar brukeren scrolle litt opp og trekke ned dekoratøren uten at fokus i meny skifter før der virker naturlig.