### PR TITLE
Fjerner survey som er utgått.

### DIFF
--- a/src/utils/decorator/decorator-utils.ts
+++ b/src/utils/decorator/decorator-utils.ts
@@ -63,7 +63,7 @@ const defaultParams = {
 };
 
 const taSurveys = {
-    taSurveys: '03229',
+    taSurveys: '',
 };
 
 export const getDecoratorParams = (content: ContentProps): DecoratorParams => {


### PR DESCRIPTION
På sikt: Vi bør se på å lage en funksjon i XP hvor teamet selv kan legge inn ta-koder for nye surveys slik at de hentes inn i dekoratøren. Pr nå har jeg bare fjernet koden, men latt riggen for å sende inn ta-koder til dekoratøren bli værende så kan jeg se på en forbedring av dette som en sommeroppgave når mange andre har fri.