### PR TITLE
Korrekt formattering av tall fra makroer avhengig av språk som artikkelen er i

### DIFF
--- a/.github/workflows/deploy.dev-gcp.yml
+++ b/.github/workflows/deploy.dev-gcp.yml
@@ -67,5 +67,5 @@ jobs:
         env:
           CLUSTER: dev-gcp
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          RESOURCE: .nais/config.yaml, .nais/persistent-volume.yaml
+          RESOURCE: .nais/config.yaml
           VARS: .nais/vars.yaml

--- a/.github/workflows/deploy.dev-gcp.yml
+++ b/.github/workflows/deploy.dev-gcp.yml
@@ -67,5 +67,5 @@ jobs:
         env:
           CLUSTER: dev-gcp
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          RESOURCE: .nais/config.yaml
+          RESOURCE: .nais/config.yaml, .nais/persistent-volume.yaml
           VARS: .nais/vars.yaml

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -42,7 +42,7 @@ const postHandler = async (req, res) => {
     mockStore.dispatch(
         setPageConfigAction({
             pageId: dummyPageProps._id,
-            language: dummyPageProps.language,
+            language: req.body?.props?.language || dummyPageProps.language,
             editorView: 'edit',
         })
     );


### PR DESCRIPTION
Tar hensyn til språket som er satt i artiklen slik at tallformattering fra makroer vises med riktig tusenskille og desimalseparator, feks 100,000.55 vs 100 000,55. Dette blir da uavhengig av locale som er satt i nettleseren.

**For ordens skyld om språk:**
Artiklene på engelsk er skrevet for britisk engelsk, så for å sikre HELT korrekt nummer- og datoformattering måtte vi ha introdusert locale (en-GB) og ikke bare language (en).