### PR TITLE
Legger til ny generisk innholdstype

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -20,6 +20,7 @@ import { ProductDetailsPage } from './pages/product-details-page/ProductDetailsP
 import { GlobalValuesPage } from './pages/global-values-page/GlobalValuesPage';
 import { MainArticleChapterPage } from './pages/main-article-chapter-page/MainArticleChapterPage';
 import { PayoutDatesPage } from './pages/payout-dates-page/PayoutDatesPage';
+import { GenericPage } from './pages/generic-page/GenericPage';
 
 const contentToReactComponent: Partial<{
     [key in ContentType]: React.FunctionComponent<ContentProps>;
@@ -40,6 +41,7 @@ const contentToReactComponent: Partial<{
     [ContentType.GuidePage]: GuidePage,
     [ContentType.ThemedArticlePage]: ThemedArticlePage,
     [ContentType.Overview]: OverviewPage,
+    [ContentType.GenericPage]: GenericPage,
 
     [ContentType.DynamicPage]: DynamicPage,
     [ContentType.MainArticle]: DynamicPage,

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.module.scss
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.module.scss
@@ -12,30 +12,31 @@
     @include common.full-width-mixin;
 
     &.situation {
-        //TODO: endre til SituationPage.$situationPageColor når den er skrevet om til Scss
-        box-shadow: 0 -4px 0 common.$navds-global-color-orange-500 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-orange-500) inset;
     }
 
     &.product {
-        //TODO: endre til ProductPage.$productPageColor når den er skrevet om til Scss
-        box-shadow: 0 -4px 0 common.$navds-global-color-green-500 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-green-500) inset;
     }
 
     &.guide {
-        //TODO: endre til GuidePage.$guidePageColor når den er skrevet om til Scss
-        box-shadow: 0 -4px 0 common.$navds-global-color-lightblue-500 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-lightblue-500) inset;
     }
 
     &.themedpage {
-        box-shadow: 0 -4px 0 common.$navds-global-color-limegreen-500 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-limegreen-500) inset;
     }
 
     &.tool {
-        box-shadow: 0 -4px 0 common.$navds-global-color-deepblue-500 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-deepblue-500) inset;
     }
 
     &.overview {
-        box-shadow: 0 -4px 0 common.$navds-global-color-deepblue-400 inset;
+        box-shadow: 0 -4px 0 var(--navds-global-color-deepblue-400) inset;
+    }
+
+    &.generic {
+        box-shadow: 0 -4px 0 var(--navds-global-color-gray-600) inset;
     }
 
     @media #{common.$mq-screen-mobile} {

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -109,6 +109,10 @@ export const ThemedPageHeader = ({
             return 'overview';
         }
 
+        if (_pageType === ContentType.GenericPage) {
+            return 'generic';
+        }
+
         return '';
     };
 

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { classNames } from '../../utils/classnames';
-import { ContentProps, ContentType } from '../../types/content-props/_content-common';
+import {
+    ContentProps,
+    ContentType,
+} from '../../types/content-props/_content-common';
 import { getContentLanguages } from '../../utils/languages';
 import { VersionHistory } from './version-history/VersionHistory';
 import { PageWarning } from './page-warning/PageWarning';
@@ -11,6 +14,7 @@ export const contentTypesWithWhiteHeader = {
     [ContentType.ProductPage]: true,
     [ContentType.SituationPage]: true,
     [ContentType.GuidePage]: true,
+    [ContentType.GenericPage]: true,
     [ContentType.ThemedArticlePage]: true,
     [ContentType.Overview]: true,
 };

--- a/src/components/pages/generic-page/GenericPage.scss
+++ b/src/components/pages/generic-page/GenericPage.scss
@@ -1,0 +1,33 @@
+@use 'src/common' as common;
+
+.genericPage {
+    display: flex;
+    flex-direction: column;
+
+    .content {
+        align-self: center;
+        width: 100%;
+
+        // Break out of the global app padding for better screen-width usage
+        // on narrower screens
+        @media #{common.$mq-screen-tablet-and-desktop} {
+            margin-left: -(common.$padding-sides-tablet);
+            margin-right: -(common.$padding-sides-tablet);
+        }
+
+        @media #{common.$mq-screen-desktop} {
+            margin-left: -(common.$padding-sides-desktop);
+            margin-right: -(common.$padding-sides-desktop);
+        }
+    }
+
+    .icon-container {
+        background-color: var(--navds-global-color-green-200);
+        img {
+            height: 50%;
+            width: 50%;
+        }
+    }
+
+    @include common.product-mixins();
+}

--- a/src/components/pages/generic-page/GenericPage.tsx
+++ b/src/components/pages/generic-page/GenericPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ComponentMapper } from '../../ComponentMapper';
+import { ProductPageProps } from '../../../types/content-props/dynamic-page-props';
+import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+
+export const GenericPage = (props: ProductPageProps) => {
+    return (
+        <div className={'genericPage'}>
+            <ThemedPageHeader contentProps={props} />
+            <div className={'content'}>
+                <ComponentMapper
+                    componentProps={props.page}
+                    pageProps={props}
+                />
+            </div>
+        </div>
+    );
+};

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -39,6 +39,7 @@ export enum ContentType {
     DynamicPage = 'no_nav_navno_DynamicPage',
     ContentList = 'no_nav_navno_ContentList',
     ContactInformationPage = 'no_nav_navno_ContactInformation',
+    GenericPage = 'no_nav_navno_GenericPage',
     PageList = 'no_nav_navno_PageList',
     MainArticle = 'no_nav_navno_MainArticle',
     MainArticleChapter = 'no_nav_navno_MainArticleChapter',


### PR DESCRIPTION
Enkelte sider er bygget på produktside-malen selv om de ikke er produkter. Vi trenger en generell sidemal som kan brukes på enkeltstående sider som ikke faller inn under de definerte sidemalene.

I første omgang gjelder det kun kontakt oss-sidene.

Liten oppussingsobb på ThemedPageHeader for oppdatert bruk av vars fremfor common.