### PR TITLE
Fikser bug med img i tom div-tag

### DIFF
--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -47,7 +47,11 @@ const hasBlockLevelMacroChildren = (element: Element) => {
 const getNonEmptyChildren = ({ children }: Element) => {
     const validChildren = children?.filter((child) => {
         if (isTag(child)) {
-            if (child.name === processedHtmlMacroTag) {
+            // Macros and image tags are allowed to be empty
+            if (
+                child.name === processedHtmlMacroTag ||
+                (child.name === 'img' && child.attribs?.src)
+            ) {
                 return true;
             }
 


### PR DESCRIPTION
Fikser en bug som hindret parsede img-elementer fra å rendres dersom de var nøstet i et div-element som ellers kun hadde tomme elementer