### PR TITLE
Oppdatert dato i nye sidemaler og justering i gamle

### DIFF
--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -37,11 +37,6 @@
 
     &__label {
         margin-top: -0.75rem;
-        letter-spacing: 0.004em;
-
-        .page-modified {
-            color: var(--navds-color-gray-60);
-        }
 
         .divider {
             padding: 0 1rem;

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -37,6 +37,15 @@
 
     &__label {
         margin-top: -0.75rem;
+        letter-spacing: 0.004em;
+
+        .page-modified {
+            color: var(--navds-color-gray-60);
+        }
+
+        .divider {
+            padding: 0 1rem;
+        }
     }
 
     // Following section is a temp fix until we determine responsive breakpoints

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { BEM, classNames } from '../../../../utils/classnames';
 import { PageHeader } from '../page-header/PageHeader';
+import { formatDate } from '../../../../utils/datetime';
 import { ContentType } from '../../../../types/content-props/_content-common';
-import { BodyShort } from '@navikt/ds-react';
+import { BodyLong } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { Illustration } from 'components/_common/illustration/Illustration';
@@ -22,11 +23,9 @@ type Props = {
 };
 
 export const ThemedPageHeader = ({ contentProps }: Props) => {
-    const { __typename: pageType, displayName, data } = contentProps;
+    const { __typename: pageType, displayName, modifiedTime, data } = contentProps;
     const { title, illustration, taxonomy } = data;
-
     const { language } = usePageConfig();
-
     const getSubtitle = () => {
         if (pageType === ContentType.SituationPage) {
             const getTaxonomyLabel = translator('situations', language);
@@ -44,7 +43,7 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
 
         return buildTaxonomyString(taxonomy, language);
     };
-
+    const getDatesLabel = translator('dates', language);
     const getPageTypeClass = (_pageType: ContentType) => {
         if (_pageType === ContentType.EmployerSituationPage || _pageType === ContentType.SituationPage) {
             return 'situation'
@@ -59,11 +58,10 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
         }
 
         return ''
-    }
-
+    };
     const pageTitle = title || displayName;
-
     const subTitle = getSubtitle();
+    const modified = getDatesLabel('updated') + ' ' + formatDate(modifiedTime, language, true);
 
     // This is a temporaty fix, especially for "Arbeidsavklaringspenger".
     // Will work with design to find solution for how long titles and illustration can stack better on mobile.
@@ -89,10 +87,20 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
             />
             <div className={bem('text')}>
                 <PageHeader justify={'left'}>{pageTitle}</PageHeader>
-                {subTitle && (
-                    <BodyShort size="small" className={bem('label')}>
-                        {subTitle.toUpperCase()}
-                    </BodyShort>
+                {(subTitle || modified) && (
+                    <BodyLong size="small" className={bem('label')}>
+                        {subTitle && subTitle.toUpperCase()}
+                        {(subTitle && modified) &&
+                            <span aria-hidden='true'
+                                  className={'page-modified divider'}
+                            >
+                                {'|'}
+                            </span>
+                        }
+                        {modified &&
+                            <span className={'page-modified'}>{modified}</span>
+                        }
+                    </BodyLong>
                 )}
             </div>
         </div>

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -61,7 +61,7 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
     };
     const pageTitle = title || displayName;
     const subTitle = getSubtitle();
-    const modified = getDatesLabel('updated') + ' ' + formatDate(modifiedTime, language, true);
+    const modified = getDatesLabel('lastChanged') + ' ' + formatDate(modifiedTime, language, true);
 
     // This is a temporaty fix, especially for "Arbeidsavklaringspenger".
     // Will work with design to find solution for how long titles and illustration can stack better on mobile.
@@ -70,7 +70,7 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
         .every((word) => word.length < 18);
 
     return (
-        <div
+        <header
             className={classNames(
                 bem(),
                 bem(undefined,getPageTypeClass(pageType))
@@ -92,17 +92,17 @@ export const ThemedPageHeader = ({ contentProps }: Props) => {
                         {subTitle && subTitle.toUpperCase()}
                         {(subTitle && modified) &&
                             <span aria-hidden='true'
-                                  className={'page-modified divider'}
+                                  className={'page-modified-info divider'}
                             >
                                 {'|'}
                             </span>
                         }
                         {modified &&
-                            <span className={'page-modified'}>{modified}</span>
+                            <span className={'page-modified-info'}>{modified}</span>
                         }
                     </BodyLong>
                 )}
             </div>
-        </div>
+        </header>
     );
 };

--- a/src/components/_common/top-container/notifications/Notification.tsx
+++ b/src/components/_common/top-container/notifications/Notification.tsx
@@ -41,7 +41,7 @@ const getDescription = ({ data }: Target) => {
 };
 
 export const Notification = (props: NotificationProps) => {
-    const { data, modifiedTime } = props;
+    const { data, language, modifiedTime } = props;
     if (!data) {
         return null;
     }
@@ -53,7 +53,7 @@ export const Notification = (props: NotificationProps) => {
 
     const description = showDescription && getDescription(target);
     const bem = BEM('notification');
-    const getDateLabel = translator('dates', props.language);
+    const getDateLabel = translator('dates', language);
 
     const IconElement = icon ? (
         <XpImage imageProps={icon} alt={''} />
@@ -78,7 +78,7 @@ export const Notification = (props: NotificationProps) => {
                 {showUpdated && (
                     <BodyShort size="small" className={bem('updated')}>
                         {`${getDateLabel('lastChanged')}: ${formatDate(
-                            modifiedTime
+                            modifiedTime, language, true
                         )}`}
                     </BodyShort>
                 )}

--- a/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { formatDate } from '../../../../utils/datetime';
 import { BodyLong } from '@navikt/ds-react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
-import { translator } from '../../../../translations';
 
 interface Props {
     publish?: {
@@ -19,20 +18,24 @@ const ArtikkelDato = (props: Props) => {
     const { publish, createdTime, modifiedTime, publishLabel, modifiedLabel} = props;
     const publishedDate = publish?.first ?? createdTime;
     const publishedString = `${publishLabel} ${formatDate(
-        publishedDate, language, true
+        publishedDate, language
     )}`;
-    const getStringParts = translator('stringParts', language);
     let modifiedString = '';
     if (new Date(modifiedTime) > new Date(publishedDate)) {
-        const lastModified = `${modifiedLabel} ${formatDate(
-            modifiedTime, language, true
+        modifiedString = ` ${modifiedLabel} ${formatDate(
+            modifiedTime, language
         )}`;
-        modifiedString = ` ${getStringParts('conjunction')} ${lastModified}`;
     }
     return (
         <time dateTime={publishedDate}>
             <BodyLong className={'page-modified-info'}>
-                {publishedString + modifiedString}
+                {publishedString}
+                {modifiedString &&
+                    <>
+                        <span aria-hidden='true'>{' |'}</span>
+                        {modifiedString}
+                    </>
+                }
             </BodyLong>
         </time>
     );

--- a/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
@@ -16,21 +16,21 @@ interface Props {
 
 const ArtikkelDato = (props: Props) => {
     const { language } = usePageConfig();
-    const publisertDato = props.publish?.first ?? props.createdTime;
-    const publishedString = `${props.publishLabel}: ${formatDate(
-        publisertDato, language, true
+    const { publish, createdTime, modifiedTime, publishLabel, modifiedLabel} = props;
+    const publishedDate = publish?.first ?? createdTime;
+    const publishedString = `${publishLabel} ${formatDate(
+        publishedDate, language, true
     )}`;
     const getStringParts = translator('stringParts', language);
     let modifiedString = '';
-    const modifiedDato = props.modifiedTime;
-    if (new Date(modifiedDato) > new Date(publisertDato)) {
-        const lastModified = `${props.modifiedLabel}: ${formatDate(
-            props.modifiedTime, language, true
+    if (new Date(modifiedTime) > new Date(publishedDate)) {
+        const lastModified = `${modifiedLabel} ${formatDate(
+            modifiedTime, language, true
         )}`;
         modifiedString = ` ${getStringParts('conjunction')} ${lastModified}`;
     }
     return (
-        <time dateTime={props.publish?.first}>
+        <time dateTime={publishedDate}>
             <BodyLong className={'page-modified-info'}>
                 {publishedString + modifiedString}
             </BodyLong>

--- a/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { formatDate } from '../../../../utils/datetime';
 import { BodyLong } from '@navikt/ds-react';
+import { usePageConfig } from 'store/hooks/usePageConfig';
+import { translator } from '../../../../translations';
 
 interface Props {
     publish?: {
@@ -13,26 +15,25 @@ interface Props {
 }
 
 const ArtikkelDato = (props: Props) => {
+    const { language } = usePageConfig();
     const publisertDato = props.publish?.first ?? props.createdTime;
-
     const publishedString = `${props.publishLabel}: ${formatDate(
-        publisertDato
+        publisertDato, language, true
     )}`;
-
+    const getStringParts = translator('stringParts', language);
     let modifiedString = '';
     const modifiedDato = props.modifiedTime;
     if (new Date(modifiedDato) > new Date(publisertDato)) {
         const lastModified = `${props.modifiedLabel}: ${formatDate(
-            props.modifiedTime
+            props.modifiedTime, language, true
         )}`;
-        modifiedString = ` | ${lastModified}`;
+        modifiedString = ` ${getStringParts('conjunction')} ${lastModified}`;
     }
-
-    const innhold = publishedString + modifiedString;
-
     return (
         <time dateTime={props.publish?.first}>
-            <BodyLong>{innhold}</BodyLong>
+            <BodyLong className={'page-modified-info'}>
+                {publishedString + modifiedString}
+            </BodyLong>
         </time>
     );
 };

--- a/src/components/parts/_legacy/page-list/PageList.tsx
+++ b/src/components/parts/_legacy/page-list/PageList.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { BEM } from 'utils/classnames';
-import { Heading, BodyLong, Ingress, BodyShort } from '@navikt/ds-react';
-import { formatDate } from 'utils/datetime';
-import { Language, translator } from 'translations';
+import { Heading, BodyLong, Ingress } from '@navikt/ds-react';
+import ArtikkelDato from '../main-article/ArtikkelDato'
+import { translator } from 'translations';
 import { PageListProps } from 'types/content-props/page-list-props';
 import { LenkeInline } from '../../../_common/lenke/LenkeInline';
 import './PageList.less';
 
 const PageList = (props: PageListProps) => {
     const bem = BEM('page-list');
-    const { modifiedTime, createdTime, language } = props;
-    const data = props.data;
+    const { publish, modifiedTime, createdTime, language, data } = props;
+    const getDateLabel = translator('mainArticle', language);
+    const publishLabel = getDateLabel('published');
+    const modifiedLabel = getDateLabel('lastChanged');
     const hideDatesOnPage = data?.hide_date;
     const hideDatesInList = data?.hideSectionContentsDate;
     const orderListByPublishedDate = data?.orderSectionContentsByPublished;
@@ -25,29 +27,29 @@ const PageList = (props: PageListProps) => {
 
     return (
         <div className={bem()}>
-            <Heading level="1" size="2xlarge">
-                {props.displayName}
-            </Heading>
-            <div className={bem('ingress')}>
-                <Ingress>{props.data.ingress}</Ingress>
-            </div>
-            {!hideDatesOnPage && (
-                <CreatedAndModifiedDate
-                    language={language}
-                    className={bem('date')}
-                    createdTime={createdTime}
-                    modifiedTime={modifiedTime}
-                />
-            )}
+            <header>
+                <Heading level="1" size="2xlarge">
+                    {props.displayName}
+                </Heading>
+                <div className={bem('ingress')}>
+                    <Ingress>{data.ingress}</Ingress>
+                </div>
+                {!hideDatesOnPage && (
+                    <ArtikkelDato
+                        publish={publish}
+                        createdTime={createdTime}
+                        modifiedTime={modifiedTime}
+                        publishLabel={publishLabel}
+                        modifiedLabel={modifiedLabel}
+                    />
+                )}
+            </header>
             <div className={bem('list')}>
                 {sectionContents.map((section) => {
-                    const { displayName, _path } = section;
-                    const data = section.data;
+                    const { displayName, _path, publish, modifiedTime, createdTime, data } = section;
                     const ingress = data?.ingress || data?.description;
-                    const modifiedTime = section.modifiedTime;
-                    const createdTime = section.createdTime;
                     return (
-                        <div key={section._path} className={bem('row')}>
+                        <article key={_path} className={bem('row')}>
                             <BodyLong>
                                 <LenkeInline href={_path}>
                                     {displayName}
@@ -59,38 +61,18 @@ const PageList = (props: PageListProps) => {
                                 </div>
                             )}
                             {!hideDatesInList && (
-                                <CreatedAndModifiedDate
-                                    language={language}
-                                    className={bem('date')}
+                                <ArtikkelDato
+                                    publish={publish}
                                     createdTime={createdTime}
                                     modifiedTime={modifiedTime}
+                                    publishLabel={publishLabel}
+                                    modifiedLabel={modifiedLabel}
                                 />
                             )}
-                        </div>
+                        </article>
                     );
                 })}
             </div>
-        </div>
-    );
-};
-
-interface DatesProps {
-    language: Language;
-    className: string;
-    createdTime: string;
-    modifiedTime: string;
-}
-
-const CreatedAndModifiedDate = (props: DatesProps) => {
-    const { createdTime, modifiedTime, language, className } = props;
-    const getDateLabel = translator('dates', language);
-    return (
-        <div className={className}>
-            <BodyShort size="small">
-                {`${getDateLabel('published')}: ${formatDate(createdTime)}`}
-                {' | '}
-                {`${getDateLabel('lastChanged')}: ${formatDate(modifiedTime)}`}
-            </BodyShort>
         </div>
     );
 };

--- a/src/components/parts/_legacy/page-list/PageList.tsx
+++ b/src/components/parts/_legacy/page-list/PageList.tsx
@@ -35,13 +35,15 @@ const PageList = (props: PageListProps) => {
                     <Ingress>{data.ingress}</Ingress>
                 </div>
                 {!hideDatesOnPage && (
-                    <ArtikkelDato
-                        publish={publish}
-                        createdTime={createdTime}
-                        modifiedTime={modifiedTime}
-                        publishLabel={publishLabel}
-                        modifiedLabel={modifiedLabel}
-                    />
+                    <div className={'page-list__date'}>
+                        <ArtikkelDato
+                            publish={publish}
+                            createdTime={createdTime}
+                            modifiedTime={modifiedTime}
+                            publishLabel={publishLabel}
+                            modifiedLabel={modifiedLabel}
+                        />
+                    </div>
                 )}
             </header>
             <div className={bem('list')}>
@@ -61,13 +63,15 @@ const PageList = (props: PageListProps) => {
                                 </div>
                             )}
                             {!hideDatesInList && (
-                                <ArtikkelDato
-                                    publish={publish}
-                                    createdTime={createdTime}
-                                    modifiedTime={modifiedTime}
-                                    publishLabel={publishLabel}
-                                    modifiedLabel={modifiedLabel}
-                                />
+                                <div className={'page-list__date'}>
+                                    <ArtikkelDato
+                                        publish={publish}
+                                        createdTime={createdTime}
+                                        modifiedTime={modifiedTime}
+                                        publishLabel={publishLabel}
+                                        modifiedLabel={modifiedLabel}
+                                    />
+                                </div>
                             )}
                         </article>
                     );

--- a/src/global.less
+++ b/src/global.less
@@ -105,7 +105,7 @@ html {
     width: 1px;
 }
 
-header .page-modified-info {
+header .page-modified-info, article .page-modified-info {
     letter-spacing: 0.004em;
     color: var(--navds-color-gray-60);
 }

--- a/src/global.less
+++ b/src/global.less
@@ -105,6 +105,11 @@ html {
     width: 1px;
 }
 
+header .page-modified-info {
+    letter-spacing: 0.004em;
+    color: var(--navds-color-gray-60);
+}
+
 // Rounds a rem-value to the nearest value which is divisible by
 // the current pixel size, taking global font-size into account
 // This is useful for cases where 1px rounding-errors are noticable

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -40,6 +40,7 @@ export const bundle = {
     dates: {
         lastChanged: 'Sist endret',
         published: 'Publisert',
+        updated: 'Oppdatert'
     },
     linkPanels: {
         label: 'Valgpaneler',

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -38,9 +38,8 @@ export const bundle = {
         error: 'Beklager, det har oppstått en feil i kalkulatoren med følgende feilmelding:',
     },
     dates: {
-        lastChanged: 'Sist endret',
+        lastChanged: 'Oppdatert',
         published: 'Publisert',
-        updated: 'Oppdatert'
     },
     linkPanels: {
         label: 'Valgpaneler',
@@ -61,7 +60,7 @@ export const bundle = {
     },
     mainArticle: {
         facts: 'Fakta',
-        lastChanged: 'Sist endret',
+        lastChanged: 'oppdatert',
         linkedListDescription: 'Kapitler',
         published: 'Publisert',
         tableOfContents: 'Innholdsfortegnelse',

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -60,7 +60,7 @@ export const bundle = {
     },
     mainArticle: {
         facts: 'Fakta',
-        lastChanged: 'oppdatert',
+        lastChanged: 'Sist endret',
         linkedListDescription: 'Kapitler',
         published: 'Publisert',
         tableOfContents: 'Innholdsfortegnelse',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -37,7 +37,7 @@ export const bundle: Translations = {
     },
     mainArticle: {
         facts: 'Facts',
-        lastChanged: 'updated',
+        lastChanged: 'Updated',
         linkedListDescription: 'Chapters',
         published: 'Published',
         tableOfContents: 'Table of contents',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -15,6 +15,7 @@ export const bundle: Translations = {
     dates: {
         published: 'Published',
         lastChanged: 'Updated',
+        updated: 'Updated'
     },
     calculator: {
         calculate: 'Calculate',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -15,7 +15,6 @@ export const bundle: Translations = {
     dates: {
         published: 'Published',
         lastChanged: 'Updated',
-        updated: 'Updated'
     },
     calculator: {
         calculate: 'Calculate',
@@ -38,7 +37,7 @@ export const bundle: Translations = {
     },
     mainArticle: {
         facts: 'Facts',
-        lastChanged: 'Updated',
+        lastChanged: 'updated',
         linkedListDescription: 'Chapters',
         published: 'Published',
         tableOfContents: 'Table of contents',

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -7,10 +7,13 @@ import utc from 'dayjs/plugin/utc';
 dayjs.extend(localizedFormat);
 dayjs.extend(utc);
 
-export const formatDate = (datetime: string, language: string = 'nb') => {
+export const formatDate = (
+    datetime: string,
+    language: string = 'nb',
+    month: boolean = false) => {
     const currentLocale = language === 'en' ? 'en-gb' : 'nb';
     return datetime
-        ? dayjs(datetime).locale(currentLocale).format('L')
+        ? dayjs(datetime).locale(currentLocale).format( month ? 'LL': 'L')
         : datetime;
 };
 


### PR DESCRIPTION
Viser oppdatert dato på livsituasjons- og produktsider.
Justert visning i artikkel, artikelliste og varsler tilsvarende.
Lagt inn språkstøtte (både tekst og datoformat).
https://github.com/navikt/team-navno/issues/141