### PR TITLE
Fikser manglende ingressOverride for kort

### DIFF
--- a/src/components/parts/product-card/ProductCard.tsx
+++ b/src/components/parts/product-card/ProductCard.tsx
@@ -24,9 +24,9 @@ export const ProductCardPart = ({
         );
     }
 
-    const { targetPage, header } = config;
+    const { targetPage, header, ingressOverride } = config;
 
-    const props = getCardProps(targetPage, language);
+    const props = getCardProps(targetPage, language, ingressOverride);
 
     if (!props) {
         return null;

--- a/src/types/component-props/parts/product-card.ts
+++ b/src/types/component-props/parts/product-card.ts
@@ -11,13 +11,12 @@ export type TargetPage = ProductPageProps | SituationPageProps | ToolsPageProps;
 export type ProductTarget = {
     header?: string;
     targetPage: TargetPage;
+    ingressOverride?: string;
 };
 
 export interface ProductCardProps extends PartComponentProps {
     descriptor: PartType.ProductCard;
-    config: {
-        ingressOverride?: string;
-    } & ProductTarget;
+    config: ProductTarget;
 }
 
 export interface ProductCardMiniProps extends PartComponentProps {


### PR DESCRIPTION
Redaktører skal kunne overstyre ingressen i produktkort. Dette fungerer i Content Studio, men frontend tok ikke hensyn til innkomne ingressOverride. Dette fikser feilen.