### PR TITLE
Fjerner livssituasjonssidemal for arbeidsgiver

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -29,7 +29,6 @@ const contentToReactComponent: Partial<{
     [ContentType.ContactInformationPage]: ContactInformationPage,
 
     [ContentType.SituationPage]: SituationPage,
-    [ContentType.EmployerSituationPage]: SituationPage,
     [ContentType.ProductPage]: ProductPage,
     [ContentType.GuidePage]: GuidePage,
     [ContentType.ThemedArticlePage]: ThemedArticlePage,

--- a/src/components/_common/top-container/TopContainer.tsx
+++ b/src/components/_common/top-container/TopContainer.tsx
@@ -15,7 +15,6 @@ export const contentTypesWithWhiteHeader = {
     [ContentType.ProductPage]: true,
     [ContentType.SituationPage]: true,
     [ContentType.GuidePage]: true,
-    [ContentType.EmployerSituationPage]: true,
     [ContentType.ThemedArticlePage]: true,
 };
 

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -51,7 +51,6 @@ export enum ContentType {
     GuidePage = 'no_nav_navno_GuidePage',
     ThemedArticlePage = 'no_nav_navno_ThemedArticlePage',
     SituationPage = 'no_nav_navno_SituationPage',
-    EmployerSituationPage = 'no_nav_navno_EmployerSituationPage',
     AnimatedIcons = 'no_nav_navno_AnimatedIcons',
     ToolsPage = 'no_nav_navno_ToolsPage',
     Calculator = 'no_nav_navno_Calculator',

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -36,7 +36,7 @@ export interface GuidePageProps extends ContentProps {
     data: GuidePageData;
 }
 export interface SituationPageProps extends ContentProps {
-    __typename: ContentType.SituationPage | ContentType.EmployerSituationPage;
+    __typename: ContentType.SituationPage;
     data: SituationPageData;
 }
 

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -7,7 +7,6 @@ export const getTargetIfRedirect = (contentData: ContentProps) => {
     switch (contentData?.__typename) {
         case ContentType.SituationPage:
         case ContentType.ProductPage:
-        case ContentType.EmployerSituationPage:
         case ContentType.ToolsPage:
             return !contentData.isDraft
                 ? getEnvUrl(


### PR DESCRIPTION
- Alle sider som bruker denne malen i Enonic er slettet.
- Innholdet er flyttet til Livssituasjonsmalen hvor målgruppen er satt til arbeidsgiver istedet.