### PR TITLE
Bugfixes for ContactOption telefonnummer ++

### DIFF
--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -4,21 +4,21 @@
     // Set a padding with equivalent negative margins to allow focus-highlight
     // to break out of the container
     $outerPadding: 0.6rem;
-    $bottomMargin: 1rem-$outerPadding;
+    $bottomMargin: 1rem - $outerPadding;
     padding: $outerPadding;
     margin: (-$outerPadding) (-$outerPadding) $bottomMargin (-$outerPadding);
     background-color: transparent;
     display: block;
     text-decoration: none;
 
-    &:hover {
-        .title {
-            text-decoration: none;
-        }
-    }
-
     .link {
         &:hover {
+            text-decoration: none;
+
+            .title {
+                text-decoration: none;
+            }
+
             .icon {
                 &.chat {
                     background-image: url('/gfx/chat-filled.svg');

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -6,13 +6,13 @@
     $outerPadding: 0.6rem;
     $bottomMargin: 1rem-$outerPadding;
     padding: $outerPadding;
-    margin: -$outerPadding -$outerPadding $bottomMargin -$outerPadding;
+    margin: (-$outerPadding) (-$outerPadding) $bottomMargin (-$outerPadding);
     background-color: transparent;
     display: block;
     text-decoration: none;
 
     &:hover {
-        .defaultOption__title {
+        .title {
             text-decoration: none;
         }
     }
@@ -70,7 +70,8 @@
             // preload mouseover icons
             position: absolute;
             z-index: -1;
-            content: url('/gfx/chat-filled.svg') url('/gfx/message-filled.svg') url('/gfx/message-phone.svg');
+            content: url('/gfx/chat-filled.svg') url('/gfx/message-filled.svg')
+                url('/gfx/message-phone.svg');
         }
     }
 

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -10,27 +10,26 @@
     background-color: transparent;
     display: block;
     text-decoration: none;
+    width: 100%;
+    border-radius: common.$border-radius-base;
 
-    .link {
-        &:hover {
+    &:hover,
+    &:focus {
+        .title {
             text-decoration: none;
+        }
 
-            .title {
-                text-decoration: none;
+        .icon {
+            &.chat {
+                background-image: url('/gfx/chat-filled.svg');
             }
 
-            .icon {
-                &.chat {
-                    background-image: url('/gfx/chat-filled.svg');
-                }
+            &.write {
+                background-image: url('/gfx/message-filled.svg');
+            }
 
-                &.write {
-                    background-image: url('/gfx/message-filled.svg');
-                }
-
-                &.call {
-                    background-image: url('/gfx/phone-filled.svg');
-                }
+            &.call {
+                background-image: url('/gfx/phone-filled.svg');
             }
         }
     }

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -10,9 +10,9 @@ import { usePageConfig } from 'store/hooks/usePageConfig';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { openChatbot } from '../../../utils/chatbot';
 
-import { BEM, classNames } from 'utils/classnames';
+import { classNames } from 'utils/classnames';
 
-import style from './ContactOption.module.scss'
+import style from './ContactOption.module.scss';
 
 interface DefaultContactProps extends DefaultContactData {
     channel: ChannelType;
@@ -44,19 +44,19 @@ export const DefaultOption = (props: DefaultContactProps) => {
     // In order to open chatbot, onClick is needed instead of href. Therefore
     // return an object which is destructed into Lenkebase with the proper props (href | onClick)
     const getUrlOrClickHandler = (channel: ChannelType) => {
-        if (channel === ChannelType.WRITE) {
+        if (channel === 'write') {
             return {
                 href: url || '/person/kontakt-oss/nb/skriv-til-oss',
             };
         }
 
-        if (channel === ChannelType.CALL) {
+        if (channel === 'call') {
             return {
                 href: 'tel:+4755553333',
             };
         }
 
-        if (channel === ChannelType.CHAT) {
+        if (channel === 'chat') {
             return {
                 href: '#',
                 onClick: openChatbot,
@@ -72,9 +72,7 @@ export const DefaultOption = (props: DefaultContactProps) => {
                 {...getUrlOrClickHandler(channel)}
                 className={style.link}
             >
-                <div
-                    className={classNames(style.icon, style[channel])}
-                />
+                <div className={classNames(style.icon, style[channel])} />
                 <Heading level="2" size="medium" className={style.title}>
                     {getTitle()}
                 </Heading>

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -67,17 +67,15 @@ export const DefaultOption = (props: DefaultContactProps) => {
     };
 
     return (
-        <div className={style.contactOption}>
-            <LenkeBase
-                {...getUrlOrClickHandler(channel)}
-                className={style.link}
-            >
-                <div className={classNames(style.icon, style[channel])} />
-                <Heading level="2" size="medium" className={style.title}>
-                    {getTitle()}
-                </Heading>
-            </LenkeBase>
+        <LenkeBase
+            {...getUrlOrClickHandler(channel)}
+            className={style.contactOption}
+        >
+            <div className={classNames(style.icon, style[channel])} />
+            <Heading level="2" size="medium" className={style.title}>
+                {getTitle()}
+            </Heading>
             <BodyLong className={style.text}>{getIngress()}</BodyLong>
-        </div>
+        </LenkeBase>
     );
 };

--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -1,8 +1,11 @@
 import React, { Fragment } from 'react';
 import { BodyLong, Heading } from '@navikt/ds-react';
-import htmlReactParser, { Element, domToReact } from 'html-react-parser';
+import htmlReactParser, {
+    Element,
+    domToReact,
+    attributesToProps,
+} from 'html-react-parser';
 import { isTag, isText } from 'domhandler';
-import attributesToProps from 'html-react-parser/lib/attributes-to-props';
 import { LenkeInline } from '../lenke/LenkeInline';
 import { getMediaUrl } from '../../../utils/urls';
 import {

--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
 
-import {
-    ChannelType,
-    SharedContactInformationData,
-} from '../../../types/component-props/parts/contact-option';
-
 import { DefaultOption } from 'components/_common/contact-option/DefaultOption';
 import { CallOption } from 'components/_common/contact-option/CallOption';
 import { ContactOptionProps } from '../../../types/component-props/parts/contact-option';
@@ -19,29 +14,31 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
 
     const channelData = config.contactOptions[channel];
 
-    if (channel === ChannelType.CALL && Object.keys(channelData).length === 0) {
-        return (
-            <EditorHelp
-                text={'Velg telefonnummer før denne kontaktkanalen kan vises.'}
-            />
-        );
-    }
+    if (channel === 'call') {
+        const { sharedContactInformation, ingress, phoneNumber } = channelData;
 
-    if (channel === ChannelType.CALL) {
-        const { sharedContactInformation } =
-            channelData as SharedContactInformationData;
-
-        // For backwards compatibility, show default call information
-        // if no sharedContactInformation has been selected.
         if (!sharedContactInformation) {
-            return <DefaultOption {...channelData} channel={channel} />;
+            // For backwards compatibility, show default call information
+            // if no sharedContactInformation has been selected but a legacy
+            // phoneNumber field exists.
+            if (phoneNumber) {
+                return <DefaultOption {...channelData} channel={channel} />;
+            }
+
+            return (
+                <EditorHelp
+                    text={
+                        'Velg telefonnummer før denne kontaktkanalen kan vises.'
+                    }
+                />
+            );
         }
 
         return (
             <CallOption
                 {...sharedContactInformation.data.contactType.telephone}
                 _path={sharedContactInformation._path}
-                ingress={channelData.ingress}
+                ingress={ingress}
             />
         );
     }

--- a/src/components/parts/link-list/LinkList.tsx
+++ b/src/components/parts/link-list/LinkList.tsx
@@ -10,9 +10,10 @@ const bem = BEM('link-list');
 
 const getListComponent = (config: DynamicLinkListProps['config']) => {
     const { title, list, chevron } = config;
-    const { _selected, contentList, linkList } = list;
+    const { _selected } = list;
 
     if (_selected === 'contentList') {
+        const { contentList } = list;
         return (
             <ContentList
                 content={contentList?.target}
@@ -23,6 +24,7 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
     }
 
     if (_selected === 'linkList') {
+        const { linkList } = list;
         const links = linkList?.links?.map(getSelectableLinkProps);
         return (
             <Lenkeliste tittel={title} lenker={links} withChevron={chevron} />

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -15,12 +15,6 @@ const relatedContent: { [key in MenuListItemKey]: string } = {
     [MenuListItemKey.Saksbehandling]: 'Saksbehandling',
     [MenuListItemKey.Selfservice]: 'Selvbetjening',
     [MenuListItemKey.Shortcuts]: 'Snarveier',
-    [MenuListItemKey.AppealRightsLegacy]: 'Klagerettigheter',
-    [MenuListItemKey.FormAndApplicationLegacy]: 'Skjema og søknad',
-    [MenuListItemKey.ProcessTimesLegacy]: 'Saksbehandlingstider',
-    [MenuListItemKey.RelatedInformationLegacy]: 'Relatert innhold',
-    [MenuListItemKey.ReportChangesLegacy]: 'Meld fra om endringer',
-    [MenuListItemKey.RulesAndRegulationsLegacy]: 'Regelverk',
 };
 
 const productTaxonomies: { [key in Taxonomy]: string } = {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -80,12 +80,6 @@ export const bundle: Translations = {
         [MenuListItemKey.Saksbehandling]: 'Procedural',
         [MenuListItemKey.Selfservice]: 'Selfservice',
         [MenuListItemKey.Shortcuts]: 'Shortcuts',
-        [MenuListItemKey.AppealRightsLegacy]: 'Appeal rights',
-        [MenuListItemKey.FormAndApplicationLegacy]: 'Form and application',
-        [MenuListItemKey.ProcessTimesLegacy]: 'Processing times',
-        [MenuListItemKey.RelatedInformationLegacy]: 'Related information',
-        [MenuListItemKey.ReportChangesLegacy]: 'Report changes',
-        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Laws and regulations',
     },
     situations: {
         youMayHaveRightTo: 'You may have right to this',

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -13,11 +13,5 @@ export const bundle: Translations = {
         [MenuListItemKey.ReportChanges]: 'Zgłoś zmiany',
         [MenuListItemKey.RulesAndRegulations]: 'Przepisy',
         [MenuListItemKey.Selfservice]: 'Samoobsługa',
-        [MenuListItemKey.AppealRightsLegacy]: 'Prawo do złożenia odwołania',
-        [MenuListItemKey.FormAndApplicationLegacy]: 'Formularze i wnioski',
-        [MenuListItemKey.ProcessTimesLegacy]: 'Czas rozpatrywania spraw',
-        [MenuListItemKey.RelatedInformationLegacy]: 'Powiązane informacje',
-        [MenuListItemKey.ReportChangesLegacy]: 'Zgłoś zmiany',
-        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Przepisy',
     },
 };

--- a/src/translations/se.ts
+++ b/src/translations/se.ts
@@ -15,12 +15,5 @@ export const bundle: Translations = {
         [MenuListItemKey.Saksbehandling]: 'NAV áššemeannudanáiggit',
         [MenuListItemKey.Selfservice]: 'Ieš-bálvaleapmi',
         [MenuListItemKey.Shortcuts]: 'Njuolggobálgát',
-        [MenuListItemKey.AppealRightsLegacy]: 'Váidinvuoigatvuođat',
-        [MenuListItemKey.FormAndApplicationLegacy]: 'Skovit',
-        [MenuListItemKey.ProcessTimesLegacy]: 'Áššemeannudanáiggit',
-        [MenuListItemKey.RelatedInformationLegacy]:
-            'Dehálaš dieđutdehálaš dieđut',
-        [MenuListItemKey.ReportChangesLegacy]: 'Dieđit daid rievdadusaid',
-        [MenuListItemKey.RulesAndRegulationsLegacy]: 'Njuolggadusat',
     },
 };

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -4,6 +4,7 @@ import { TypoStyle } from '../typo-style';
 import { AnimatedIconsProps } from '../content-props/animated-icons';
 import { Taxonomy } from 'types/taxonomies';
 import { AuthStateType } from '../../store/slices/authState';
+import { EmptyObject, OptionSetSingle } from '../util-types';
 
 export type HeaderWithAnchorMixin = {
     title: string;
@@ -19,11 +20,10 @@ export type ProductDataMixin = {
     externalProductUrl?: string;
 };
 
-export type LinkSelectable = {
-    _selected: 'internal' | 'external';
+export type LinkSelectable = OptionSetSingle<{
     internal: InternalLinkMixin;
     external: ExternalLinkMixin;
-};
+}>;
 
 export type ContentListMixin = {
     target: ContentListProps;
@@ -69,21 +69,22 @@ export type LayoutCommonConfigMixin = Partial<
         marginTop: number;
         marginBottom: number;
         bgColor: ColorMixin;
-        paddingSides: {
-            _selected: 'standard' | 'fullWidth' | 'custom';
-            custom?: {
+        paddingSides: OptionSetSingle<{
+            fullWidth: EmptyObject;
+            standard: EmptyObject;
+            custom: {
                 remValue: number;
             };
-        };
+        }>;
     } & RenderOnAuthStateMixin
 >;
 
 export type HeaderCommonConfig = {
     justify: 'left' | 'center' | 'right';
-    typo: {
-        _selected: 'default' | 'custom';
+    typo: OptionSetSingle<{
+        default: EmptyObject;
         custom: {
             typo: TypoStyle;
         };
-    };
+    }>;
 };

--- a/src/types/component-props/parts/contact-option.ts
+++ b/src/types/component-props/parts/contact-option.ts
@@ -1,12 +1,19 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
 import { RenderOnAuthStateMixin } from '../_mixins';
+import { OptionSetSingle } from '../../util-types';
 
-export enum ChannelType {
-    CHAT = 'chat',
-    WRITE = 'write',
-    CALL = 'call',
+interface LegacyCall {
+    phoneNumber?: string;
 }
+
+interface Options {
+    chat: DefaultContactData;
+    write: DefaultContactData;
+    call: SharedContactInformationData & LegacyCall;
+}
+
+export type ChannelType = keyof Options;
 
 export interface OpeningHour {
     status: string;
@@ -15,6 +22,7 @@ export interface OpeningHour {
     dayName?: string;
     date?: string;
 }
+
 export interface DefaultContactData {
     ingress?: string;
     title?: string;
@@ -31,6 +39,7 @@ export interface SharedContactInformationData extends DefaultContactData {
         };
     };
 }
+
 export interface TelephoneData {
     phoneNumber?: string;
     title?: string;
@@ -52,12 +61,6 @@ export interface TelephoneData {
 export interface ContactOptionProps extends PartComponentProps {
     descriptor: PartType.ContactOption;
     config: {
-        contactOptions: {
-            _selected: ChannelType;
-        } & {
-            chat: DefaultContactData;
-            write: DefaultContactData;
-            call: SharedContactInformationData;
-        };
+        contactOptions: OptionSetSingle<Options>;
     } & RenderOnAuthStateMixin;
 }

--- a/src/types/component-props/parts/link-list.ts
+++ b/src/types/component-props/parts/link-list.ts
@@ -6,19 +6,19 @@ import {
     LinkSelectable,
     RenderOnAuthStateMixin,
 } from '../_mixins';
+import { OptionSetSingle } from '../../util-types';
 
 export interface DynamicLinkListProps extends PartComponentProps {
     descriptor: PartType.LinkList;
     config: {
         title?: string;
         chevron?: boolean;
-        list: {
-            _selected: 'contentList' | 'linkList';
+        list: OptionSetSingle<{
             contentList: ContentListMixin;
             linkList: {
                 links: LinkSelectable[];
             };
-        };
+        }>;
     } & ExpandableMixin &
         RenderOnAuthStateMixin;
 }

--- a/src/types/component-props/parts/link-panel.ts
+++ b/src/types/component-props/parts/link-panel.ts
@@ -6,19 +6,18 @@ import {
     RenderOnAuthStateMixin,
 } from '../_mixins';
 import { XpImageProps } from '../../media';
-
-type Variant = 'vertical' | 'verticalWithBgColor';
+import { EmptyObject, OptionSetSingle } from '../../util-types';
 
 type LinkPanelConfig = {
     background: XpImageProps;
     icon: XpImageProps;
-    variant: {
-        _selected: Variant;
+    variant: OptionSetSingle<{
+        vertical: EmptyObject;
         verticalWithBgColor: {
             iconBg: ColorMixin;
             iconJustify: 'flex-start' | 'center' | 'flex-end';
         };
-    };
+    }>;
 } & LinkWithIngressMixin &
     RenderOnAuthStateMixin;
 

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -33,6 +33,5 @@ export type MainArticleData = Partial<{
 
 export interface MainArticleProps extends ContentProps {
     __typename: ContentType.MainArticle;
-    children?: MainArticleChapterProps[]; // TODO: remove after backend chapters-update
     data: MainArticleData;
 }

--- a/src/types/menu-list-items.ts
+++ b/src/types/menu-list-items.ts
@@ -1,3 +1,5 @@
+import { OptionSetMulti } from './util-types';
+
 export interface LinkItem {
     links?: {
         text: string;
@@ -5,7 +7,6 @@ export interface LinkItem {
     }[];
 }
 
-// TODO: fjern legacy når XP er oppdatert
 export enum MenuListItemKey {
     Selfservice = 'selfservice',
     FormAndApplication = 'form_and_application',
@@ -19,14 +20,8 @@ export enum MenuListItemKey {
     RulesAndRegulations = 'rules_and_regulations',
     Saksbehandling = 'saksbehandling',
     Shortcuts = 'shortcuts',
-    FormAndApplicationLegacy = 'formAndApplication',
-    ProcessTimesLegacy = 'processTimes',
-    RelatedInformationLegacy = 'relatedInformation',
-    ReportChangesLegacy = 'reportChanges',
-    AppealRightsLegacy = 'appealRights',
-    RulesAndRegulationsLegacy = 'rulesAndRegulations',
 }
 
-export type MenuListItem = {
+export type MenuListItem = OptionSetMulti<{
     [key in MenuListItemKey]: LinkItem;
-} & { _selected: MenuListItemKey[] };
+}>;

--- a/src/types/util-types.ts
+++ b/src/types/util-types.ts
@@ -1,3 +1,18 @@
 export type DeepPartial<T> = {
     [P in keyof T]?: DeepPartial<T[P]>;
 };
+
+export type OptionSetSingle<
+    Options,
+    Selected extends keyof Options = keyof Options
+> = Selected extends keyof Options
+    ? {
+          _selected: Selected;
+      } & { [Key in Selected]: Options[Key] }
+    : never;
+
+export type OptionSetMulti<Options> = {
+    _selected: Array<keyof Options>;
+} & { [Key in keyof Options]: Options[Key] };
+
+export type EmptyObject = Record<string, never>;

--- a/src/utils/links-from-content.ts
+++ b/src/utils/links-from-content.ts
@@ -32,9 +32,11 @@ export const getSelectableLinkProps = (link: LinkSelectable): LinkProps => {
         return invalidLinkProps;
     }
 
-    const { _selected, external, internal } = link;
+    const { _selected } = link;
 
     if (_selected === 'internal') {
+        const { internal } = link;
+
         if (!internal?.target) {
             return invalidLinkProps;
         }
@@ -46,6 +48,8 @@ export const getSelectableLinkProps = (link: LinkSelectable): LinkProps => {
     }
 
     if (_selected === 'external') {
+        const { external } = link;
+
         if (!external) {
             return invalidLinkProps;
         }


### PR DESCRIPTION
- Fikser vising av telefonnummer i ContactOption parts som ikke er oppdatert til nytt system med gjenbrukbar kontakt-info.
- Fikser noen styling-bugs
- Generiske typer for OptionSets fra XP
- Fjerner legacy-felter som ikke er i bruk