### PR TITLE
Varsel for duplikate anchor-ids i navigasjonsmeny

### DIFF
--- a/src/components/_common/page-navigation-menu/PageNavigationDupeLinkWarning.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationDupeLinkWarning.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { AnchorLink } from '../../../types/component-props/parts/page-navigation-menu';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
+
+type Props = {
+    dupes: AnchorLink[];
+};
+
+export const PageNavigationDupeLinkWarning = ({ dupes }: Props) => {
+    if (dupes.length === 0) {
+        return null;
+    }
+
+    const dupesString = dupes.map((dupe) => dupe.anchorId).join(', ');
+
+    return (
+        <EditorHelp
+            text={`Obs! Siden har duplikate anker-id'er: "${dupesString}" - Kun det første menypunktet vil vises for dette ankeret`}
+            type={'error'}
+        />
+    );
+};

--- a/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
@@ -61,6 +61,7 @@ const getValidLinks = (anchorLinks: AnchorLink[]): AnchorLink[] =>
         (link) =>
             link.anchorId &&
             link.linkText &&
+            !link.isDupe &&
             // On the client-side we also check if the element is in the DOM
             (typeof document === 'undefined' ||
                 !!document.getElementById(link.anchorId))
@@ -147,6 +148,7 @@ export const PageNavigationMenu = ({
         title: title,
         links: links,
         scrollDirection: scrollDir.current,
+        dupes: anchorLinks.filter((link) => link.isDupe),
     };
 
     return viewStyle === 'sidebar' ? (

--- a/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
@@ -4,15 +4,17 @@ import { Header } from '../../headers/Header';
 import { PageNavigationLink } from '../PageNavigationLink';
 import { AnchorLink } from '../../../../types/component-props/parts/page-navigation-menu';
 import { getPageNavigationLinkId } from '../PageNavigationMenu';
+import { PageNavigationDupeLinkWarning } from '../PageNavigationDupeLinkWarning';
 
 const bem = BEM('page-nav-in-content');
 
 type Props = {
     title?: string;
     links: AnchorLink[];
+    dupes: AnchorLink[];
 };
 
-export const PageNavigationInContent = ({ title, links }: Props) => {
+export const PageNavigationInContent = ({ title, links, dupes }: Props) => {
     return (
         <div className={classNames(bem())}>
             {title && (
@@ -25,6 +27,7 @@ export const PageNavigationInContent = ({ title, links }: Props) => {
                     {title}
                 </Header>
             )}
+            <PageNavigationDupeLinkWarning dupes={dupes} />
             <nav aria-label={'Innhold'}>
                 <ul className={bem('list')}>
                     {links.map((anchorLink) => (

--- a/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
@@ -7,12 +7,14 @@ import {
     getPageNavigationLinkId,
     PageNavScrollDirection,
 } from '../PageNavigationMenu';
+import { PageNavigationDupeLinkWarning } from '../PageNavigationDupeLinkWarning';
 
 const bem = BEM('page-nav-sidebar');
 
 type Props = {
     title?: string;
     links: AnchorLink[];
+    dupes: AnchorLink[];
     currentIndex: number;
     scrollDirection: PageNavScrollDirection;
 };
@@ -20,6 +22,7 @@ type Props = {
 export const PageNavigationSidebar = ({
     title,
     links,
+    dupes,
     currentIndex,
     scrollDirection,
 }: Props) => {
@@ -30,6 +33,7 @@ export const PageNavigationSidebar = ({
                     {title}
                 </Heading>
             )}
+            <PageNavigationDupeLinkWarning dupes={dupes} />
             <nav aria-label={'Innhold'}>
                 <ul className={bem('list')}>
                     {links.map((anchorLink, index) => (

--- a/src/types/component-props/parts/page-navigation-menu.ts
+++ b/src/types/component-props/parts/page-navigation-menu.ts
@@ -4,6 +4,7 @@ import { PartType } from '../parts';
 export type AnchorLink = {
     anchorId: string;
     linkText: string;
+    isDupe?: boolean;
 };
 
 export type PageNavViewStyle = 'sidebar' | 'inContent';


### PR DESCRIPTION
Viser et varsel i editoren når det eksisterer duplikate anker-id'er på en side