### PR TITLE
Fjerner visning av "legacy" global-verdi bruk

### DIFF
--- a/src/components/pages/global-values-page/api/services/usage.ts
+++ b/src/components/pages/global-values-page/api/services/usage.ts
@@ -8,7 +8,6 @@ type ContentInfo = {
 
 type ServiceResponse = {
     usage: ContentInfo[];
-    legacyUsage: ContentInfo[];
 };
 
 export const gvServiceGetUsage = (

--- a/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
@@ -59,13 +59,7 @@ export const GVItemEditor = ({
             .then((res) => {
                 const usage = res?.usage;
                 if (!usage || usage.length > 0) {
-                    setMessages(
-                        generateGvUsageMessages(
-                            usage,
-                            item.itemName,
-                            res?.legacyUsage
-                        )
-                    );
+                    setMessages(generateGvUsageMessages(usage, item.itemName));
                     setAwaitDeleteConfirm(true);
                 } else {
                     deleteConfirm();

--- a/src/components/pages/global-values-page/components/values/item/GVItem.tsx
+++ b/src/components/pages/global-values-page/components/values/item/GVItem.tsx
@@ -74,8 +74,7 @@ export const GVItem = ({ item }: Props) => {
                                 setMessages(
                                     generateGvUsageMessages(
                                         res.usage,
-                                        item.itemName,
-                                        res.legacyUsage
+                                        item.itemName
                                     )
                                 )
                             )

--- a/src/components/pages/global-values-page/utils.tsx
+++ b/src/components/pages/global-values-page/utils.tsx
@@ -55,11 +55,7 @@ const getUsageMessages = (usage) => {
     );
 };
 
-export const generateGvUsageMessages = (
-    usage,
-    itemName,
-    legacyUsage
-): GVMessageProps[] => {
+export const generateGvUsageMessages = (usage, itemName): GVMessageProps[] => {
     if (!usage) {
         return [
             {
@@ -76,9 +72,7 @@ export const generateGvUsageMessages = (
 
     const usageMessages = getUsageMessages(usage);
 
-    const legacyUsageMessages = getUsageMessages(legacyUsage);
-
-    if (usageMessages.length === 0 && legacyUsageMessages.length === 0) {
+    if (usageMessages.length === 0) {
         return [
             {
                 message: `Verdien "${itemName}" er ikke i bruk`,
@@ -93,10 +87,5 @@ export const generateGvUsageMessages = (
             level: 'info',
         },
         ...usageMessages,
-        legacyUsageMessages.length > 0 && {
-            message: `Verdien "${itemName}" er i bruk på følgende sider med gammelt format:`,
-            level: 'warning',
-        },
-        ...legacyUsageMessages,
     ];
 };


### PR DESCRIPTION
Har fjernet denne funksjonaliteten i backend, og sjekket at macroer med "legacy"-formatet (uten spesifisert content-id) ikke eksisterer i prod.