### PR TITLE
Fjerner FLoC-header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -101,14 +101,5 @@ module.exports = withPlugins([withLess, withImages, withTranspileModules], {
                 },
             ],
         },
-        {
-            source: '/(.*)',
-            headers: [
-                {
-                    key: 'Permissions-Policy',
-                    value: 'interest-cohort=()',
-                },
-            ],
-        },
     ],
 });


### PR DESCRIPTION
Google går ikke videre med FLoC-eksperimentet, så headeren for å blokkere dette kan fjernes.

https://blog.google/products/chrome/get-know-new-topics-api-privacy-sandbox/