### PR TITLE
Endrer admin-content service url for CS 4.1 kompatibilitet

### DIFF
--- a/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
+++ b/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
@@ -4,6 +4,7 @@ import { ContentProps } from '../../../types/content-props/_content-common';
 
 const adminAuthUrl = `${adminOrigin}/admin/rest/auth/authenticated`;
 const userInfoUrl = `${adminOrigin}/admin/rest-v2/cs/security/principals/user:`;
+const contentServiceUrl = `${adminOrigin}/admin/tool/com.enonic.app.contentstudio/main/_/service/com.enonic.app.contentstudio/content`;
 
 type UserInfo = {
     key: string;
@@ -29,7 +30,7 @@ export const fetchAdminUserId = () =>
 
 export const fetchAdminContent = async (contentId: string) =>
     fetchJson<AdminContentResponse>(
-        `${adminOrigin}${parent.window.CONFIG?.services?.contentUrl}?contentId=${contentId}`,
+        `${contentServiceUrl}?contentId=${contentId}`,
         5000
     );
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,12 +1,6 @@
 declare global {
     interface Window {
         dispatchEventActual?: Window['dispatchEvent'];
-        // The CONFIG object is available on the parent window in content studio
-        CONFIG?: {
-            services?: {
-                contentUrl?: string;
-            };
-        };
     }
 }
 


### PR DESCRIPTION
Denne brekker med CS 4.1+ (brukes for QoL hacks i content studio)