### PR TITLE
Håndterer routing for URL med ugyldig/gammel build-id

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -88,11 +88,11 @@ nextApp.prepare().then(() => {
             handleInvalidateAllReq(nextApp)
         );
 
-        server.get(`/_next/data/:buildId/*`, (req, res) => {
+        server.get('/_next/data/:buildId/*.json', (req, res) => {
             const { buildId } = req.params;
             if (buildId !== currentBuildId) {
                 console.log(
-                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match expected build-id`
+                    `Expected build-id ${currentBuildId}, got ${buildId} on ${req.path}`
                 );
                 req.url = req.url.replace(buildId, currentBuildId);
                 req.path = req.path.replace(buildId, currentBuildId);

--- a/server/server.js
+++ b/server/server.js
@@ -92,7 +92,7 @@ nextApp.prepare().then(() => {
             const { buildId } = req.params;
             if (buildId !== currentBuildId) {
                 console.log(
-                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match expected`
+                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match expected build-id`
                 );
                 req.url = req.url.replace(buildId, currentBuildId);
                 req.path = req.path.replace(buildId, currentBuildId);

--- a/server/server.js
+++ b/server/server.js
@@ -92,7 +92,7 @@ nextApp.prepare().then(() => {
             const { buildId } = req.params;
             if (buildId !== currentBuildId) {
                 console.log(
-                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match current`
+                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match expected`
                 );
                 req.url = req.url.replace(buildId, currentBuildId);
                 req.path = req.path.replace(buildId, currentBuildId);

--- a/server/server.js
+++ b/server/server.js
@@ -43,6 +43,8 @@ nextApp.prepare().then(() => {
         ENV,
     } = process.env;
 
+    const currentBuildId = nextApp.server.getBuildId();
+
     const isFailover = IS_FAILOVER_INSTANCE === 'true';
 
     if (!isFailover && PAGE_CACHE_DIR) {
@@ -86,8 +88,21 @@ nextApp.prepare().then(() => {
             handleInvalidateAllReq(nextApp)
         );
 
-        server.all('*', (req, res) => {
+        server.get(`/_next/data/:buildId/*`, (req, res) => {
+            const { buildId } = req.params;
+            if (buildId !== currentBuildId) {
+                console.log(
+                    `Expected build-id ${currentBuildId}, got ${buildId} - Rewriting request path to match current`
+                );
+                req.url = req.url.replace(buildId, currentBuildId);
+                req.path = req.path.replace(buildId, currentBuildId);
+            }
+
             setJsonCacheHeaders(req, res);
+            return nextRequestHandler(req, res);
+        });
+
+        server.all('*', (req, res) => {
             return nextRequestHandler(req, res);
         });
     }

--- a/server/set-json-cache-headers.js
+++ b/server/set-json-cache-headers.js
@@ -1,16 +1,12 @@
 const onHeaders = require('on-headers');
 
-const isJsonCacheUrl = (url) => /_next\/data\/.*\.json/.test(url);
-
 // Set the no-cache header on json files from the incremental cache to ensure
 // data requested during client side navigation is always validated if cached
 // by browsers/proxies/CDNs etc
 const setJsonCacheHeaders = (req, res) => {
-    if (isJsonCacheUrl(req.url)) {
-        onHeaders(res, () => {
-            res.setHeader('Cache-Control', 'no-cache');
-        });
-    }
+    onHeaders(res, () => {
+        res.setHeader('Cache-Control', 'no-cache');
+    });
 };
 
 module.exports = { setJsonCacheHeaders };

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { translator } from 'translations';
 import { Area } from 'types/areas';
 import { OverviewPageProps } from 'types/content-props/dynamic-page-props';
-import ErrorPage404 from 'pages/404';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { OverviewFilter } from 'components/pages/overview-page/product-filter/OverviewFilter';
@@ -17,8 +16,7 @@ const isVisiblePredicate = (product: SimplifiedProductData, areaFilter: Area) =>
 
 export const OverviewPage = (props: OverviewPageProps) => {
     const { productList, overviewType } = props.data;
-    const { language, pageConfig } = usePageConfig();
-    const { isPagePreview, editorView } = pageConfig;
+    const { language } = usePageConfig();
 
     // Misc translations
     const getTranslationString = translator('overview', language);


### PR DESCRIPTION
Rewriter requests til JSON-cachen slik at de alltid benytter nåværende build-id. Se [issue](https://github.com/navikt/nav-enonicxp-frontend/issues/848) for mer om problemstillingen.