### PR TITLE
Setter env var for npm config cache

### DIFF
--- a/.nais/config-failover.yml
+++ b/.nais/config-failover.yml
@@ -24,6 +24,9 @@ spec:
   {{/each}}
   envFrom:
     - secret: {{secret}}
+  env:
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/npm-cache
   replicas:
     min: 1
     max: 2

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -26,6 +26,9 @@ spec:
   {{/each}}
   envFrom:
     - secret: {{secret}}
+  env:
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/npm-cache
   replicas:
     min: 2
     max: 4

--- a/failover/Dockerfile
+++ b/failover/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-bullseye-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Dette har plutselig begynt å krasje containerne på nais, dersom denne ikke er satt og npm skriver logger til et readonly område.