### PR TITLE
Unngå_at_skjermlesere_leser_title-tagger_fra_svg_filer_Lenkepaneler

### DIFF
--- a/src/components/parts/link-panel/LinkPanelPart.tsx
+++ b/src/components/parts/link-panel/LinkPanelPart.tsx
@@ -52,7 +52,7 @@ export const LinkPanelPart = ({ config }: LinkPanelPartProps) => {
             <div className={bem('innhold')}>
                 <div className={bem('header')}>
                     {icon && (
-                        <div
+                        <div aria-hidden={'true'}
                             className={classNames(
                                 bem('icon'),
                                 selectedVariant === 'verticalWithBgColor' &&


### PR DESCRIPTION
Lagt til aria-hidden. Gjelder ikoner i lenkepaneler.