### PR TITLE
Fix uu heading og semantikk

### DIFF
--- a/src/components/_common/illustration/IllustrationAnimated.tsx
+++ b/src/components/_common/illustration/IllustrationAnimated.tsx
@@ -77,11 +77,7 @@ export const IllustrationAnimated = ({
     }
 
     return (
-        <div
-            className={classNames(bem('image'), className)}
-            role="img"
-            aria-label={illustration.displayName}
-        >
+        <div className={classNames(bem('image'), className)} aria-hidden="true">
             <div
                 ref={lottieContainer}
                 className={classNames(bem('lottie-container'))}

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -30,11 +30,7 @@ export const IllustrationStatic = ({
     const [icon1, icon2] = icons;
 
     return (
-        <div
-            className={classNames(bem('image'), className)}
-            role="img"
-            aria-label={illustration.displayName}
-        >
+        <div className={classNames(bem('image'), className)} aria-hidden="true">
             <div
                 className={classNames(bem('icon'), bem('icon', 'icon1'))}
                 style={{

--- a/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
@@ -26,7 +26,7 @@ export const PageNavigationInContent = ({ title, links }: Props) => {
                     {title}
                 </Header>
             )}
-            <nav role={'navigation'} aria-label={'Innhold'}>
+            <nav aria-label={'Innhold'}>
                 <ul className={bem('list')}>
                     {links.map((anchorLink) => (
                         <li key={anchorLink.anchorId}>

--- a/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
@@ -27,11 +27,11 @@ export const PageNavigationSidebar = ({
     return (
         <div className={classNames(bem())}>
             {title && (
-                <Title level={3} size="m" className={bem('title')}>
+                <Title level={2} size="m" className={bem('title')}>
                     {title}
                 </Title>
             )}
-            <nav role={'navigation'} aria-label={'Innhold'}>
+            <nav aria-label={'Innhold'}>
                 <ul className={bem('list')}>
                     {links.map((anchorLink, index) => (
                         <li key={anchorLink.anchorId}>

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -34,7 +34,7 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
 
     return (
         <nav className={bem()}>
-            <Title level={3} size="m" className={bem('title')}>
+            <Title level={2} size="m" className={bem('title')}>
                 Navigasjon
             </Title>
             <ul>


### PR DESCRIPTION
- Setter aria-hidden="true" på illustrasjoner i header etter diskusjon med UU.
- Fjerner role="navigation" som er overflødig innenfor nav-tag.
- Setter korrekt h-nivå på menyer. Skal være h2, på samme nivå som overskriftene i hver seksjon. Avklart spesifikt med UU.