### PR TITLE
Setter header-farge til hvit på oversiktsside

### DIFF
--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.module.scss
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.module.scss
@@ -35,7 +35,7 @@
     }
 
     &.overview {
-        box-shadow: 0 -4px 0 common.$navds-global-color-green-500 inset;
+        box-shadow: 0 -4px 0 common.$navds-global-color-white inset;
     }
 
     @media #{common.$mq-screen-mobile} {


### PR DESCRIPTION
Oversiktssiden skal ikke ha tematisk farge. Settes til hvit.