### PR TITLE
Tweaks for å forbedre stabilitet i prod

### DIFF
--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -19,7 +19,7 @@ spec:
     initialDelay: 30
   prometheus:
     enabled: true
-    path: /internal/metrics
+    path: /api/internal/metrics
   ingresses:
   {{#each ingresses as |url|}}
     - {{url}}

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -13,9 +13,10 @@ spec:
   liveness:
     path: /api/internal/isAlive
     initialDelay: 10
+    timeout: 5
   readiness:
     path: /api/internal/isReady
-    initialDelay: 10
+    initialDelay: 30
   prometheus:
     enabled: true
     path: /internal/metrics

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "dayjs": "^1.10.7",
                 "dotenv": "^11.0.0",
                 "express": "^4.17.3",
-                "express-prom-bundle": "^6.4.1",
                 "html-react-parser": "^1.4.8",
                 "immer": "^9.0.12",
                 "js-cookie": "^3.0.1",
@@ -3339,21 +3338,6 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/express-prom-bundle": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.4.1.tgz",
-            "integrity": "sha512-Sg0svLQe/SS5z1tHDTVfZVjNumobiDlXM0jmemt5Dm9K6BX8z9yCwEr93zbko6fNMR4zKav77iPfxUWi6gAjNA==",
-            "dependencies": {
-                "on-finished": "^2.3.0",
-                "url-value-parser": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "prom-client": ">=12.0.0"
             }
         },
         "node_modules/express/node_modules/debug": {
@@ -7478,14 +7462,6 @@
             "deprecated": "Please see https://github.com/lydell/urix#deprecated",
             "dev": true
         },
-        "node_modules/url-value-parser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
-            "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw==",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/use-subscription": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
@@ -10278,15 +10254,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
-            }
-        },
-        "express-prom-bundle": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.4.1.tgz",
-            "integrity": "sha512-Sg0svLQe/SS5z1tHDTVfZVjNumobiDlXM0jmemt5Dm9K6BX8z9yCwEr93zbko6fNMR4zKav77iPfxUWi6gAjNA==",
-            "requires": {
-                "on-finished": "^2.3.0",
-                "url-value-parser": "^2.0.0"
             }
         },
         "fast-deep-equal": {
@@ -13327,11 +13294,6 @@
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
             "dev": true
-        },
-        "url-value-parser": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
-            "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw=="
         },
         "use-subscription": {
             "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "dayjs": "^1.10.7",
         "dotenv": "^11.0.0",
         "express": "^4.17.3",
-        "express-prom-bundle": "^6.4.1",
         "html-react-parser": "^1.4.8",
         "immer": "^9.0.12",
         "js-cookie": "^3.0.1",

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 
 const express = require('express');
-const expressPromBundle = require('express-prom-bundle');
 const next = require('next');
 
 const { setJsonCacheHeaders } = require('./set-json-cache-headers');
@@ -20,10 +19,6 @@ const nextRequestHandler = nextApp.getRequestHandler();
 const port = 3000;
 
 const jsonBodyParser = express.json();
-const prometheusMiddleware = expressPromBundle({
-    includePath: true,
-    metricsPath: '/internal/metrics',
-});
 
 const verifySecret = (req, res, next) => {
     if (req.headers.secret !== process.env.SERVICE_SECRET) {
@@ -65,7 +60,7 @@ nextApp.prepare().then(() => {
         handleInvalidateAllReq(nextApp)
     );
 
-    server.all('*', prometheusMiddleware, (req, res) => {
+    server.all('*', (req, res) => {
         setJsonCacheHeaders(req, res);
 
         return nextRequestHandler(req, res);

--- a/src/components/_common/lenke/LenkeBase.tsx
+++ b/src/components/_common/lenke/LenkeBase.tsx
@@ -40,8 +40,9 @@ export const LenkeBase = ({
     const { pageConfig } = usePageConfig();
 
     // Setting prefetch=true on next/link is deprecated, hence this strange thing (true is default)
-    const shouldPrefetch =
-        prefetch === false || !!pageConfig.editorView ? false : undefined;
+    // (setting to always false for the time being to prevent backend load spikes with cold cache)
+    const shouldPrefetch = false;
+    // prefetch === false || !!pageConfig.editorView ? false : undefined;
 
     const getFinalHref = () => {
         if (isInternalUrl(href)) {

--- a/src/pages/api/internal/metrics.ts
+++ b/src/pages/api/internal/metrics.ts
@@ -1,0 +1,14 @@
+import prometheus from 'prom-client';
+
+if (process.env.NODE_ENV === 'development') {
+    prometheus.register.clear();
+}
+
+prometheus.collectDefaultMetrics();
+
+const metrics = async (req, res) => {
+    res.setHeader('Content-Type', prometheus.register.contentType);
+    res.end(await prometheus.register.metrics());
+};
+
+export default metrics;


### PR DESCRIPTION
- Øker liveness timeout. Default er 1 sec, har sett en del timeouts siden flytting til GCP, tror dette forårsaket pod-restarter i går
- Øker readiness delay for å spre ut oppstart av nye pods ved deploy
- Tar i bruk tidligere løsning for metrics. Ser en betydelig økning i minnebruk etter at prometheusMiddleware ble tatt i bruk, sjekker om det kan være årsaken (eller om det var tilfeldig!)
- Hindrer automatisk prefetch av alle lenker når en side lastes. Prefetch vil fortsatt skje ved mouseover. Denne prefetchen skaper en "eksplosiv" mengde requests til backend kort tid etter prodsettinger når det er mye trafikk. Mulig vi kan finne en løsning for å gjøre prefetchingen litt mindre hissig.