### PR TITLE
Hindrer forsøk på caching av eksterne bilder + ingress-fiks

### DIFF
--- a/.nais/vars-prod.yml
+++ b/.nais/vars-prod.yml
@@ -4,3 +4,4 @@ secret: nav-enonicxp
 ingresses:
   - https://www.nav.no
   - https://www.nav.no/soknad-dagpenger-utdanning
+  - https://www.nav.no/soker-jobb

--- a/.nais/vars-prod.yml
+++ b/.nais/vars-prod.yml
@@ -5,3 +5,4 @@ ingresses:
   - https://www.nav.no
   - https://www.nav.no/soknad-dagpenger-utdanning
   - https://www.nav.no/soker-jobb
+  - https://www.nav.no/soknaden-og-cv

--- a/next.config.js
+++ b/next.config.js
@@ -73,9 +73,9 @@ module.exports = withPlugins([withLess, withTranspileModules], {
     images: {
         minimumCacheTTL: 60,
         dangerouslyAllowSVG: true,
-        // Domains must not include protocol prefixes
-        domains: [process.env.XP_ORIGIN, process.env.ADMIN_ORIGIN].map(
-            (origin) => origin?.replace(/^https?:\/\//, '')
+        domains: [process.env.APP_ORIGIN, process.env.XP_ORIGIN].map((origin) =>
+            // Domain whitelist must not include protocol prefixes
+            origin?.replace(/^https?:\/\//, '')
         ),
         deviceSizes: [480, 768, 1024, 1440],
         imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],

--- a/src/components/_common/image/NextImage.tsx
+++ b/src/components/_common/image/NextImage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { usePageConfig } from '../../../store/hooks/usePageConfig';
 import { updateImageManifest } from '../../../utils/fetch/fetch-images';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
+import { isPublicAppUrl } from '../../../utils/urls';
 
 // These types should match what's specified in next.config
 type DeviceSize = 480 | 768 | 1024 | 1440;
@@ -71,8 +72,8 @@ const NextImageRunTime = (props: Props) => {
         return null;
     }
 
-    // We don't want caching for the editor-views. Always get the image directly from XP
-    if (pageConfig.editorView) {
+    // Skip caching when viewed from the editor, or for external image urls
+    if (pageConfig.editorView || !isPublicAppUrl(src)) {
         return <img {...imgAttribs} src={src} alt={alt} />;
     }
 

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -48,7 +48,7 @@ export const isAppUrl = (url: string) => url && appUrlPattern.test(url);
 // Matches both relative and absolute urls which points to publically available
 // content internal to the app
 const publicAppUrlPattern = new RegExp(
-    `^(${appOrigin}|${appOriginProd})?($|\\/(${internalPaths.join('|')}))`,
+    `^(${appOrigin}|${appOriginProd})?($|\\/(${internalPaths.join('|')})|_\\/)`,
     'i'
 );
 export const isPublicAppUrl = (url: string) =>

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -19,11 +19,14 @@ const internalUrlPrefix = `^(${appOrigin}|${appOriginProd}|${adminOrigin})?(${xp
 
 const internalUrlPrefixPattern = new RegExp(internalUrlPrefix, 'i');
 
+// Links to these paths and any sub-paths will use SPA navigation.
+// If any subpaths point to a separate app, insert an appropriate regex to ensure
+// we don't show 404-errors on links from our app
 const internalPaths = [
     '$',
-    'no(?!\\/rss)',
+    'no(?!\\/rss)', // rss-feed must be a full page load
     'en',
-    'se(?!\\/samegiella\\/bestilling-av-samtale)',
+    'se(?!\\/samegiella\\/bestilling-av-samtale)', // "bestilling-av-samtale" is a separate app
     'nav.no',
     'skjemaer',
     'forsiden',
@@ -31,16 +34,25 @@ const internalPaths = [
     'footer-contactus-en',
     'sykepenger-korona',
     'beskjed',
-    'person\\/kontakt-oss(?!(\\/(nb|en))?\\/tilbakemeldinger)',
+    'person\\/kontakt-oss(?!(\\/(nb|en))?\\/tilbakemeldinger)', // "tilbakemeldinger" is a separate app
     'version',
 ];
 
-// Matches both relative and absolute urls which points to content internal to the app
+// Matches both relative and absolute urls which points to any content internal to the app
 const appUrlPattern = new RegExp(
     `${internalUrlPrefix}($|\\/(${internalPaths.join('|')}))`,
     'i'
 );
 export const isAppUrl = (url: string) => url && appUrlPattern.test(url);
+
+// Matches both relative and absolute urls which points to publically available
+// content internal to the app
+const publicAppUrlPattern = new RegExp(
+    `^(${appOrigin}|${appOriginProd})?($|\\/(${internalPaths.join('|')}))`,
+    'i'
+);
+export const isPublicAppUrl = (url: string) =>
+    url && publicAppUrlPattern.test(url);
 
 // Matches urls pointing directly to XP (/_/*)
 const xpUrlPattern = new RegExp(`${internalUrlPrefix}/_`, 'i');


### PR DESCRIPTION
Kun bilder fra denne appen eller fra public-url'en til XP skal hentes via next/image (dvs fra www.nav.no/_/ eller statiske imports i appen). Får en del feil i loggene nå pga forsøk på å cache bilder fra portal-admin, som denne appen ikke har tilgang til.

Legger også inn disse url'ene som en eksplisitte ingress: /soker-jobb, /soknaden-og-cv
Alt under /sok* går til søkeappen vår med mindre de er eksplisitt satt som en ingress til nais. Skal høre om dette kan fikses på en generell måte :D