### PR TITLE
Fjerner og-logikk for filtere

### DIFF
--- a/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/src/components/_common/filtered-content/FilteredContent.tsx
@@ -1,30 +1,19 @@
 import React from 'react';
-import { FilterLogic, FilterSelection } from 'types/component-props/_mixins';
+import { FilterSelection } from 'types/component-props/_mixins';
 import { useFilterState } from '../../../store/hooks/useFilteredContent';
 
 type Props = {
     filters: string[];
-    filterLogic: FilterLogic;
     children: React.ReactNode;
 };
 
 const checkForFilterMatch = (
     filters: string[],
-    selectedFilters: FilterSelection,
-    filterLogic: FilterLogic
-) => {
-    if (filterLogic === 'and' && selectedFilters.length > 1) {
-        return filters.every((filter) => selectedFilters.includes(filter));
-    }
+    selectedFilters: FilterSelection
+) => filters.some((filter) => selectedFilters.includes(filter));
 
-    return filters.some((filter) => selectedFilters.includes(filter));
-};
-
-export const FilteredContent = ({ filters, children, filterLogic }: Props) => {
+export const FilteredContent = ({ filters, children }: Props) => {
     const { selectedFilters, availableFilters } = useFilterState();
-
-    // Existing product pages might not have filterLogic set for all htmlareas.
-    const normalizedFilterLogic = filterLogic || 'or';
 
     // No filters were set for this particular part, so let children through.
     if (!filters) {
@@ -44,11 +33,7 @@ export const FilteredContent = ({ filters, children, filterLogic }: Props) => {
         );
     });
 
-    const isFilterMatch = checkForFilterMatch(
-        filters,
-        selectedFilters,
-        filterLogic
-    );
+    const isFilterMatch = checkForFilterMatch(filters, selectedFilters);
 
     if (isAffectedByFiltering && !isFilterMatch) {
         return null;

--- a/src/components/parts/calculator/Calculator.tsx
+++ b/src/components/parts/calculator/Calculator.tsx
@@ -19,10 +19,7 @@ export const CalculatorPart = ({ config }: CalculatorProps) => {
     }
 
     return (
-        <FilteredContent
-            filters={config.filters}
-            filterLogic={config.filterLogic}
-        >
+        <FilteredContent filters={config.filters}>
             <Calculator
                 calculatorData={config.targetCalculator.data}
                 header={config.header}

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -18,8 +18,6 @@ export enum Audience {
     PROVIDER = 'provider',
 }
 
-export type FilterLogic = 'or' | 'and';
-
 export type FilterSelection = string[];
 
 export type ProductDataMixin = {
@@ -65,7 +63,6 @@ export type ExpandableMixin = {
 
 export type FiltersMixin = {
     filters: string[];
-    filterLogic: FilterLogic;
 };
 
 export type ColorMixin = {

--- a/src/types/component-props/parts/calculator.ts
+++ b/src/types/component-props/parts/calculator.ts
@@ -1,6 +1,5 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
-import { FilterLogic } from '../_mixins';
 
 export enum FieldType {
     INPUT,
@@ -49,6 +48,5 @@ export interface CalculatorProps extends PartComponentProps {
             data: CalculatorData;
         };
         filters: string[];
-        filterLogic: FilterLogic;
     }>;
 }


### PR DESCRIPTION
OG-logikk fungerte ikke helt slik vi tenkte for Foreldrepenger. Vi har derfor blitt enige om å fjerne den igjen før flere tar den i bruk.