### PR TITLE
Fragment editor props

### DIFF
--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -20,7 +20,10 @@ type FilterBarProps = {
 
 export const FilterBar = ({ layoutProps }: FilterBarProps) => {
     const { content, intro } = layoutProps.regions;
-    const components = [...content.components, ...intro.components];
+    const components = [
+        ...(content ? content.components : []),
+        ...(intro ? intro.components : []),
+    ];
     const { language } = usePageConfig();
     const getLabel = translator('filteredContent', language);
 

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -35,11 +35,13 @@ const layoutComponents: {
 };
 
 export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
-    const { descriptor, path, regions } = layoutProps;
+    const { descriptor, path, regions, fragment } = layoutProps;
     const isEditView = pageProps.editorView === 'edit';
 
     const editorProps = {
-        'data-portal-component-type': ComponentType.Layout,
+        'data-portal-component-type': fragment
+            ? ComponentType.Fragment
+            : ComponentType.Layout,
         'data-portal-component': path,
     };
 

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { PartWithOwnData, PartWithPageData } from 'types/component-props/parts';
-import { PartDeprecated, PartType } from 'types/component-props/parts';
+import {
+    PartDeprecated,
+    PartType,
+    PartWithOwnData,
+    PartWithPageData,
+} from 'types/component-props/parts';
 import LinkLists from './_legacy/link-lists/LinkLists';
 import { LinkPanelsLegacyPart } from './_legacy/link-panels/LinkPanelsLegacyPart';
 import { MainArticleChapterNavigation } from './_legacy/main-article-chapter-navigation/MainArticleChapterNavigation';
@@ -99,13 +103,15 @@ const PartComponent = ({ partProps, pageProps }: Props) => {
 };
 
 export const PartsMapper = ({ pageProps, partProps }: Props) => {
-    const { path, descriptor, config } = partProps;
+    const { path, descriptor, config, fragment } = partProps;
     const isEditView = pageProps.editorView === 'edit';
     const renderOnAuthState = config?.renderOnAuthState;
 
     const editorProps = isEditView
         ? {
-              'data-portal-component-type': ComponentType.Part,
+              'data-portal-component-type': fragment
+                  ? ComponentType.Fragment
+                  : ComponentType.Part,
               'data-portal-component': path,
           }
         : undefined;

--- a/src/types/component-props/_component-common.ts
+++ b/src/types/component-props/_component-common.ts
@@ -19,6 +19,7 @@ export type ComponentCommonProps = {
 export interface PartComponentProps extends ComponentCommonProps {
     type: ComponentType.Part;
     descriptor: PartType;
+    fragment?: string;
 }
 
 export interface TextComponentProps extends ComponentCommonProps {

--- a/src/types/component-props/layouts.ts
+++ b/src/types/component-props/layouts.ts
@@ -38,6 +38,7 @@ export interface LayoutCommonProps extends ComponentCommonProps {
     descriptor: LayoutType;
     regions?: { [key: string]: RegionProps };
     config?: any;
+    fragment?: string;
 }
 
 export type LayoutProps =


### PR DESCRIPTION
Bruker component-type for fragmenter i editor-viewet for komponenter som hører til et fragment. Det kommer noen endringer i https://github.com/navikt/nav-enonicxp/pull/1290 som krever dette.

Fikser også en potensiell type-error i filter-bar komponenten dersom denne brukes i et fragment