### PR TITLE
Fikser visning av navn ved publisering/avpublisering i CS

### DIFF
--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -6,7 +6,7 @@ import {
 } from '../site-info/feature-toggles/utils';
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
-import { PublishedNameFixHack } from './published-name-fix/PublishedNameFixHack';
+import { PublishedNameDisplayHack } from './published-name-display/PublishedNameDisplayHack';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users
 
@@ -23,7 +23,7 @@ export const EditorHacks = ({ content }: Props) => {
 
     return (
         <>
-            <PublishedNameFixHack contentId={_id} />
+            <PublishedNameDisplayHack contentId={_id} />
             {editorView === 'edit' && (
                 <>
                     <AutoReloadDisableHack content={content} />

--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -6,6 +6,7 @@ import {
 } from '../site-info/feature-toggles/utils';
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
+import { PublishedNameFixHack } from './published-name-fix/PublishedNameFixHack';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users
 
@@ -14,16 +15,23 @@ type Props = {
 };
 
 export const EditorHacks = ({ content }: Props) => {
-    if (content.editorView !== 'edit') {
+    const { _id, editorView } = content;
+
+    if (!editorView || editorView === 'preview') {
         return null;
     }
 
     return (
         <>
-            <AutoReloadDisableHack content={content} />
-            <CustomSelectorLinkTargetHack />
-            {isEditorFeatureEnabled(EditorFeatureCookie.HideLeftPanel) && (
-                <SetSidepanelToggleHack contentId={content._id} />
+            <PublishedNameFixHack contentId={_id} />
+            {editorView === 'edit' && (
+                <>
+                    <AutoReloadDisableHack content={content} />
+                    <CustomSelectorLinkTargetHack />
+                    {isEditorFeatureEnabled(
+                        EditorFeatureCookie.HideLeftPanel
+                    ) && <SetSidepanelToggleHack contentId={_id} />}
+                </>
             )}
         </>
     );

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
@@ -1,7 +1,7 @@
 import {
-    fetchAdminContent,
-    fetchAdminUserId,
-    fetchUserInfo,
+    editorFetchAdminContent,
+    editorFetchAdminUserId,
+    editorFetchUserInfo,
 } from '../editor-fetch-utils';
 import {
     ContentProps,
@@ -85,11 +85,11 @@ export const hookDispatchEventForBatchContentServerEvent = ({
     let userId;
     let skipNextEventIfBatchContentServerEvent = false;
 
-    fetchAdminUserId().then((id) => {
+    editorFetchAdminUserId().then((id) => {
         userId = id;
     });
 
-    fetchAdminContent(contentId).then((res) => {
+    editorFetchAdminContent(contentId).then((res) => {
         prevWorkflowState = res?.workflow.state;
     });
 
@@ -149,7 +149,7 @@ export const hookDispatchEventForBatchContentServerEvent = ({
         }
 
         // We use the internal Content Studio content api to check who last modified the content
-        fetchAdminContent(contentId).then((content) => {
+        editorFetchAdminContent(contentId).then((content) => {
             if (!content) {
                 // In the unexpected event that this call fails, just dispatch the event as normal to ensure we
                 // don't break anything :)
@@ -184,7 +184,7 @@ export const hookDispatchEventForBatchContentServerEvent = ({
                     `Content was updated by another user (${userId}) - showing warning`
                 );
 
-                fetchUserInfo(content.modifier).then((userInfo) => {
+                editorFetchUserInfo(content.modifier).then((userInfo) => {
                     if (userInfo) {
                         setExternalUserName(
                             getUserNameFromEmail(userInfo.displayName)

--- a/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
+++ b/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
@@ -1,10 +1,12 @@
 import { adminOrigin } from '../../../utils/urls';
 import { fetchJson } from '../../../utils/fetch/fetch-utils';
 import { ContentProps } from '../../../types/content-props/_content-common';
+import { Branch } from '../../../types/branch';
 
 const adminAuthUrl = `${adminOrigin}/admin/rest/auth/authenticated`;
 const userInfoUrl = `${adminOrigin}/admin/rest-v2/cs/security/principals/user:`;
 const contentServiceUrl = `${adminOrigin}/admin/tool/com.enonic.app.contentstudio/main/_/service/com.enonic.app.contentstudio/content`;
+const versionsUrl = `${adminOrigin}/admin/rest-v2/cs/cms/default/content/content/getVersionsForView`;
 
 type UserInfo = {
     key: string;
@@ -36,3 +38,20 @@ export const fetchAdminContent = async (contentId: string) =>
 
 export const fetchUserInfo = async (userId: string) =>
     fetchJson<UserInfo>(`${userInfoUrl}${userId}?memberships=false`, 5000);
+
+type VersionsResponse = {
+    contentVersions?: Array<{
+        publishInfo?: {
+            publisher: string;
+            publisherDisplayName: string;
+            type: 'PUBLISHED' | 'UNPUBLISHED';
+        };
+    }>;
+};
+
+export const editorFetchVersions = async (contentId: string) =>
+    fetchJson<VersionsResponse>(versionsUrl, 5000, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        body: JSON.stringify({ contentId, size: -1 }),
+    });

--- a/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
+++ b/src/components/_editor-only/editor-hacks/editor-fetch-utils.ts
@@ -1,7 +1,6 @@
 import { adminOrigin } from '../../../utils/urls';
 import { fetchJson } from '../../../utils/fetch/fetch-utils';
 import { ContentProps } from '../../../types/content-props/_content-common';
-import { Branch } from '../../../types/branch';
 
 const adminAuthUrl = `${adminOrigin}/admin/rest/auth/authenticated`;
 const userInfoUrl = `${adminOrigin}/admin/rest-v2/cs/security/principals/user:`;
@@ -13,41 +12,42 @@ type UserInfo = {
     displayName: string;
 };
 
+export type ContentWorkflowState = 'READY' | 'IN_PROGRESS';
+
 type AdminAuthResponse = {
     authenticated: boolean;
     user: UserInfo;
 };
-
-export type ContentWorkflowState = 'READY' | 'IN_PROGRESS';
 
 export type AdminContentResponse = ContentProps & {
     workflow: { state: ContentWorkflowState };
     modifier: string;
 };
 
-export const fetchAdminUserId = () =>
+type VersionsResponse = {
+    activeVersion?: {
+        contentVersion?: {
+            modifierDisplayName: string;
+            publishInfo?: {
+                publisherDisplayName: string;
+            };
+        };
+    };
+};
+
+export const editorFetchAdminUserId = () =>
     fetchJson<AdminAuthResponse>(adminAuthUrl, 5000).then((res) => {
         return res?.user?.key;
     });
 
-export const fetchAdminContent = async (contentId: string) =>
+export const editorFetchAdminContent = async (contentId: string) =>
     fetchJson<AdminContentResponse>(
         `${contentServiceUrl}?contentId=${contentId}`,
         5000
     );
 
-export const fetchUserInfo = async (userId: string) =>
+export const editorFetchUserInfo = async (userId: string) =>
     fetchJson<UserInfo>(`${userInfoUrl}${userId}?memberships=false`, 5000);
-
-type VersionsResponse = {
-    contentVersions?: Array<{
-        publishInfo?: {
-            publisher: string;
-            publisherDisplayName: string;
-            type: 'PUBLISHED' | 'UNPUBLISHED';
-        };
-    }>;
-};
 
 export const editorFetchVersions = async (contentId: string) =>
     fetchJson<VersionsResponse>(versionsUrl, 5000, {

--- a/src/components/_editor-only/editor-hacks/published-name-display/PublishedNameDisplayHack.tsx
+++ b/src/components/_editor-only/editor-hacks/published-name-display/PublishedNameDisplayHack.tsx
@@ -6,19 +6,19 @@ type Props = {
 };
 
 // Ensure the correct name is displayed on the top of the editor-view
-// There is a bug in CS which shows the last editor to modify the content
-// only, which ignores publishing/unpublishing actions
-export const PublishedNameFixHack = ({ contentId }: Props) => {
+// There is a bug in CS which causes it to always shows the last editor to
+// modify the content, ignoring publishing/unpublishing actions
+export const PublishedNameDisplayHack = ({ contentId }: Props) => {
     useEffect(() => {
         editorFetchVersions(contentId).then((res) => {
-            if (!res) {
+            const activeVersion = res?.activeVersion?.contentVersion;
+            if (!activeVersion) {
                 return;
             }
 
             const editorDisplayName =
-                res.activeVersion?.contentVersion?.publishInfo
-                    ?.publisherDisplayName ||
-                res.activeVersion.contentVersion.modifierDisplayName;
+                activeVersion.publishInfo?.publisherDisplayName ||
+                activeVersion.modifierDisplayName;
             if (!editorDisplayName) {
                 return;
             }

--- a/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
+++ b/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
@@ -5,6 +5,9 @@ type Props = {
     contentId: string;
 };
 
+// Ensure the correct name is displayed on the top of the editor-view
+// There is a bug in CS which shows the last editor to modify the content
+// only, which ignores publishing/unpublishing actions
 export const PublishedNameFixHack = ({ contentId }: Props) => {
     useEffect(() => {
         editorFetchVersions(contentId).then((res) => {
@@ -12,16 +15,13 @@ export const PublishedNameFixHack = ({ contentId }: Props) => {
                 return;
             }
 
-            const lastCommitedVersion = res.contentVersions?.find(
-                (version) => !!version.publishInfo
-            );
-            if (!lastCommitedVersion) {
+            const editorDisplayName =
+                res.activeVersion?.contentVersion?.publishInfo
+                    ?.publisherDisplayName ||
+                res.activeVersion.contentVersion.modifierDisplayName;
+            if (!editorDisplayName) {
                 return;
             }
-
-            console.log(
-                `Last committer: ${lastCommitedVersion.publishInfo.publisherDisplayName}`
-            );
 
             const authorContainer =
                 parent.window.document.getElementsByClassName(
@@ -32,7 +32,7 @@ export const PublishedNameFixHack = ({ contentId }: Props) => {
             }
 
             const preposition = authorContainer.innerText.split(' ')[0];
-            authorContainer.innerText = `${preposition} ${lastCommitedVersion.publishInfo.publisherDisplayName}`;
+            authorContainer.innerText = `${preposition} ${editorDisplayName}`;
         });
     }, [contentId]);
 

--- a/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
+++ b/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
@@ -31,8 +31,8 @@ export const PublishedNameFixHack = ({ contentId }: Props) => {
                 return;
             }
 
-            authorContainer.innerText =
-                lastCommitedVersion.publishInfo.publisherDisplayName;
+            const preposition = authorContainer.innerText.split(' ')[0];
+            authorContainer.innerText = `${preposition} ${lastCommitedVersion.publishInfo.publisherDisplayName}`;
         });
     }, [contentId]);
 

--- a/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
+++ b/src/components/_editor-only/editor-hacks/published-name-fix/PublishedNameFixHack.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import { editorFetchVersions } from '../editor-fetch-utils';
+
+type Props = {
+    contentId: string;
+};
+
+export const PublishedNameFixHack = ({ contentId }: Props) => {
+    useEffect(() => {
+        editorFetchVersions(contentId).then((res) => {
+            if (!res) {
+                return;
+            }
+
+            const lastCommitedVersion = res.contentVersions?.find(
+                (version) => !!version.publishInfo
+            );
+            if (!lastCommitedVersion) {
+                return;
+            }
+
+            console.log(
+                `Last committer: ${lastCommitedVersion.publishInfo.publisherDisplayName}`
+            );
+
+            const authorContainer =
+                parent.window.document.getElementsByClassName(
+                    'author'
+                )[0] as HTMLElement;
+            if (!authorContainer) {
+                return;
+            }
+
+            authorContainer.innerText =
+                lastCommitedVersion.publishInfo.publisherDisplayName;
+        });
+    }, [contentId]);
+
+    return null;
+};

--- a/src/components/_editor-only/editor-hacks/set-sidepanels-defaults/SetSidepanelToggleHack.tsx
+++ b/src/components/_editor-only/editor-hacks/set-sidepanels-defaults/SetSidepanelToggleHack.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { fetchAdminContent } from '../editor-fetch-utils';
+import { editorFetchAdminContent } from '../editor-fetch-utils';
 
 /*
  * Closes the left-side data editor panel for content which has been customized
@@ -23,7 +23,7 @@ type Props = {
 
 export const SetSidepanelToggleHack = ({ contentId }: Props) => {
     useEffect(() => {
-        fetchAdminContent(contentId).then((res) => {
+        editorFetchAdminContent(contentId).then((res) => {
             if (res?.page?.type === 'page') {
                 minimizeLeftPanel();
             }


### PR DESCRIPTION
Er en bug i Content Studio som i enkelte tilfeller viser feil navn for siste endring på et innhold, det har visst skapt noe forvirring. Den viser alltid navn på siste redaktør som lagret innholdet, og ignorerer publisering/avpublisering. (Se https://github.com/navikt/nav-enonicxp/issues/1382#issuecomment-1145721043)
