### PR TITLE
UU fix empty htags

### DIFF
--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -187,10 +187,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
             // Replace empty rows with stylable element
             if (tag === 'tr' && !validChildren) {
                 return (
-                    <tr
-                        {...attributesToProps(attribs)}
-                        className={'spacer-row'}
-                    />
+                    <tr {...props} className={'spacer-row'} />
                 );
             }
 

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Label, BodyLong, Title } from '@navikt/ds-react';
+import { BodyLong, Title } from '@navikt/ds-react';
 import htmlReactParser, { Element, domToReact } from 'html-react-parser';
 import { isTag, isText } from 'domhandler';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
@@ -140,7 +140,6 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 if (hasBlockLevelMacroChildren(element)) {
                     return <>{domToReact(children, replaceElements)}</>;
                 }
-
                 return (
                     <BodyLong spacing {...props}>
                         {domToReact(children, replaceElements)}
@@ -193,14 +192,6 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                         className={'spacer-row'}
                     />
                 );
-            }
-
-            // strong -> Label
-            if (tag === 'strong') {
-                if (!validChildren) {
-                    return <Fragment />
-                }
-                return <Label>{domToReact(validChildren)}</Label>;
             }
 
             // Remove empty divs

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { BodyLong, Title } from '@navikt/ds-react';
+import { Label, BodyLong, Title } from '@navikt/ds-react';
 import htmlReactParser, { Element, domToReact } from 'html-react-parser';
 import { isTag, isText } from 'domhandler';
 import attributesToProps from 'html-react-parser/lib/attributes-to-props';
@@ -185,14 +185,8 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
-            // Special handling for large-table (fucked up html from source)
-            if (attribs?.class === 'statTab' &&
-                tag === 'tr' &&
-                (!children ||
-                    children.filter((col) => isTag(col) && col.children?.length)
-                        .length === 0
-                )
-            ) {
+            // Replace empty rows with stylable element
+            if (tag === 'tr' && !validChildren) {
                 return (
                     <tr
                         {...attributesToProps(attribs)}
@@ -201,17 +195,17 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
-            // Remove strong, as it is inconsistently used and we apply font-styling in css instead
+            // strong -> Label
             if (tag === 'strong') {
-                return <>{domToReact(children)}</>;
+                if (!validChildren) {
+                    return <Fragment />
+                }
+                return <Label>{domToReact(validChildren)}</Label>;
             }
 
-            // Remove empty footers etc
-            if (tag === 'div')
-            {
-                if (!validChildren) {
-                    return <Fragment />;
-                }
+            // Remove empty divs
+            if (tag === 'div' && !validChildren) {
+                return <Fragment />;
             }
         },
     };

--- a/src/components/ParsedHtml.tsx
+++ b/src/components/ParsedHtml.tsx
@@ -90,7 +90,9 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
             const { name, attribs, children } = element;
             const tag = name?.toLowerCase();
             const props = !!attribs && attributesToProps(attribs);
+            const validChildren = getNonEmptyChildren(element);
 
+            // Handle macros
             if (tag === processedHtmlMacroTag) {
                 return (
                     <MacroMapper
@@ -100,24 +102,25 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
+            // Remove img without src
             if (tag === 'img') {
-                return attribs?.src ? (
+                if ( !attribs?.src ) {
+                    return <Fragment />;
+                }
+                return (
                     <img
                         {...props}
                         alt={attribs.alt || ''}
                         src={getMediaUrl(attribs.src)}
                     />
-                ) : (
-                    <Fragment />
                 );
             }
 
+            // Fix header-tags
             if (tag?.match(/^h[1-6]$/)) {
-                const validChildren = getNonEmptyChildren(element);
-
                 // Header-tags should not be used as empty spacers
                 if (!validChildren) {
-                    return <p>{'&nbsp;'}</p>;
+                    return <p>{' '}</p>;
                 }
 
                 const level = headingToLevel[tag] || 2; //Level 1 reserved for page title
@@ -131,6 +134,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
+            // Handle paragraphs
             if (tag === 'p' && children) {
                 // Block level elements should not be nested under inline elements
                 if (hasBlockLevelMacroChildren(element)) {
@@ -144,26 +148,25 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
+            // Handle links
             if (tag === 'a') {
                 const href = attribs?.href?.replace('https://www.nav.no', '');
-                const validChildren = getNonEmptyChildren(element);
 
-                return validChildren ? (
+                if (!validChildren) {
+                    return <Fragment />;
+                }
+                return (
                     <LenkeInline {...props} href={href}>
                         {domToReact(validChildren, replaceElements)}
                     </LenkeInline>
-                ) : (
-                    <Fragment />
                 );
             }
 
             // Remove empty lists
             if (tag === 'ul') {
-                const validChildren = getNonEmptyChildren(element);
                 if (!validChildren) {
                     return <Fragment />;
                 }
-
                 return (
                     <ul {...props}>
                         {domToReact(validChildren, replaceElements)}
@@ -171,7 +174,8 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                 );
             }
 
-            if (tag === 'table') {
+            // Table class fix, excluding large-table (statistics pages)
+            if (tag === 'table' && attribs?.class !== 'statTab') {
                 return (
                     <div className={classNames(bem('horisontal-scroll'))}>
                         <table {...props} className={'tabell tabell--stripet'}>
@@ -179,6 +183,35 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
                         </table>
                     </div>
                 );
+            }
+
+            // Special handling for large-table (fucked up html from source)
+            if (attribs?.class === 'statTab' &&
+                tag === 'tr' &&
+                (!children ||
+                    children.filter((col) => isTag(col) && col.children?.length)
+                        .length === 0
+                )
+            ) {
+                return (
+                    <tr
+                        {...attributesToProps(attribs)}
+                        className={'spacer-row'}
+                    />
+                );
+            }
+
+            // Remove strong, as it is inconsistently used and we apply font-styling in css instead
+            if (tag === 'strong') {
+                return <>{domToReact(children)}</>;
+            }
+
+            // Remove empty footers etc
+            if (tag === 'div')
+            {
+                if (!validChildren) {
+                    return <Fragment />;
+                }
             }
         },
     };

--- a/src/components/pages/large-table-page/LargeTablePage.tsx
+++ b/src/components/pages/large-table-page/LargeTablePage.tsx
@@ -1,60 +1,16 @@
-import React, { Fragment } from 'react';
-import htmlReactParser, { Element, domToReact } from 'html-react-parser';
-import { isTag } from 'domhandler';
-import attributesToProps from 'html-react-parser/lib/attributes-to-props';
+import React from 'react';
 import { LargeTableProps } from '../../../types/content-props/large-table-props';
 import { makeErrorProps } from '../../../utils/make-error-props';
 import { ErrorPage } from '../error-page/ErrorPage';
+import { ParsedHtml } from '../../ParsedHtml'
 import './LargeTablePage.less';
-
-const parseHtml = (htmlString: string) => {
-    const options = {
-        replace: ({ name, attribs, children }: Element) => {
-            // Replace rows with no content with an easily styled element
-            if (
-                name?.toLowerCase() === 'tr' &&
-                (!children ||
-                    children.filter((col) => isTag(col) && col.children?.length)
-                        .length === 0)
-            ) {
-                return (
-                    <tr
-                        {...attributesToProps(attribs)}
-                        className={'spacer-row'}
-                    />
-                );
-            }
-
-            // Remove strong, as it is inconsistently used and we apply font-styling in css instead
-            if (name?.toLowerCase() === 'strong') {
-                return <>{domToReact(children)}</>;
-            }
-
-            // Remove empty footers etc
-            if (
-                name?.toLowerCase() === 'div' &&
-                (!children || children.length === 0)
-            ) {
-                return <Fragment />;
-            }
-        },
-    };
-
-    const htmlParsed = htmlReactParser(
-        // remove whitespace
-        htmlString.replace(/(\t|\n|\r|&nbsp;)/gm, ''),
-        options
-    );
-
-    return <>{htmlParsed}</>;
-};
 
 export const LargeTablePage = (contentData: LargeTableProps) => {
     const html = contentData.data?.text;
 
     return html || !!contentData.editorView ? (
         <div className={'large-table-page'}>
-            {html ? parseHtml(html.processedHtml) : ''}
+           <ParsedHtml htmlProps={html} />
         </div>
     ) : (
         <ErrorPage


### PR DESCRIPTION
Lar large-table bruke samme HTML-parser som alle andre sider.
Justert denne parseren tilsvarende.
Dropper håndtering av strong, er ikke kritisk mener jeg (skapte en del problemer i artikkelsider).