### PR TITLE
Overrides på "skriv til oss"-kontaktkort

### DIFF
--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -38,14 +38,13 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
             return '';
         }
 
-        if (channel !== ContactOption.CALL) {
-            // Only CALL section is allowed to change title.
-            return translations.title;
+        if (channel === ContactOption.CALL) {
+            return `${translations.title} ${abroadPrefix} ${
+                data.phoneNumber || '55 55 33 33'
+            }`;
         }
 
-        return `${translations.title} ${abroadPrefix} ${
-            data.phoneNumber || '55 55 33 33'
-        }`;
+        return data.title || translations.title;
     };
 
     const getIngress = (channel: ContactOption, data: ChannelData) => {
@@ -68,7 +67,7 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
 
         if (channel === ContactOption.WRITE) {
             return {
-                href: '/person/kontakt-oss/nb/skriv-til-oss',
+                href: data.url || '/person/kontakt-oss/nb/skriv-til-oss',
             };
         }
 

--- a/src/types/component-props/parts/contact-option.ts
+++ b/src/types/component-props/parts/contact-option.ts
@@ -11,6 +11,8 @@ export enum ContactOption {
 export interface ChannelData {
     ingress?: string;
     phoneNumber?: string;
+    title?: string;
+    url?: string;
 }
 
 export interface ContactOptionProps extends PartComponentProps {


### PR DESCRIPTION
Kontaktkort (livssituasjons- og produktsidemal) kan nå vises med alternativ tittel og url.

![kontakt](https://user-images.githubusercontent.com/1443997/142887086-3111ff63-104f-4691-ad7c-1fe0e35fa48a.png)