### PR TITLE
Quickfixes for mindre belastning på backend ved deploy

### DIFF
--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -15,7 +15,7 @@ spec:
     initialDelay: 10
   readiness:
     path: /api/internal/isReady
-    initialDelay: 10
+    initialDelay: 60
   prometheus:
     enabled: true
     path: /api/internal/metrics

--- a/src/utils/fetch-content.ts
+++ b/src/utils/fetch-content.ts
@@ -14,7 +14,7 @@ export type XpResponseProps = ContentProps | MediaProps;
 // itself not being found (ie if something is wrong with the nav.no app)
 const contentNotFoundMessage = 'Site path not found';
 
-const fetchTimeoutMs = 15000;
+const fetchTimeoutMs = 60000;
 
 const fetchSiteContent = async (
     idOrPath: string,


### PR DESCRIPTION
- Øker readiness delay til 60 sec. Dette vil føre til en >60 sec periode mellom hver nye pod som får trafikk. Nye podder med blank cache vil dermed dele belastningen med eksisterende podder som allerede har en populert cache i en lengre periode.
- Øker fetch-timeout til 60 sec.