### PR TITLE
Mal for Temaartikkel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "nav-enonicxp-frontend",
             "version": "1.2.1",
             "dependencies": {
-                "@navikt/ds-css": "^0.12.14",
+                "@navikt/ds-css": "^0.15.3",
                 "@navikt/ds-icons": "^0.7.3",
                 "@navikt/ds-react": "^0.14.15",
                 "@navikt/ds-tokens": "^0.7.1",
@@ -519,9 +519,9 @@
             }
         },
         "node_modules/@navikt/ds-css": {
-            "version": "0.12.14",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/0.12.14/eddf4260846dfc796969d1f49b4e9a5c57a5885be5581cf866c0473fea805515",
-            "integrity": "sha512-ew7ROTVVR1W6DS2hhHv2bQ/FBUD6/d0scjq7io/bhTfhNv/SdqIpJmfjdXW5aQHScLHxx/nfEaIufpVorxrQ0w==",
+            "version": "0.15.3",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/0.15.3/83c6fbcf31e67924d806bbcc2acd2a9222a71f3a1b15af75b300e7c02c8752a9",
+            "integrity": "sha512-/BFw77BnbjEl3yL45hO5H0Z8bgDLMnY5ty//aGpk+Jy//1Gm5WlF7JvWSlIu1/hDj6eeT4zwRdXJVO6pFkHCFA==",
             "license": "MIT"
         },
         "node_modules/@navikt/ds-icons": {
@@ -8165,9 +8165,9 @@
             }
         },
         "@navikt/ds-css": {
-            "version": "0.12.14",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/0.12.14/eddf4260846dfc796969d1f49b4e9a5c57a5885be5581cf866c0473fea805515",
-            "integrity": "sha512-ew7ROTVVR1W6DS2hhHv2bQ/FBUD6/d0scjq7io/bhTfhNv/SdqIpJmfjdXW5aQHScLHxx/nfEaIufpVorxrQ0w=="
+            "version": "0.15.3",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/0.15.3/83c6fbcf31e67924d806bbcc2acd2a9222a71f3a1b15af75b300e7c02c8752a9",
+            "integrity": "sha512-/BFw77BnbjEl3yL45hO5H0Z8bgDLMnY5ty//aGpk+Jy//1Gm5WlF7JvWSlIu1/hDj6eeT4zwRdXJVO6pFkHCFA=="
         },
         "@navikt/ds-icons": {
             "version": "0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@navikt/ds-css": "^0.15.3",
                 "@navikt/ds-icons": "^0.7.3",
                 "@navikt/ds-react": "^0.14.15",
-                "@navikt/ds-tokens": "^0.7.1",
+                "@navikt/ds-tokens": "^0.8.1",
                 "@navikt/fnrvalidator": "^1.1.4",
                 "@navikt/nav-dekoratoren-moduler": "^1.6.10",
                 "@reduxjs/toolkit": "^1.7.1",
@@ -559,9 +559,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "0.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.7.1/84f978b0f8a62579d9f336b9cb6da3c2719d1341f7e1a5a7254eaaa613a0e51f",
-            "integrity": "sha512-qdpqFZdNplVrQYHg5u4DSEISNAVOs/0YfrPYNTeyMBDnmqjlPpk6VL2i5lgiNdXYVNqxx+V5Q7RF9RTuHL0QUA==",
+            "version": "0.8.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.8.1/a329368f148e0a3cc3856583c4e1d77b2b0939b25861afe2d10cfea2388e3c73",
+            "integrity": "sha512-W1uc3nj9xcDu/YeWbWK4TRSHwF9UA9NjsK1GTD2RPehw85MT8hPMoSxeJ6zKjaRzc8PJFSfTOMBgt6qP3s4xeQ==",
             "license": "MIT"
         },
         "node_modules/@navikt/fnrvalidator": {
@@ -8194,9 +8194,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "0.7.1",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.7.1/84f978b0f8a62579d9f336b9cb6da3c2719d1341f7e1a5a7254eaaa613a0e51f",
-            "integrity": "sha512-qdpqFZdNplVrQYHg5u4DSEISNAVOs/0YfrPYNTeyMBDnmqjlPpk6VL2i5lgiNdXYVNqxx+V5Q7RF9RTuHL0QUA=="
+            "version": "0.8.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/0.8.1/a329368f148e0a3cc3856583c4e1d77b2b0939b25861afe2d10cfea2388e3c73",
+            "integrity": "sha512-W1uc3nj9xcDu/YeWbWK4TRSHwF9UA9NjsK1GTD2RPehw85MT8hPMoSxeJ6zKjaRzc8PJFSfTOMBgt6qP3s4xeQ=="
         },
         "@navikt/fnrvalidator": {
             "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "deploy-q6": "npm run deploy -- deploy.q6.yml"
     },
     "dependencies": {
-        "@navikt/ds-css": "^0.12.14",
+        "@navikt/ds-css": "^0.15.3",
         "@navikt/ds-icons": "^0.7.3",
         "@navikt/ds-react": "^0.14.15",
         "@navikt/ds-tokens": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@navikt/ds-css": "^0.15.3",
         "@navikt/ds-icons": "^0.7.3",
         "@navikt/ds-react": "^0.14.15",
-        "@navikt/ds-tokens": "^0.7.1",
+        "@navikt/ds-tokens": "^0.8.1",
         "@navikt/fnrvalidator": "^1.1.4",
         "@navikt/nav-dekoratoren-moduler": "^1.6.10",
         "@reduxjs/toolkit": "^1.7.1",

--- a/src/common.scss
+++ b/src/common.scss
@@ -34,10 +34,48 @@ $border-radius-large: 6px;
 }
 
 @function withUnit($value, $unit) {
-    $result: "#{$value}#{unit}"
+    $result: '#{$value}#{unit}';
 }
 
 @function px-to-rem($px) {
     $rem: withUnit($px * $pixel-size-rem, 'rem');
 }
 
+// This is an override mixin specific for product and livesituation pages.
+// To be removed when DS has updated design packages.
+@mixin product-mixins() {
+    // h3 signifies a new "sub chapter" within a section.
+    // should have extra spacing above content, but only if
+    // not the topmost element within region. Except first-child.
+    .part {
+        .html-area,
+        &__dynamic-header {
+            h3 {
+                margin-top: 2.75rem;
+            }
+        }
+    }
+
+    .region__content {
+        > :first-child {
+            h3:first-child {
+                margin-top: 0;
+            }
+        }
+    }
+
+    // The very last child of the very last part or fragment
+    // within a region__content should not have margin-bottom.
+    // Reason for select all (">"): fragments are inserted without a class,
+    // so just select any child that may contain any of the elements.
+    .region__content {
+        > :last-child {
+            .card:last-child,
+            .calculator,
+            ul:last-child,
+            p:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -13,12 +13,13 @@ import { TemplatePage } from './pages/template-page/TemplatePage';
 import { make404Props } from '../utils/make-error-props';
 import { SituationPage } from './pages/situation-page/SituationPage';
 import { GuidePage } from './pages/guide-page/GuidePage';
+import { ThemedArticlePage } from './pages/themed-article-page/ThemedArticlePage';
 import { ProductPage } from './pages/product-page/ProductPage';
 import { GlobalValuesPage } from './pages/global-values-page/GlobalValuesPage';
 
-const contentToReactComponent: Partial<
-    { [key in ContentType]: React.FunctionComponent<ContentProps> }
-> = {
+const contentToReactComponent: Partial<{
+    [key in ContentType]: React.FunctionComponent<ContentProps>;
+}> = {
     [ContentType.Error]: ErrorPage,
     [ContentType.LargeTable]: LargeTablePage,
     [ContentType.Fragment]: FragmentPage,
@@ -31,6 +32,7 @@ const contentToReactComponent: Partial<
     [ContentType.EmployerSituationPage]: SituationPage,
     [ContentType.ProductPage]: ProductPage,
     [ContentType.GuidePage]: GuidePage,
+    [ContentType.ThemedArticlePage]: ThemedArticlePage,
 
     [ContentType.DynamicPage]: DynamicPage,
     [ContentType.MainArticle]: DynamicPage,

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -41,7 +41,7 @@
             }
 
             .card__themed-article {
-                background-color: @navds-global-color-gray-200;
+                background-color: @navds-global-color-gray-300;
             }
 
             .card__title,

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -26,20 +26,23 @@
             height: 100%;
         }
 
-        
         @media (hover: hover) {
-            &:hover, &:focus-visible {
-
+            &:hover,
+            &:focus-visible {
                 .card__situation {
                     background-color: @navds-global-color-orange-200;
                 }
-        
+
                 .card__product {
                     background-color: @navds-global-color-green-200;
                 }
-        
+
                 .card__tool {
                     background-color: @navds-global-color-deepblue-200;
+                }
+
+                .card__themed-article {
+                    background-color: #707070;
                 }
 
                 .card__title,
@@ -51,7 +54,8 @@
             }
         }
 
-        &:focus-visible, &:active {
+        &:focus-visible,
+        &:active {
             .card__bed {
                 position: relative;
                 box-shadow: 0 0 0 3px #00347d;
@@ -66,7 +70,7 @@
                     top: 0;
                 }
             }
-            
+
             .card__bed.card__large {
                 &:after {
                     box-shadow: 0 0 0 4px #ffffff;
@@ -76,8 +80,9 @@
                     margin: 4px;
                 }
             }
-            
-            .card__bed.card__mini, .card__bed.card__micro {
+
+            .card__bed.card__mini,
+            .card__bed.card__micro {
                 &:after {
                     box-shadow: 0 0 0 2px #ffffff;
                     height: calc(100% - 2px);
@@ -85,13 +90,13 @@
                     width: calc(100% - 2px);
                 }
             }
-            
+
             .card__bed.card__mini {
                 &:after {
                     border-radius: 6px;
                 }
             }
-            
+
             .card__bed.card__micro {
                 &:after {
                     border-radius: 16px;

--- a/src/components/_common/card/Card.less
+++ b/src/components/_common/card/Card.less
@@ -42,7 +42,7 @@
                 }
 
                 .card__themed-article {
-                    background-color: #707070;
+                    background-color: @navds-global-color-gray-200;
                 }
 
                 .card__title,

--- a/src/components/_common/card/LargeCard.tsx
+++ b/src/components/_common/card/LargeCard.tsx
@@ -27,7 +27,9 @@ export const LargeCard = (props: StortKortProps) => {
 
     const hasIllustration =
         illustration &&
-        (type === CardType.Product || type === CardType.Situation);
+        (type === CardType.Product ||
+            type === CardType.Situation ||
+            type === CardType.ThemedArticle);
 
     const { isHovering, cardInteractionHandler } = useCardState();
     const { pageConfig } = usePageConfig();

--- a/src/components/_common/card/MicroCard.less
+++ b/src/components/_common/card/MicroCard.less
@@ -8,7 +8,7 @@
 
     &__micro {
         border-radius: 16px;
-        border: 1px solid #B0B0B0;
+        border: 1px solid #b0b0b0;
         box-shadow: 0 0 0 3px @navds-semantic-color-link;
         color: @navds-global-color-gray-900;
         display: flex;
@@ -18,20 +18,25 @@
         margin: 0 0.5rem 0 0;
         padding: 0 0.5rem;
         position: relative;
-        
+
         &:not(:hover):not(:active) {
-            box-shadow: 0px 1px 3px rgba(38, 38, 38, 0.2), 0px 1px 6px rgba(0, 0, 0, 0.14), 0px 2px 8px rgba(38, 38, 38, 0.12);
-        }
-        
-        &:hover {
-            border: 1px solid transparent;
-            box-shadow: 0px 1px 3px rgba(38, 38, 38, 0.2), 0px 1px 6px rgba(0, 0, 0, 0.14), 0px 2px 8px rgba(38, 38, 38, 0.12);
+            box-shadow: 0px 1px 3px rgba(38, 38, 38, 0.2),
+                0px 1px 6px rgba(0, 0, 0, 0.14),
+                0px 2px 8px rgba(38, 38, 38, 0.12);
         }
 
-        &:hover, &:focus-visible {
+        &:hover {
+            border: 1px solid transparent;
+            box-shadow: 0px 1px 3px rgba(38, 38, 38, 0.2),
+                0px 1px 6px rgba(0, 0, 0, 0.14),
+                0px 2px 8px rgba(38, 38, 38, 0.12);
+        }
+
+        &:hover,
+        &:focus-visible {
             border: 1px solid transparent;
         }
-        
+
         &:before {
             content: '';
             align-self: center;
@@ -48,16 +53,21 @@
                 background-color: @navds-global-color-orange-500;
             }
         }
-        
+
         &.card__product {
             &:before {
                 background-color: @navds-global-color-green-500;
             }
         }
-        
+
         &.card__tool {
             &:before {
                 background-color: @navds-global-color-deepblue-500;
+            }
+        }
+        &.card__themed-article {
+            &:before {
+                background-color: @navds-global-color-gray-600;
             }
         }
     }

--- a/src/components/_common/card/card-utils.ts
+++ b/src/components/_common/card/card-utils.ts
@@ -8,7 +8,7 @@ import {
     ToolsPageProps,
 } from '../../../types/content-props/dynamic-page-props';
 import { Language } from '../../../translations';
-import { buildTaxonomyString } from 'utils/string';
+import { getTranslatedTaxonomies, joinWithConjunction } from 'utils/string';
 
 type CardTargetProps = ProductPageProps | SituationPageProps | ToolsPageProps;
 
@@ -47,14 +47,15 @@ export const getCardProps = (
         text: cardTitle,
     };
 
-    const category = buildTaxonomyString(taxonomy, language);
+    const categories = getTranslatedTaxonomies(taxonomy, language);
+    const categoryString = joinWithConjunction(taxonomy, language);
     const description = ingressOverride || ingress;
 
     return {
         type: cardType,
         link,
         description,
-        category,
+        category: categoryString,
         illustration,
     };
 };

--- a/src/components/_common/card/card-utils.ts
+++ b/src/components/_common/card/card-utils.ts
@@ -24,6 +24,7 @@ const cardTypeMap = {
     [ContentType.ProductPage]: CardType.Product,
     [ContentType.SituationPage]: CardType.Situation,
     [ContentType.ToolsPage]: CardType.Tool,
+    [ContentType.ThemedArticlePage]: CardType.ThemedArticle,
 };
 
 export const getCardProps = (
@@ -36,7 +37,14 @@ export const getCardProps = (
     }
 
     const { data, __typename, _path, displayName } = content;
-    const { title, ingress, illustration, taxonomy, externalProductUrl } = data;
+    const {
+        title,
+        ingress,
+        illustration,
+        taxonomy,
+        externalProductUrl,
+        customCategory,
+    } = data;
 
     const cardType = cardTypeMap[__typename];
     const cardUrl = externalProductUrl || _path;
@@ -47,8 +55,12 @@ export const getCardProps = (
         text: cardTitle,
     };
 
-    const categories = getTranslatedTaxonomies(taxonomy, language);
-    const categoryString = joinWithConjunction(taxonomy, language);
+    const categories = [
+        ...getTranslatedTaxonomies(taxonomy, language),
+        customCategory,
+    ].filter((category) => !!category);
+
+    const categoryString = joinWithConjunction(categories, language);
     const description = ingressOverride || ingress;
 
     return {

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -24,7 +24,7 @@
     }
 
     &--themedpage {
-        box-shadow: 0 -4px 0 @navds-global-color-gray-800 inset;
+        box-shadow: 0 -4px 0 @navds-global-color-gray-600 inset;
     }
 
     &__illustration {

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -23,12 +23,15 @@
         box-shadow: 0 -4px 0 @guidePageColor inset;
     }
 
+    &--themedpage {
+        box-shadow: 0 -4px 0 #707070 inset;
+    }
+
     &__illustration {
         width: #px-to-rem(80) [];
         height: #px-to-rem(80) [];
         margin-right: 2rem;
         pointer-events: none;
-
     }
 
     &__text {
@@ -45,8 +48,9 @@
         }
     }
 
-    &__tagline-label.navds-body-short, &__modified-label.navds-body-short {
-        font-size: #px-to-rem(14) [];;
+    &__tagline-label.navds-body-short,
+    &__modified-label.navds-body-short {
+        font-size: #px-to-rem(14) [];
     }
 
     &__tagline-label.navds-body-short {

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.less
@@ -24,7 +24,7 @@
     }
 
     &--themedpage {
-        box-shadow: 0 -4px 0 #707070 inset;
+        box-shadow: 0 -4px 0 @navds-global-color-gray-800 inset;
     }
 
     &__illustration {

--- a/src/components/_common/top-container/TopContainer.tsx
+++ b/src/components/_common/top-container/TopContainer.tsx
@@ -16,6 +16,7 @@ export const contentTypesWithWhiteHeader = {
     [ContentType.SituationPage]: true,
     [ContentType.GuidePage]: true,
     [ContentType.EmployerSituationPage]: true,
+    [ContentType.ThemedArticlePage]: true,
 };
 
 const hideNotificationsForContentTypes: { [key in ContentType]?: boolean } = {

--- a/src/components/pages/themed-article-page/ThemedArticlePage.module.scss
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.module.scss
@@ -1,7 +1,5 @@
 @use '../../../common' as common;
 
-$productPageColor: common.$navds-global-color-green-200;
-
 .themed-article-page {
     display: flex;
     flex-direction: column;

--- a/src/components/pages/themed-article-page/ThemedArticlePage.module.scss
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.module.scss
@@ -1,0 +1,27 @@
+@use '../../../common' as common;
+
+$productPageColor: common.$navds-global-color-green-200;
+
+.themed-article-page {
+    display: flex;
+    flex-direction: column;
+
+    .content {
+        align-self: center;
+        width: 100%;
+
+        // Break out of the global app padding for better screen-width usage
+        // on narrower screens
+        @media (common.$mq-screen-tablet-and-desktop) {
+            margin-left: -(common.$padding-sides-tablet);
+            margin-right: -(common.$padding-sides-tablet);
+        }
+
+        @media (common.$mq-screen-desktop) {
+            margin-left: -(common.$padding-sides-desktop);
+            margin-right: -(common.$padding-sides-desktop);
+        }
+    }
+
+    @include common.product-mixins;
+}

--- a/src/components/pages/themed-article-page/ThemedArticlePage.tsx
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ComponentMapper } from '../../ComponentMapper';
+import { ThemedArticlePageProps } from '../../../types/content-props/dynamic-page-props';
+import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { BEM } from '../../../utils/classnames';
+
+import style from './ThemedArticlePage.module.scss';
+
+export const ThemedArticlePage = (props: ThemedArticlePageProps) => {
+    return (
+        <div className={style['themed-article-page']}>
+            <ThemedPageHeader contentProps={props} />
+            <div className={style.content}>
+                <ComponentMapper
+                    componentProps={props.page}
+                    pageProps={props}
+                />
+            </div>
+        </div>
+    );
+};

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -3,6 +3,7 @@ export enum CardType {
     Situation = 'situation',
     Tool = 'tool',
     Provider = 'provider',
+    ThemedArticle = 'themed-article',
 }
 
 export enum CardSize {

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -16,6 +16,7 @@ export type ProductDataMixin = {
     title: string;
     ingress?: string;
     taxonomy?: Taxonomy[];
+    customCategory?: string;
     illustration: AnimatedIconsProps;
     externalProductUrl?: string;
 };

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -49,6 +49,7 @@ export enum ContentType {
     GlobalValues = 'no_nav_navno_GlobalValueSet',
     ProductPage = 'no_nav_navno_ContentPageWithSidemenus',
     GuidePage = 'no_nav_navno_GuidePage',
+    ThemedArticlePage = 'no_nav_navno_ThemedArticlePage',
     SituationPage = 'no_nav_navno_SituationPage',
     EmployerSituationPage = 'no_nav_navno_EmployerSituationPage',
     AnimatedIcons = 'no_nav_navno_AnimatedIcons',

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -16,6 +16,7 @@ export type DynamicPageData = Partial<{
     ContentDecoratorToggles;
 
 export type ProductPageData = ProductDataMixin & DynamicPageData;
+export type ThemedArticlePageData = ProductDataMixin & DynamicPageData;
 export type GuidePageData = ProductDataMixin & DynamicPageData;
 export type SituationPageData = ProductDataMixin & DynamicPageData;
 export type ToolsPageData = ProductDataMixin & DynamicPageData;
@@ -23,6 +24,11 @@ export type ToolsPageData = ProductDataMixin & DynamicPageData;
 export interface ProductPageProps extends ContentProps {
     __typename: ContentType.ProductPage;
     data: ProductPageData;
+}
+
+export interface ThemedArticlePageProps extends ContentProps {
+    __typename: ContentType.ThemedArticlePage;
+    data: ThemedArticlePageData;
 }
 
 export interface GuidePageProps extends ContentProps {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -14,19 +14,19 @@ export const joinWithConjunction = (
     return joinableArray.join(', ').replace(/, ([^,]*)$/, ` ${conjunction} $1`);
 };
 
-export const buildTaxonomyString = (
+export const getTranslatedTaxonomies = (
     taxonomies: Taxonomy[],
     language: Language
-): string => {
+): string[] => {
     if (!Array.isArray(taxonomies)) {
-        return '';
+        return [];
     }
     const getTaxonomyLabel = translator('productTaxonomies', language);
     const taxonomyLabels = taxonomies.map((taxonomy) => {
         return getTaxonomyLabel(taxonomy) || '';
     });
 
-    return joinWithConjunction(taxonomyLabels, language);
+    return taxonomyLabels;
 };
 
 export const numberToFormattedValue = (


### PR DESCRIPTION
- Lar redaktørene opprette Temaartikler og generelle artikler som ikke nødvendigvis er knyttet direkte til en produktside, via en egen mal.
- Støtter også å legge inn Temaartikler som kort på andre sidemaler.
- Oppgraderer ds-css for riktige farge-tokens.