### PR TITLE
Renamer "navigasjon" => "innhold" i legacy høyremeny

### DIFF
--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { Label, Title } from '@navikt/ds-react';
 import { translator } from 'translations';
+
+import classNames from 'classnames';
 import { ContentType, ContentProps } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
 import { BEM } from 'utils/classnames';
 import { MainArticleChapterProps } from '../../../../types/content-props/main-article-chapter-props';
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
-import './MainArticleChapterNavigation.less';
-import classNames from 'classnames';
 import { usePageConfig } from 'store/hooks/usePageConfig';
+
+import './MainArticleChapterNavigation.less';
 
 /*
     Render of XP part named main-article-linked-list

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { BodyShort, Label, Title } from '@navikt/ds-react';
+import { Label, Title } from '@navikt/ds-react';
+import { translator } from 'translations';
 import { ContentType, ContentProps } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
 import { BEM } from 'utils/classnames';
@@ -7,6 +8,7 @@ import { MainArticleChapterProps } from '../../../../types/content-props/main-ar
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
 import './MainArticleChapterNavigation.less';
 import classNames from 'classnames';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 
 /*
     Render of XP part named main-article-linked-list
@@ -14,6 +16,8 @@ import classNames from 'classnames';
 
 export const MainArticleChapterNavigation = (props: ContentProps) => {
     const bem = BEM('main-article-chapter-navigation');
+    const { language } = usePageConfig();
+    const getLabel = translator('mainArticle', language);
     const chapters =
         props.data?.chapters ||
         props.parent?.data?.chapters ||
@@ -35,7 +39,7 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
     return (
         <nav className={bem()}>
             <Title level={3} size="m" className={bem('title')}>
-                Innhold
+                {getLabel('contents')}
             </Title>
             <ul>
                 <li>

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -35,7 +35,7 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
     return (
         <nav className={bem()}>
             <Title level={3} size="m" className={bem('title')}>
-                Navigasjon
+                Innhold
             </Title>
             <ul>
                 <li>

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -64,6 +64,7 @@ export const bundle = {
         linkedListDescription: 'Kapitler',
         published: 'Publisert',
         tableOfContents: 'Innholdsfortegnelse',
+        contents: 'Innhold',
     },
     mainPanels: {
         label: 'Hovedvalg',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -41,6 +41,7 @@ export const bundle: Translations = {
         linkedListDescription: 'Chapters',
         published: 'Published',
         tableOfContents: 'Table of contents',
+        contents: 'Contents',
     },
     mainPanels: { label: 'Main panels' },
     publishingCalendar: {


### PR DESCRIPTION
Avgjørelse med design om å rename "Navigasjon" => "Innhold" så lenge. Deretter blir det en vurdering om vi skal gjøre noe mer med høyremenyen som uansett tilhører legacy maler.