### PR TITLE
Fikser lenke-styling-konflikt som kommer fra chatbot

### DIFF
--- a/src/common.less
+++ b/src/common.less
@@ -69,7 +69,7 @@
 
 .link-border-bottom-mixin() {
     border-bottom: 1px @navds-semantic-color-link solid;
-    text-decoration: none;
+    text-decoration: none !important; // Konflikt med Chatbot pga gammelt designsystem (pr 25.04.22)
     transition: border-bottom-color 0.12s ease-out;
 
     &:hover,


### PR DESCRIPTION
Mistenker en styling-konflikt som kommer via gamle nav-frontend-lenke-style. Denne PR'en setter en !important som en nødfiks frem til chatbot har oppdatert pakkene til @navikt/ds-react.