### PR TITLE
Fikse 4 kolonner kontaktkanaler i situasjonssmal

### DIFF
--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -43,7 +43,7 @@ export const CallOption = (props: CallOptionProps) => {
     } = props;
 
     const { language } = usePageConfig();
-    const [isOpen, setIsOpen] = useState(false);
+    const [isClosed, setIsClosed] = useState(false);
 
     const getDateTimeTranslations = translator('dateTime', language);
     const relatives = getDateTimeTranslations('relatives');
@@ -162,7 +162,7 @@ export const CallOption = (props: CallOptionProps) => {
     const isCurrentlyClosed = getIsCurrentyClosed(todaysOpeningHour);
 
     useEffect(() => {
-        setIsOpen(!isCurrentlyClosed);
+        setIsClosed(isCurrentlyClosed);
     }, [isCurrentlyClosed]);
 
     return (
@@ -188,7 +188,7 @@ export const CallOption = (props: CallOptionProps) => {
                 spacing
                 className={classNames(
                     style.openingHour,
-                    isOpen ? style.open : style.closed
+                    isClosed ? style.closed : style.open
                 )}
             >
                 {typeof window !== 'undefined' &&

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 import { translator } from 'translations';
 import { Heading, BodyLong, Alert, BodyShort } from '@navikt/ds-react';
 
@@ -52,12 +52,16 @@ export const CallOption = (props: CallOptionProps) => {
     const sharedTranslations = getContactTranslations('shared');
 
     const allOpeningHours = mergeOpeningHours(
-        regularOpeningHours?.hours,
-        specialOpeningHours?.hours
+        regularOpeningHours?.hours || [],
+        specialOpeningHours?.hours || []
     );
 
     const findNextOpeningDayAfterToday = () => {
         const todayISO = getCurrentISODate();
+
+        if (!allOpeningHours) {
+            return null;
+        }
 
         for (let day = 0; day < allOpeningHours.length; day++) {
             const openingHour = allOpeningHours[day];
@@ -161,7 +165,7 @@ export const CallOption = (props: CallOptionProps) => {
 
     const isCurrentlyClosed = getIsCurrentyClosed(todaysOpeningHour);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         setIsClosed(isCurrentlyClosed);
     }, [isCurrentlyClosed]);
 

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -108,10 +108,10 @@
 
         &:before {
             display: inline-flex;
-            border-radius: 20px;
+            border-radius: 9px;
             content: '';
-            width: 20px;
-            height: 20px;
+            width: 18px;
+            height: 19px;
             margin-top: -2px;
             margin-right: 0.5rem;
         }

--- a/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
@@ -4,7 +4,6 @@ import Region from '../Region';
 import { LayoutContainer } from '../LayoutContainer';
 import { SituationPageFlexColsLayoutProps } from '../../../types/component-props/layouts/situation-flex-cols';
 import { Header } from '../../_common/headers/Header';
-import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 type Props = {
     pageProps: ContentProps;

--- a/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
@@ -4,6 +4,7 @@ import Region from '../Region';
 import { LayoutContainer } from '../LayoutContainer';
 import { SituationPageFlexColsLayoutProps } from '../../../types/component-props/layouts/situation-flex-cols';
 import { Header } from '../../_common/headers/Header';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 type Props = {
     pageProps: ContentProps;
@@ -28,6 +29,13 @@ export const SituationPageFlexColsLayout = ({
         ...(justifyContent && { justifyContent }),
     };
 
+    const calculateColCount = () => {
+        return regionProps.components.length % 3 === 0 ? 3 : 2;
+    };
+
+    const colCount =
+        typeof numCols === 'number' ? numCols : calculateColCount();
+
     return (
         <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
             {title && (
@@ -46,7 +54,7 @@ export const SituationPageFlexColsLayout = ({
                 pageProps={pageProps}
                 regionProps={regionProps}
                 regionStyle={regionStyle}
-                bemModifier={`${numCols}-cols`}
+                bemModifier={`${colCount}-cols`}
             />
         </LayoutContainer>
     );

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -122,7 +122,7 @@ export const bundle = {
             openNow: 'Åpent nå',
             opensAt: 'Åpner {$1} kl {$2}',
             closedNow: 'Stengt nå',
-            seeMoreOptions: 'Mer om tastevalg',
+            seeMoreOptions: 'Mer om åpningstider og tastevalg',
             todaysPhoneOpeningHours: 'Åpningstider på telefon i dag',
             callUsAt: 'Ring oss på',
             businessDays: 'hverdager',

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -122,7 +122,7 @@ export const bundle = {
             openNow: 'Ope no',
             opensAt: 'Opnar {$1} kl {$2}',
             closedNow: 'Stengt no',
-            seeMoreOptions: 'Meir om tasteval',
+            seeMoreOptions: 'Meir om åpningstider og tasteval',
             todaysPhoneOpeningHours: 'Opningstider på telefon i dag',
             callUsAt: 'Ring oss på',
             businessDays: 'kvardagar',

--- a/src/types/component-props/layouts/flex-cols.ts
+++ b/src/types/component-props/layouts/flex-cols.ts
@@ -12,7 +12,7 @@ export interface FlexColsLayoutProps extends LayoutCommonProps {
         };
     };
     config: {
-        numCols: number;
+        numCols?: number;
         justifyContent: 'flex-start' | 'center' | 'flex-end';
     } & LayoutCommonConfigMixin;
 }


### PR DESCRIPTION
- Støtter samme 4-kolonners regel som på produktsider, men lar i tillegg redaktøren overstyre ved å angi kolonner. Dette er pga at flex-layouten også brukes på produktkort etc i tillegg til kontaktkanaler.
- Fikser feil hvor sirkel ved åpningstid har feil farge.