### PR TITLE
Støtter nye content-typer i main-article-chapter (++)

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -16,6 +16,7 @@ import { GuidePage } from './pages/guide-page/GuidePage';
 import { ThemedArticlePage } from './pages/themed-article-page/ThemedArticlePage';
 import { ProductPage } from './pages/product-page/ProductPage';
 import { GlobalValuesPage } from './pages/global-values-page/GlobalValuesPage';
+import { MainArticleChapterPage } from './pages/main-article-chapter-page/MainArticleChapterPage';
 
 const contentToReactComponent: Partial<{
     [key in ContentType]: React.FunctionComponent<ContentProps>;
@@ -35,7 +36,7 @@ const contentToReactComponent: Partial<{
 
     [ContentType.DynamicPage]: DynamicPage,
     [ContentType.MainArticle]: DynamicPage,
-    [ContentType.MainArticleChapter]: DynamicPage,
+    [ContentType.MainArticleChapter]: MainArticleChapterPage,
     [ContentType.OfficeInformation]: DynamicPage,
     [ContentType.PageList]: DynamicPage,
     [ContentType.SectionPage]: DynamicPage,

--- a/src/components/macros/infoboks/MacroInfoBoks.tsx
+++ b/src/components/macros/infoboks/MacroInfoBoks.tsx
@@ -9,7 +9,7 @@ export const MacroInfoBoks = ({ config }: MacroInfoBoksProps) => {
         return null;
     }
 
-    // TODO: this should only be plain text, but it seems to be used
+    // This should only be plain text, but it seems to be used
     // with HTML by some editors
     const { infoBoks } = config.infoBoks;
 

--- a/src/components/macros/varselboks/MacroVarselBoks.tsx
+++ b/src/components/macros/varselboks/MacroVarselBoks.tsx
@@ -9,7 +9,7 @@ export const MacroVarselBoks = ({ config }: MacroVarselBoksProps) => {
         return null;
     }
 
-    // TODO: this should only be plain text, but it seems to be used
+    // This should only be plain text, but it seems to be used
     // with HTML by some editors
     const { varselBoks } = config.varselBoks;
 

--- a/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
+++ b/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import {
-    ContentProps,
-    ContentType,
-} from '../../../types/content-props/_content-common';
+import { ContentType } from '../../../types/content-props/_content-common';
 import { RedirectPage } from '../redirect-page/RedirectPage';
 import { DynamicPage } from '../dynamic-page/DynamicPage';
+import { MainArticleChapterProps } from '../../../types/content-props/main-article-chapter-props';
 
-export const MainArticleChapterPage = (props: ContentProps) => {
-    if (props.__typename !== ContentType.MainArticle) {
+export const MainArticleChapterPage = (props: MainArticleChapterProps) => {
+    if (props.data?.article?.__typename !== ContentType.MainArticle) {
         return <RedirectPage {...props} />;
     }
 

--- a/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
+++ b/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {
+    ContentProps,
+    ContentType,
+} from '../../../types/content-props/_content-common';
+import { RedirectPage } from '../redirect-page/RedirectPage';
+import { DynamicPage } from '../dynamic-page/DynamicPage';
+
+export const MainArticleChapterPage = (props: ContentProps) => {
+    if (props.__typename !== ContentType.MainArticle) {
+        return <RedirectPage {...props} />;
+    }
+
+    return <DynamicPage {...props} />;
+};

--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -1,19 +1,15 @@
 import { useEffect } from 'react';
-import { ExternalLinkProps } from '../../../types/content-props/external-link-props';
-import { InternalLinkProps } from '../../../types/content-props/internal-link-props';
 import { useRouter } from 'next/router';
-import { SiteProps } from '../../../types/content-props/site-props';
 import { getTargetIfRedirect } from '../../../utils/redirects';
-import { UrlProps } from '../../../types/content-props/url-props';
 import { BodyLong } from '@navikt/ds-react';
 import { LenkeInline } from '../../_common/lenke/LenkeInline';
+import { ContentProps } from '../../../types/content-props/_content-common';
+import { stripXpPathPrefix } from '../../../utils/urls';
 
-export const RedirectPage = (
-    props: ExternalLinkProps | InternalLinkProps | SiteProps | UrlProps
-) => {
+export const RedirectPage = (props: ContentProps) => {
     const { editorView, _path } = props;
     const router = useRouter();
-    const target = getTargetIfRedirect(props);
+    const target = getTargetIfRedirect(props) || stripXpPathPrefix(_path);
 
     useEffect(() => {
         // When viewed from the editor, we don't want to redirect. Instead we

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -6,11 +6,14 @@ import classNames from 'classnames';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
 import { BEM } from 'utils/classnames';
-import { MainArticleChapterProps } from '../../../../types/content-props/main-article-chapter-props';
+import { MainArticleChapterNavigationData } from '../../../../types/content-props/main-article-chapter-props';
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
-const getChapterPath = (chapter: MainArticleChapterProps) =>
+// If the chapter points to any content other than a main-article, we want
+// to link directly to the content instead, rather than try to render it
+// as a chapter
+const getChapterPath = (chapter: MainArticleChapterNavigationData) =>
     !chapter.data?.article ||
     chapter.data.article.__typename === ContentType.MainArticle
         ? chapter._path

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -10,6 +10,8 @@ import { MainArticleChapterNavigationData } from '../../../../types/content-prop
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
+const bem = BEM('main-article-chapter-navigation');
+
 // If the chapter points to any content other than a main-article, we want
 // to link directly to the content instead, rather than try to render it
 // as a chapter
@@ -20,7 +22,6 @@ const getChapterPath = (chapter: MainArticleChapterNavigationData) =>
         : chapter.data.article._path;
 
 export const MainArticleChapterNavigation = (props: ContentProps) => {
-    const bem = BEM('main-article-chapter-navigation');
     const { language } = usePageConfig();
     const getLabel = translator('mainArticle', language);
     const chapters = props.data?.chapters || props.parent?.data?.chapters || [];

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,31 +1,26 @@
 import React from 'react';
-import { Label, Heading } from '@navikt/ds-react';
+import { Heading, Label } from '@navikt/ds-react';
 import { translator } from 'translations';
 
 import classNames from 'classnames';
-import { ContentType, ContentProps } from 'types/content-props/_content-common';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
 import { BEM } from 'utils/classnames';
 import { MainArticleChapterProps } from '../../../../types/content-props/main-article-chapter-props';
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
-/*
-    Render of XP part named main-article-linked-list
-*/
+const getChapterPath = (chapter: MainArticleChapterProps) =>
+    !chapter.data?.article ||
+    chapter.data.article.__typename === ContentType.MainArticle
+        ? chapter._path
+        : chapter.data.article._path;
 
 export const MainArticleChapterNavigation = (props: ContentProps) => {
     const bem = BEM('main-article-chapter-navigation');
     const { language } = usePageConfig();
     const getLabel = translator('mainArticle', language);
-    const chapters =
-        props.data?.chapters ||
-        props.parent?.data?.chapters ||
-        // TODO: remove after backend chapters-update
-        ((props.children || props.parent?.children)?.filter(
-            (child) => child.__typename === ContentType.MainArticleChapter
-        ) as MainArticleChapterProps[]) ||
-        [];
+    const chapters = props.data?.chapters || props.parent?.data?.chapters || [];
 
     if (chapters.length === 0) {
         return null;
@@ -62,7 +57,9 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
                     )}
                 </li>
                 {chapters.map((chapter) => {
-                    const chapterPath = stripXpPathPrefix(chapter._path);
+                    const chapterPath = stripXpPathPrefix(
+                        getChapterPath(chapter)
+                    );
                     const chapterSelected = currentPath === chapterPath;
 
                     return (

--- a/src/components/parts/_legacy/main-article/MainArticle.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticle.tsx
@@ -14,19 +14,30 @@ import { MainArticleProps } from '../../../../types/content-props/main-article-p
 import { MainArticleChapterProps } from '../../../../types/content-props/main-article-chapter-props';
 import ErrorPage404 from '../../../../pages/404';
 
-export const MainArticle = (
-    propsInitial: MainArticleProps | MainArticleChapterProps
-) => {
-    const props =
-        propsInitial.__typename === ContentType.MainArticleChapter
-            ? propsInitial.data.article
-            : propsInitial;
+type Props = MainArticleProps | MainArticleChapterProps;
 
-    // Any other type than main-article should have resulted in a redirect
-    // This condition should never be true (famous last words :)
-    if (props.__typename !== ContentType.MainArticle) {
+// Get props from the chapter article if the content is a chapter
+const getPropsToRender = (propsInitial: Props) => {
+    if (propsInitial.__typename !== ContentType.MainArticleChapter) {
+        return propsInitial;
+    }
+
+    const articleProps = propsInitial.data?.article;
+
+    if (articleProps?.__typename === ContentType.MainArticle) {
+        return articleProps;
+    }
+
+    // Any other article type than main-article should have resulted in a redirect
+    // This branch should never happen (famous last words :)
+    return null;
+};
+
+export const MainArticle = (propsInitial: Props) => {
+    const props = getPropsToRender(propsInitial);
+    if (!props) {
         console.error(
-            `Misplaced MainArticle part on content type ${props.__typename} - ${props._path} - ${props._id}`
+            `Misplaced MainArticle part on content type ${propsInitial.__typename} - ${propsInitial._path} - ${propsInitial._id}`
         );
         return <ErrorPage404 />;
     }

--- a/src/components/parts/_legacy/main-article/MainArticle.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticle.tsx
@@ -23,7 +23,7 @@ export const MainArticle = (
             : propsInitial;
 
     // Any other type than main-article should have resulted in a redirect
-    // This should never render (famous last words :)
+    // This condition should never be true (famous last words :)
     if (props.__typename !== ContentType.MainArticle) {
         console.error(
             `Misplaced MainArticle part on content type ${props.__typename} - ${props._path} - ${props._id}`

--- a/src/components/parts/_legacy/main-article/MainArticle.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticle.tsx
@@ -12,6 +12,7 @@ import { parseInnholdsfortegnelse } from './innholdsfortegnelse/parseInnholdsfor
 import { ContentType } from '../../../../types/content-props/_content-common';
 import { MainArticleProps } from '../../../../types/content-props/main-article-props';
 import { MainArticleChapterProps } from '../../../../types/content-props/main-article-chapter-props';
+import ErrorPage404 from '../../../../pages/404';
 
 export const MainArticle = (
     propsInitial: MainArticleProps | MainArticleChapterProps
@@ -20,6 +21,15 @@ export const MainArticle = (
         propsInitial.__typename === ContentType.MainArticleChapter
             ? propsInitial.data.article
             : propsInitial;
+
+    // Any other type than main-article should have resulted in a redirect
+    // This should never render (famous last words :)
+    if (props.__typename !== ContentType.MainArticle) {
+        console.error(
+            `Misplaced MainArticle part on content type ${props.__typename} - ${props._path} - ${props._id}`
+        );
+        return <ErrorPage404 />;
+    }
 
     const { data } = props;
     const bem = BEM('main-article');

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -24,6 +24,7 @@ import { Params as DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
 import { AnimatedIconsData } from './animated-icons';
 import { GlobalValuesData } from './global-values-props';
 import { ContactInformationData } from './contact-information-props';
+import { MediaType } from '../media';
 
 export enum ContentType {
     Error = 'error',
@@ -56,7 +57,8 @@ export enum ContentType {
     Calculator = 'no_nav_navno_Calculator',
 }
 
-export type MediaContentCommonProps = {
+export type ContentCommonProps = {
+    __typename: ContentType | MediaType;
     _id: XpContentRef;
     _path: XpContentRef;
     createdTime: string;
@@ -85,7 +87,7 @@ export type ContentProps = {
     pathMap?: PathMap;
     livePath?: string;
     versionTimestamps?: string[];
-} & MediaContentCommonProps;
+} & ContentCommonProps;
 
 export type PathMap = { [key: string]: string };
 

--- a/src/types/content-props/main-article-chapter-props.ts
+++ b/src/types/content-props/main-article-chapter-props.ts
@@ -1,4 +1,8 @@
-import { ContentType, ContentProps } from './_content-common';
+import {
+    ContentType,
+    ContentProps,
+    ContentCommonProps,
+} from './_content-common';
 import { LanguageProps } from '../language';
 
 export type MainArticleChapterData = Partial<{
@@ -6,9 +10,15 @@ export type MainArticleChapterData = Partial<{
     languages: LanguageProps[];
 }>;
 
+export type MainArticleChapterNavigationData = {
+    data: {
+        article: ContentCommonProps;
+    };
+} & ContentCommonProps;
+
 type ParentProps = {
     data?: {
-        chapters?: Omit<MainArticleChapterProps, 'parent'>[];
+        chapters?: MainArticleChapterNavigationData[];
     };
 } & ContentProps;
 

--- a/src/types/content-props/main-article-chapter-props.ts
+++ b/src/types/content-props/main-article-chapter-props.ts
@@ -1,16 +1,14 @@
 import { ContentType, ContentProps } from './_content-common';
-import { MainArticleProps } from './main-article-props';
 import { LanguageProps } from '../language';
 
 export type MainArticleChapterData = Partial<{
-    article: MainArticleProps;
+    article: ContentProps;
     languages: LanguageProps[];
 }>;
 
 type ParentProps = {
-    children?: ContentProps[];
     data?: {
-        chapters?: ContentProps[];
+        chapters?: Omit<MainArticleChapterProps, 'parent'>[];
     };
 } & ContentProps;
 

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -1,4 +1,4 @@
-import { MainArticleChapterProps } from './main-article-chapter-props';
+import { MainArticleChapterNavigationData } from './main-article-chapter-props';
 import {
     ContentType,
     ContentProps,
@@ -26,7 +26,7 @@ export type MainArticleData = Partial<{
     social: string[];
     picture: Picture;
     menuListItems: MenuListItem;
-    chapters: MainArticleChapterProps[];
+    chapters: MainArticleChapterNavigationData[];
 }> &
     SeoDataProps &
     ContentDecoratorToggles;

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,5 +1,5 @@
 import { XpResponseProps } from '../utils/fetch-content';
-import { MediaContentCommonProps } from './content-props/_content-common';
+import { ContentCommonProps } from './content-props/_content-common';
 
 export enum MediaType {
     Archive = 'media_Archive',
@@ -20,7 +20,7 @@ export enum MediaType {
 export type MediaProps = {
     __typename: MediaType;
     mediaUrl: string;
-} & MediaContentCommonProps;
+} & ContentCommonProps;
 
 export type VectorImage = {
     __typename: MediaType.Vector;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -25,8 +25,6 @@ export const isNotFound = (content: ContentProps) => {
 // These status codes may indicate that the requested page has been intentionally
 // made unavailable.  We want to perform cache revalidation in these cases.
 const revalidateOnErrorCode = {
-    // 401: true, // unauthorized @TODO: temporarily disabled while migrating secrets
-    403: true, // forbidden
     404: true, // not found
 };
 

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -4,35 +4,37 @@ import {
 } from '../types/content-props/_content-common';
 import { stripXpPathPrefix } from './urls';
 
-export const getTargetIfRedirect = (contentData: ContentProps) => {
+const getTargetPath = (contentData: ContentProps) => {
     switch (contentData?.__typename) {
         case ContentType.SituationPage:
         case ContentType.ProductPage:
         case ContentType.ToolsPage:
         case ContentType.GuidePage:
         case ContentType.ThemedArticlePage:
-            // Redirect to the externalProductUrl if it is defined
-            return (
-                !contentData.isDraft &&
-                stripXpPathPrefix(contentData.data?.externalProductUrl)
-            );
+            return !contentData.isDraft
+                ? contentData.data?.externalProductUrl
+                : null;
         case ContentType.Site:
             return '/no/person';
         case ContentType.InternalLink:
             return contentData.data?.target?._path;
         case ContentType.ExternalLink:
         case ContentType.Url:
-            return stripXpPathPrefix(contentData.data?.url);
+            return contentData.data?.url;
         case ContentType.MainArticleChapter:
             // If the main article chapter content is anything other than a main article
             // we want to redirect to the actual content page. This is provided as a way
             // to gradually migrate individual pages from the chapter structure
-            return (
-                contentData.data.article.__typename !==
-                    ContentType.MainArticle &&
-                stripXpPathPrefix(contentData.data.article._path)
-            );
+            return contentData.data.article.__typename !==
+                ContentType.MainArticle
+                ? contentData.data.article._path
+                : null;
         default:
             return null;
     }
+};
+
+export const getTargetIfRedirect = (contentData: ContentProps) => {
+    const targetPath = getTargetPath(contentData);
+    return targetPath ? stripXpPathPrefix(targetPath) : null;
 };

--- a/src/utils/url-lookup-table.ts
+++ b/src/utils/url-lookup-table.ts
@@ -1,7 +1,0 @@
-import { getUrlFromLookupTable } from '@navikt/nav-dekoratoren-moduler';
-const { ENV } = process.env;
-
-export const getEnvUrl = (path: string) =>
-    ENV && ENV !== 'localhost' && ENV !== 'prod'
-        ? getUrlFromLookupTable(path, ENV as 'dev' | 'q0' | 'q1' | 'q2' | 'q6')
-        : path;


### PR DESCRIPTION
- article-feltet i main-article-chapter kan nå inneholde data for vilkårlige content-typer. Hvis article peker til noe annet enn en main-article vil det behandles som en redirect til den aktuelle siden. Chapter-navigasjonen vil også lenke direkte til innholdet.
- Fjerner url-lookup-table funksjonalitet. Denne var ment for å korrigere eksterne lenker i forhold til hvilket testmiljø appen kjørte i, men etter overgang til GCP har vi ingen fast url-struktur for testmiljøene. Så da gir ikke denne så mye mening lengre.
- Fjerner spesialhåndtering av 401/403 feil. Dette fungerer uansett ikke konsistent ettersom BigIP (?) filtrerer responser med disse feilkodene.