### PR TITLE
Håndterer client-side redirect fra/til skyggesider

### DIFF
--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -26,7 +26,7 @@ export const RedirectPage = (props: ContentProps) => {
     useEffect(() => {
         // When viewed from the editor or a shadow page, we don't want to redirect. Instead we
         // render a page showing the redirect target, while also giving access to the version
-        // history selector
+        // history selector in the editor
         if (shouldNotRedirect) {
             return;
         }

--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -1,15 +1,23 @@
 import { useEffect } from 'react';
-import { useRouter } from 'next/router';
+import { NextRouter, useRouter } from 'next/router';
 import { getTargetIfRedirect } from '../../../utils/redirects';
 import { BodyLong } from '@navikt/ds-react';
 import { LenkeInline } from '../../_common/lenke/LenkeInline';
 import { ContentProps } from '../../../types/content-props/_content-common';
 import { stripXpPathPrefix } from '../../../utils/urls';
 
+const getTarget = (props: ContentProps, router: NextRouter) => {
+    const target = getTargetIfRedirect(props) || stripXpPathPrefix(props._path);
+    if (router.query.shadowRouter) {
+        return `/shadow${target}`;
+    }
+    return target;
+};
+
 export const RedirectPage = (props: ContentProps) => {
     const { editorView, _path } = props;
     const router = useRouter();
-    const target = getTargetIfRedirect(props) || stripXpPathPrefix(_path);
+    const target = getTarget(props, router);
 
     useEffect(() => {
         // When viewed from the editor, we don't want to redirect. Instead we

--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -20,7 +20,7 @@ export const RedirectPage = (props: ContentProps) => {
     const { editorView, _path } = props;
     const router = useRouter();
     const isShadow = !!router.query?.shadowRouter;
-    const shouldNotRedirect = editorView || isShadow;
+    const shouldNotRedirect = !!editorView || isShadow;
     const target = getTarget(props, isShadow);
 
     useEffect(() => {

--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -1,29 +1,33 @@
 import { useEffect } from 'react';
-import { NextRouter, useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { getTargetIfRedirect } from '../../../utils/redirects';
 import { BodyLong } from '@navikt/ds-react';
 import { LenkeInline } from '../../_common/lenke/LenkeInline';
 import { ContentProps } from '../../../types/content-props/_content-common';
 import { stripXpPathPrefix } from '../../../utils/urls';
 
-const getTarget = (props: ContentProps, router: NextRouter) => {
+const getTarget = (props: ContentProps, isShadow: boolean) => {
     const target = getTargetIfRedirect(props) || stripXpPathPrefix(props._path);
-    if (router.query.shadowRouter) {
+
+    if (isShadow) {
         return `/shadow${target}`;
     }
+
     return target;
 };
 
 export const RedirectPage = (props: ContentProps) => {
     const { editorView, _path } = props;
     const router = useRouter();
-    const target = getTarget(props, router);
+    const isShadow = !!router.query?.shadowRouter;
+    const shouldNotRedirect = editorView || isShadow;
+    const target = getTarget(props, isShadow);
 
     useEffect(() => {
-        // When viewed from the editor, we don't want to redirect. Instead we
-        // render a page showing the redirect target, while also giving access
-        // to the version history selector
-        if (editorView) {
+        // When viewed from the editor or a shadow page, we don't want to redirect. Instead we
+        // render a page showing the redirect target, while also giving access to the version
+        // history selector
+        if (shouldNotRedirect) {
             return;
         }
 
@@ -31,9 +35,9 @@ export const RedirectPage = (props: ContentProps) => {
             console.log(`Redirecting from ${_path} to ${target}`);
             router.push(target);
         }
-    }, [target, editorView, _path, router]);
+    }, [target, shouldNotRedirect, _path, router]);
 
-    return editorView ? (
+    return shouldNotRedirect ? (
         <div className={'redirect-page'}>
             <BodyLong size="medium">
                 {`Dette er en redirect til `}


### PR DESCRIPTION
Dersom /shadow endepunktet benyttes mot en content-type som normalt vil trigge en client-side redirect (internal-link/external-link/url), vis isteden lenke til redirect-target på samme måte som ved visning fra editoren