### PR TITLE
Komponenter for utlisting av situasjoner på områdesider

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -181,16 +181,20 @@ module.exports = withPlugins([withTranspileModules], {
         return config;
     },
     redirects: async () => [
-        {
-            source: '/',
-            destination: '/no/person',
-            permanent: false,
-        },
-        {
-            source: '/forsiden',
-            destination: '/no/person',
-            permanent: false,
-        },
+        ...(process.env.ENV === 'prod'
+            ? [
+                  {
+                      source: '/',
+                      destination: '/no/person',
+                      permanent: false,
+                  },
+                  {
+                      source: '/forsiden',
+                      destination: '/no/person',
+                      permanent: false,
+                  },
+              ]
+            : []),
         {
             source: '/www.nav.no',
             destination: '/',

--- a/src/components/_common/animate-height/AnimateHeight.tsx
+++ b/src/components/_common/animate-height/AnimateHeight.tsx
@@ -56,7 +56,9 @@ export const AnimateHeight = ({
         setHeightToRender(prevHeight);
 
         // Trigger animation by setting the new height on the next frame
-        requestAnimationFrame(() => setHeightToRender(height));
+        const animationFrameRequestHandle = requestAnimationFrame(() =>
+            setHeightToRender(height)
+        );
 
         // Calculate the duration of the transition from the height delta to ensure
         // a consistent animation speed
@@ -66,7 +68,12 @@ export const AnimateHeight = ({
         // After the transition is finished, remove the height attribute
         // We don't want to leave the height static, in case the content of
         // the container changes
-        setTimeout(() => setHeightToRender(null), durationMs);
+        setTimeout(() => {
+            // Cancel the animationframe request in case it is slower than our
+            // calculated animation duration
+            window.cancelAnimationFrame(animationFrameRequestHandle);
+            setHeightToRender(null);
+        }, durationMs);
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [childrenToRender]);

--- a/src/components/_editor-only/editor-help/EditorHelp.module.scss
+++ b/src/components/_editor-only/editor-help/EditorHelp.module.scss
@@ -9,8 +9,8 @@
     margin: 1rem 0;
 
     .icon {
-        height: common.round-rem(1.55rem);
-        width: common.round-rem(1.55rem);
+        height: 1.5rem;
+        width: 1.5rem;
         margin-right: 1rem;
 
         &.info,

--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -37,7 +37,7 @@ export const EditorHelp = ({ text, type = 'help' }: Props) => {
             <StaticImage
                 imageData={imagePath[type]}
                 alt={''}
-                className={classNames(style.icon, type)}
+                className={classNames(style.icon, style[type])}
             />
             <BodyShort spacing={false} size="small" className={style.content}>
                 {text}

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -17,6 +17,8 @@ export const contentTypesWithWhiteHeader = {
     [ContentType.GenericPage]: true,
     [ContentType.ThemedArticlePage]: true,
     [ContentType.Overview]: true,
+    [ContentType.FrontPage]: true,
+    [ContentType.AreaPage]: true,
 };
 type Props = {
     content: ContentProps;

--- a/src/components/layouts/LayoutContainer.tsx
+++ b/src/components/layouts/LayoutContainer.tsx
@@ -51,7 +51,8 @@ export const LayoutContainer = ({
                 paddingConfig === 'standard' && style.standard,
                 config.bgColor?.color && style.bg,
                 pageConfig.editorView === 'edit' &&
-                    editorAuthstateClassname(config.renderOnAuthState)
+                    editorAuthstateClassname(config.renderOnAuthState),
+                divElementProps.className
             )}
             style={{ ...commonLayoutStyle, ...layoutStyle }}
         >

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -13,6 +13,7 @@ import { ProductPageFlexColsLayout } from './flex-cols/ProductPageFlexColsLayout
 import { ProductDetailsLayout } from './product-details-layout/ProductDetailsLayout';
 import { IndexPage } from './index-page/IndexPage';
 import { useLayoutConfig } from './useLayoutConfig';
+import { AreapageSituationsLayout } from './areapage-situations/AreapageSituationsLayout';
 
 type Props = {
     pageProps: ContentProps;
@@ -37,7 +38,7 @@ const layoutComponents: {
     [LayoutType.ProductPageFlexCols]: ProductPageFlexColsLayout,
     [LayoutType.ProductDetailsPage]: ProductDetailsLayout,
     [LayoutType.IndexPage]: IndexPage,
-    [LayoutType.AreapageSituations]: () => null,
+    [LayoutType.AreapageSituations]: AreapageSituationsLayout,
 };
 
 export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -37,6 +37,7 @@ const layoutComponents: {
     [LayoutType.ProductPageFlexCols]: ProductPageFlexColsLayout,
     [LayoutType.ProductDetailsPage]: ProductDetailsLayout,
     [LayoutType.IndexPage]: IndexPage,
+    [LayoutType.AreapageSituations]: () => null,
 };
 
 export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {

--- a/src/components/layouts/Region.tsx
+++ b/src/components/layouts/Region.tsx
@@ -19,7 +19,8 @@ export const Region = ({
     regionProps,
     regionStyle,
     bemModifier,
-}: Props) => {
+    ...divElementProps
+}: Props & React.HTMLAttributes<HTMLDivElement>) => {
     if (!regionProps) {
         return (
             <EditorHelp
@@ -33,11 +34,13 @@ export const Region = ({
 
     return (
         <div
+            {...divElementProps}
             style={regionStyle}
             className={classNames(
                 bem(),
                 bem(name),
-                bemModifier && bem(name, bemModifier)
+                bemModifier && bem(name, bemModifier),
+                divElementProps.className
             )}
             data-portal-region={!!pageProps.editorView ? name : undefined}
         >

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
@@ -11,7 +11,7 @@
 .situations {
     display: flex;
     flex-wrap: wrap;
-    @include common.flex-cols-mixin(2, 1.5rem, 0);
+    @include common.flex-cols-mixin(2, 1.5rem, 1.5rem);
 }
 
 .header {

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
@@ -1,0 +1,17 @@
+@use 'src/common' as common;
+
+.container {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+    background-color: common.$navds-global-color-deepblue-50;
+
+    @include common.full-width-mixin();
+}
+
+.situations {
+    @include common.flex-cols-mixin(2);
+}
+
+.header {
+    margin-bottom: 1rem;
+}

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
@@ -9,7 +9,9 @@
 }
 
 .situations {
-    @include common.flex-cols-mixin(2);
+    display: flex;
+    flex-wrap: wrap;
+    @include common.flex-cols-mixin(2, 1.5rem, 0);
 }
 
 .header {

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -43,8 +43,14 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             </Header>
             <EditorHelp
                 text={
-                    'Listen genereres automatisk ut fra målgruppe og område, og kan ikke endres manuelt.' +
+                    'Listen oppdateres automatisk ut fra målgruppe og område, og kan ikke endres manuelt.' +
                     ' For å skjule et kort, klikk og velg "Skjul..." i høyre-panelet.'
+                }
+            />
+            <EditorHelp
+                text={
+                    'Når listen oppdateres kan det i enkelte tilfeller vises en feilmelding.' +
+                    ' Denne skal forsvinne ved reload av editoren (F5).'
                 }
             />
             <Region

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { AreapageSituationsProps } from '../../../types/component-props/layouts/areapage-situations';
+import { ContentProps } from '../../../types/content-props/_content-common';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
+import { LayoutContainer } from '../LayoutContainer';
+import { Header } from '../../_common/headers/Header';
+import Region from '../Region';
+
+import style from './AreapageSituationsLayout.module.scss';
+
+type Props = {
+    pageProps: ContentProps;
+    layoutProps: AreapageSituationsProps;
+};
+
+export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
+    const { regions, config } = layoutProps;
+
+    if (!config || !regions) {
+        return (
+            <EditorHelp
+                type={'error'}
+                text={'Feil: Komponenten mangler data'}
+            />
+        );
+    }
+
+    const { title } = config;
+
+    return (
+        <LayoutContainer
+            pageProps={pageProps}
+            layoutProps={layoutProps}
+            className={style.container}
+        >
+            <Header
+                level={'2'}
+                justify={'left'}
+                size={'large'}
+                className={style.header}
+            >
+                {title}
+            </Header>
+            <Region
+                pageProps={pageProps}
+                regionProps={regions.situations}
+                className={style.situations}
+            />
+        </LayoutContainer>
+    );
+};

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -44,7 +44,7 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             <EditorHelp
                 text={
                     'Listen oppdateres automatisk ut fra målgruppe og område, og kan ikke endres manuelt.' +
-                    ' For å skjule et kort, klikk og velg "Skjul..." i høyre-panelet.'
+                    ' For å fjerne et kort fra siden, velg "Skjul..." i høyre-panelet.'
                 }
             />
             <EditorHelp

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -41,6 +41,11 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             >
                 {title}
             </Header>
+            <EditorHelp
+                text={
+                    'Denne listen genereres automatisk. Kort kan ikke slettes eller opprettes manuelt.'
+                }
+            />
             <Region
                 pageProps={pageProps}
                 regionProps={regions.situations}

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -43,7 +43,8 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             </Header>
             <EditorHelp
                 text={
-                    'Denne listen genereres automatisk. Kort kan ikke slettes eller opprettes manuelt.'
+                    'Listen genereres automatisk ut fra målgruppe og område, og kan ikke endres manuelt.' +
+                    ' For å skjule et kort, klikk og velg "Skjul..." i høyre-panelet.'
                 }
             />
             <Region

--- a/src/components/layouts/index-page/IndexPage.module.scss
+++ b/src/components/layouts/index-page/IndexPage.module.scss
@@ -1,0 +1,3 @@
+.indexPage {
+    max-width: 1272px;
+}

--- a/src/components/layouts/index-page/IndexPage.module.scss
+++ b/src/components/layouts/index-page/IndexPage.module.scss
@@ -1,4 +1,8 @@
 .indexPage {
     max-width: 1272px;
     margin: 0 auto;
+
+    :global(.region__contentTop) {
+        margin-bottom: 2rem;
+    }
 }

--- a/src/components/layouts/index-page/IndexPage.module.scss
+++ b/src/components/layouts/index-page/IndexPage.module.scss
@@ -1,3 +1,4 @@
 .indexPage {
     max-width: 1272px;
+    margin: 0 auto;
 }

--- a/src/components/layouts/index-page/IndexPage.tsx
+++ b/src/components/layouts/index-page/IndexPage.tsx
@@ -17,6 +17,8 @@ import { AlertBox } from '../../_common/alert-box/AlertBox';
 import { LenkeInline } from '../../_common/lenke/LenkeInline';
 import { AnimateHeight } from '../../_common/animate-height/AnimateHeight';
 
+import style from './IndexPage.module.scss';
+
 export type IndexPageContentProps = FrontPageProps | AreaPageProps;
 
 const IndexPageContent = (pageProps: IndexPageContentProps) => {
@@ -28,6 +30,7 @@ const IndexPageContent = (pageProps: IndexPageContentProps) => {
         <LayoutContainer
             pageProps={currentPageProps}
             layoutProps={currentPageProps.page}
+            className={style.indexPage}
         >
             <Head>
                 <title>{getPageTitle(currentPageProps)}</title>

--- a/src/components/layouts/index-page/IndexPage.tsx
+++ b/src/components/layouts/index-page/IndexPage.tsx
@@ -48,10 +48,12 @@ const IndexPageContent = (pageProps: IndexPageContentProps) => {
                 </AlertBox>
             )}
             <AnimateHeight trigger={currentPageProps._id}>
-                <Region
-                    pageProps={currentPageProps}
-                    regionProps={regions.contentTop}
-                />
+                {currentPageProps.__typename === ContentType.FrontPage && (
+                    <Region
+                        pageProps={currentPageProps}
+                        regionProps={regions.contentTop}
+                    />
+                )}
             </AnimateHeight>
             <IndexPageNavigation
                 pageProps={currentPageProps}

--- a/src/components/layouts/index-page/navigation/IndexPageNavigation.module.scss
+++ b/src/components/layouts/index-page/navigation/IndexPageNavigation.module.scss
@@ -1,7 +1,7 @@
 @use 'src/common' as common;
 
 .centerNavigation {
-    padding: 2rem 0;
+    padding-bottom: 2rem;
     background-color: #fff;
     @include common.full-width-mixin();
 }

--- a/src/components/layouts/index-page/navigation/IndexPageNavigation.tsx
+++ b/src/components/layouts/index-page/navigation/IndexPageNavigation.tsx
@@ -33,10 +33,12 @@ export const IndexPageNavigation = ({
                 />
             </AnimateHeight>
             <FrontPageAreasHeader content={pageProps} />
-            <IndexPageAreaPanels
-                content={pageProps}
-                navigationCallback={navigationCallback}
-            />
+            <AnimateHeight trigger={_id}>
+                <IndexPageAreaPanels
+                    content={pageProps}
+                    navigationCallback={navigationCallback}
+                />
+            </AnimateHeight>
         </div>
     );
 };

--- a/src/components/layouts/index-page/navigation/IndexPageNavigation.tsx
+++ b/src/components/layouts/index-page/navigation/IndexPageNavigation.tsx
@@ -9,6 +9,7 @@ import { AreaPageNavigationBar } from './area-page-navigation/AreaPageNavigation
 import { FrontPageAreasHeader } from './front-page-areas-header/FrontPageAreasHeader';
 
 import style from './IndexPageNavigation.module.scss';
+import { AnimateHeight } from '../../../_common/animate-height/AnimateHeight';
 
 type Props = {
     pageProps: FrontPageProps | AreaPageProps;
@@ -24,11 +25,13 @@ export const IndexPageNavigation = ({
 
     return (
         <div className={style.centerNavigation}>
-            <AreaPageNavigationBar
-                isVisible={__typename === ContentType.AreaPage}
-                areasRefs={areasRefs.filter((ref) => ref._id !== _id)}
-                navigationCallback={navigationCallback}
-            />
+            <AnimateHeight trigger={_id}>
+                <AreaPageNavigationBar
+                    isVisible={__typename === ContentType.AreaPage}
+                    areasRefs={areasRefs.filter((ref) => ref._id !== _id)}
+                    navigationCallback={navigationCallback}
+                />
+            </AnimateHeight>
             <FrontPageAreasHeader content={pageProps} />
             <IndexPageAreaPanels
                 content={pageProps}

--- a/src/components/layouts/index-page/navigation/area-panels/IndexPageAreaPanels.module.scss
+++ b/src/components/layouts/index-page/navigation/area-panels/IndexPageAreaPanels.module.scss
@@ -5,8 +5,4 @@
     flex-wrap: wrap;
     width: 100%;
     justify-content: space-between;
-
-    & > * {
-        width: 30%;
-    }
 }

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AreaPageProps } from '../../../../../../types/content-props/index-pages-props';
 import { IndexPageContentProps } from '../../../IndexPage';
 import { ContentType } from '../../../../../../types/content-props/_content-common';
 import { WarningFilled } from '@navikt/ds-icons';
 import { classNames } from '../../../../../../utils/classnames';
 import { AreaHeaderPanelExpanded } from './expanded/AreaHeaderPanelExpanded';
+import { getPublicPathname } from '../../../../../../utils/urls';
 
 import style from './AreaPanel.module.scss';
-import { getPublicPathname } from '../../../../../../utils/urls';
 
 const AreaCardPlaceholder = ({
     areaContent,
@@ -51,16 +51,41 @@ export const AreaHeaderPanel = ({
 }: Props) => {
     const { __typename: currentType, _id: currentId } = currentContent;
 
+    const [prevType, setPrevType] = useState(currentType);
+    const [useFrontpageTransition, setUseFrontpageTransition] = useState(false);
+
+    useEffect(() => {
+        if (currentType === prevType) {
+            return;
+        }
+
+        if (
+            prevType === ContentType.FrontPage &&
+            currentType === ContentType.AreaPage
+        ) {
+            setUseFrontpageTransition(true);
+        }
+
+        setPrevType(currentType);
+    }, [currentType, prevType]);
+
     return currentType === ContentType.AreaPage &&
         areaContent._id === currentId ? (
-        <div className={classNames(style.areaPanel, style.areaPanelActive)}>
+        <div
+            className={classNames(
+                style.areaPanel,
+                style.areaPanelActive,
+                useFrontpageTransition && style.animate
+            )}
+        >
             <AreaHeaderPanelExpanded areaContent={currentContent} />
         </div>
     ) : (
         <div
             className={classNames(
                 style.areaPanel,
-                currentType === ContentType.AreaPage && style.areaPanelHidden
+                currentType === ContentType.AreaPage && style.areaPanelHidden,
+                useFrontpageTransition && style.animate
             )}
         >
             <AreaCardPlaceholder

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
@@ -49,26 +49,27 @@ export const AreaHeaderPanel = ({
     currentContent,
     navigationCallback,
 }: Props) => {
-    const { __typename: currentType, _id: currentId } = currentContent;
+    const { __typename, _id } = currentContent;
 
-    const [prevType, setPrevType] = useState(currentType);
-    const [useFrontpageTransition, setUseFrontpageTransition] = useState(false);
+    const [currentId, setCurrentId] = useState(_id);
+    const [currentType, setCurrentType] = useState<ContentType>(__typename);
+    const [prevType, setPrevType] = useState<ContentType>();
 
     useEffect(() => {
-        if (currentType === prevType) {
-            setUseFrontpageTransition(false);
+        if (currentId === _id) {
             return;
         }
 
-        setUseFrontpageTransition(
-            prevType === ContentType.FrontPage &&
-                currentType === ContentType.AreaPage
-        );
-
+        setCurrentId(_id);
         setPrevType(currentType);
-    }, [currentType, prevType]);
+        setCurrentType(__typename);
+    }, [__typename, currentType, currentId, _id]);
 
-    return currentType === ContentType.AreaPage &&
+    const useFrontpageTransition =
+        prevType === ContentType.FrontPage &&
+        currentType === ContentType.AreaPage;
+
+    return __typename === ContentType.AreaPage &&
         areaContent._id === currentId ? (
         <div
             className={classNames(

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
@@ -59,12 +59,10 @@ export const AreaHeaderPanel = ({
             return;
         }
 
-        if (
+        setUseFrontpageTransition(
             prevType === ContentType.FrontPage &&
-            currentType === ContentType.AreaPage
-        ) {
-            setUseFrontpageTransition(true);
-        }
+                currentType === ContentType.AreaPage
+        );
 
         setPrevType(currentType);
     }, [currentType, prevType]);

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaHeaderPanel.tsx
@@ -56,6 +56,7 @@ export const AreaHeaderPanel = ({
 
     useEffect(() => {
         if (currentType === prevType) {
+            setUseFrontpageTransition(false);
             return;
         }
 

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaPanel.module.scss
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaPanel.module.scss
@@ -7,32 +7,31 @@
 }
 
 .areaPanelActive {
-    width: 100%;
-    height: 100%;
-    min-height: 100%;
+    animation-name: expandActive;
+    animation-duration: 0ms;
+    animation-fill-mode: forwards;
+    animation-direction: alternate;
+    animation-timing-function: ease-in;
 
-    .animate {
-        animation-name: expandActive;
-        animation-duration: 500ms;
-        animation-fill-mode: forwards;
-        animation-direction: alternate;
-        animation-timing-function: ease-in;
+    @media not screen and (prefers-reduced-motion) {
+        &.animate {
+            animation-duration: 500ms;
+        }
     }
 }
 
 .areaPanelHidden {
-    visibility: hidden;
-    width: 0;
-    min-height: 0;
-    height: 0;
+    overflow: hidden;
+    animation-name: shrinkInactive;
+    animation-duration: 0ms;
+    animation-fill-mode: forwards;
+    animation-direction: alternate;
+    animation-timing-function: ease-in;
 
-    .animate {
-        overflow: hidden;
-        animation-name: shrinkInactive;
-        animation-duration: 500ms;
-        animation-fill-mode: forwards;
-        animation-direction: alternate;
-        animation-timing-function: ease-in;
+    @media not screen and (prefers-reduced-motion) {
+        &.animate {
+            animation-duration: 500ms;
+        }
     }
 }
 

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaPanel.module.scss
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/AreaPanel.module.scss
@@ -3,24 +3,37 @@
     justify-content: space-between;
     background-color: #fff;
     min-height: 100px;
+    width: 30%;
 }
 
 .areaPanelActive {
-    animation-name: expandActive;
-    animation-duration: 500ms;
-    animation-fill-mode: forwards;
-    animation-direction: alternate;
-    animation-timing-function: ease-in;
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+
+    .animate {
+        animation-name: expandActive;
+        animation-duration: 500ms;
+        animation-fill-mode: forwards;
+        animation-direction: alternate;
+        animation-timing-function: ease-in;
+    }
 }
 
 .areaPanelHidden {
-    overflow: hidden;
+    visibility: hidden;
+    width: 0;
+    min-height: 0;
+    height: 0;
 
-    animation-name: shrinkInactive;
-    animation-duration: 500ms;
-    animation-fill-mode: forwards;
-    animation-direction: alternate;
-    animation-timing-function: ease-in;
+    .animate {
+        overflow: hidden;
+        animation-name: shrinkInactive;
+        animation-duration: 500ms;
+        animation-fill-mode: forwards;
+        animation-direction: alternate;
+        animation-timing-function: ease-in;
+    }
 }
 
 .icon {
@@ -29,6 +42,12 @@
 }
 
 @keyframes expandActive {
+    from {
+        width: 0;
+        height: 0;
+        min-height: 0;
+    }
+
     to {
         width: 100%;
         height: 100%;
@@ -37,6 +56,10 @@
 }
 
 @keyframes shrinkInactive {
+    from {
+        visibility: visible;
+    }
+
     to {
         visibility: hidden;
         width: 0;

--- a/src/components/layouts/index-page/navigation/area-panels/header-panel/expanded/AreaHeaderPanelExpanded.module.scss
+++ b/src/components/layouts/index-page/navigation/area-panels/header-panel/expanded/AreaHeaderPanelExpanded.module.scss
@@ -17,7 +17,6 @@
 .iconContainer {
     display: flex;
     justify-content: space-between;
-    width: 100%;
 
     .banner {
         margin-top: 1rem;

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -40,6 +40,7 @@ import { ProductCardMicroPart } from './product-card-micro/ProductCardMicro';
 import { editorAuthstateClassname } from '../_common/auth-dependant-render/AuthDependantRender';
 import { AlertPanelPart } from './alert-panel/AlertPanelPart';
 import { PayoutDatesPart } from './payout-dates/PayoutDatesPart';
+import { AreapageSituationCardPart } from './areapage-situation-card/AreapageSituationCardPart';
 
 type Props = {
     partProps: PartComponentProps;
@@ -83,6 +84,7 @@ const partsWithOwnData: {
     [PartType.ProductDetails]: ProductDetailsPart,
     [PartType.ContactOption]: ContactOptionPart,
     [PartType.PayoutDates]: PayoutDatesPart,
+    [PartType.AreapageSituationCard]: AreapageSituationCardPart,
 };
 
 const partsDeprecated: { [key in PartDeprecated] } = {

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
@@ -1,0 +1,7 @@
+.card {
+    width: 100%;
+
+    :global(.situation) {
+        min-height: 0 !important;
+    }
+}

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
@@ -1,5 +1,8 @@
+@use 'src/common' as common;
+
 .card {
     width: 100%;
+    position: relative;
 
     & > * {
         margin-bottom: 0;
@@ -9,4 +12,23 @@
     :global(.situation) {
         min-height: 0 !important;
     }
+}
+
+.disabled {
+    pointer-events: none;
+    :global(.situation) {
+        filter: grayscale(100%) blur(3px);
+    }
+}
+
+.disabledMsg {
+    position: absolute;
+    width: calc(100% - 2rem);
+    height: auto;
+    margin: 1rem;
+    padding: 1rem;
+    text-align: center;
+    z-index: 1;
+    border-radius: 4px;
+    background-color: common.$navds-global-color-orange-100;
 }

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.module.scss
@@ -1,6 +1,11 @@
 .card {
     width: 100%;
 
+    & > * {
+        margin-bottom: 0;
+        height: 100%;
+    }
+
     :global(.situation) {
         min-height: 0 !important;
     }

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
@@ -12,8 +12,13 @@ export const AreapageSituationCardPart = ({
     config,
 }: AreapageSituationCardPartProps) => {
     const { language } = usePageConfig();
-    if (!config?.target) {
-        return <EditorHelp text={'Komponenten er ikke konfigurert'} />;
+    if (!config?.target?._id) {
+        return (
+            <EditorHelp
+                type={'error'}
+                text={'Feil: komponenten har ingen gyldig referanse'}
+            />
+        );
     }
 
     const { target, disabled } = config;

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
@@ -25,7 +25,9 @@ export const AreapageSituationCardPart = ({
         <div className={classNames(style.card, disabled && style.disabled)}>
             {disabled && (
                 <span className={style.disabledMsg}>
-                    <strong>{`"${target.data.title}"`}</strong>
+                    <strong>{`"${
+                        target.data.title || target.displayName
+                    }"`}</strong>
                     {' er skjult på denne siden'}
                 </span>
             )}

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { AreapageSituationCardPartProps } from '../../../types/component-props/parts/areapage-situation-card';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
+import { LargeCard } from '../../_common/card/LargeCard';
+import { getCardProps } from '../../_common/card/card-utils';
+import { usePageConfig } from '../../../store/hooks/usePageConfig';
+
+import style from './AreapageSituationCardPart.module.scss';
+
+export const AreapageSituationCardPart = ({
+    config,
+}: AreapageSituationCardPartProps) => {
+    const { pageConfig, language } = usePageConfig();
+    const { editorView } = pageConfig;
+
+    if (!config?.target) {
+        return <EditorHelp text={'Komponenten er ikke konfigurert'} />;
+    }
+
+    const { target, disabled } = config;
+
+    if (disabled) {
+        return (
+            <EditorHelp
+                type={'info'}
+                text={`Situasjonen ${target.data.title} er skjult på denne siden`}
+            />
+        );
+    }
+
+    const props = getCardProps(target, language);
+
+    // Using product card as placeholder for now
+    return (
+        <div className={style.card}>
+            <LargeCard {...props} />
+        </div>
+    );
+};

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
@@ -4,35 +4,31 @@ import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 import { LargeCard } from '../../_common/card/LargeCard';
 import { getCardProps } from '../../_common/card/card-utils';
 import { usePageConfig } from '../../../store/hooks/usePageConfig';
+import classNames from 'classnames';
 
 import style from './AreapageSituationCardPart.module.scss';
 
 export const AreapageSituationCardPart = ({
     config,
 }: AreapageSituationCardPartProps) => {
-    const { pageConfig, language } = usePageConfig();
-    const { editorView } = pageConfig;
-
+    const { language } = usePageConfig();
     if (!config?.target) {
         return <EditorHelp text={'Komponenten er ikke konfigurert'} />;
     }
 
     const { target, disabled } = config;
 
-    if (disabled) {
-        return (
-            <EditorHelp
-                type={'info'}
-                text={`Situasjonen ${target.data.title} er skjult på denne siden`}
-            />
-        );
-    }
-
     const props = getCardProps(target, language);
 
     // Using product card as placeholder for now
     return (
-        <div className={style.card}>
+        <div className={classNames(style.card, disabled && style.disabled)}>
+            {disabled && (
+                <span className={style.disabledMsg}>
+                    <strong>{`"${target.data.title}"`}</strong>
+                    {' er skjult på denne siden'}
+                </span>
+            )}
             <LargeCard {...props} />
         </div>
     );

--- a/src/types/component-props/layouts.ts
+++ b/src/types/component-props/layouts.ts
@@ -12,6 +12,7 @@ import { SingleColPageProps } from './pages/single-col-page';
 import { SituationPageFlexColsLayoutProps } from './layouts/situation-flex-cols';
 import { ProductPageFlexColsLayoutProps } from './layouts/product-flex-cols';
 import { IndexPageProps } from './pages/index-page';
+import { AreapageSituationsProps } from './layouts/areapage-situations';
 
 export enum LayoutType {
     Fixed1Col = 'no.nav.navno:dynamic-1-col',
@@ -57,4 +58,5 @@ export type LayoutProps =
     | SingleColPageProps
     | SituationPageFlexColsLayoutProps
     | ProductPageFlexColsLayoutProps
-    | IndexPageProps;
+    | IndexPageProps
+    | AreapageSituationsProps;

--- a/src/types/component-props/layouts.ts
+++ b/src/types/component-props/layouts.ts
@@ -29,17 +29,22 @@ export enum LayoutType {
     ProductPageFlexCols = 'no.nav.navno:product-flex-cols',
     ProductDetailsPage = 'no.nav.navno:product-details-page',
     IndexPage = 'no.nav.navno:index-page',
+    AreapageSituations = 'no.nav.navno:areapage-situations',
 }
 
-export type RegionProps = {
+export type RegionProps<Name = string> = {
     components: ComponentProps[];
-    name: string;
+    name: Name;
+};
+
+export type Regions<RegionNames extends string> = {
+    [Name in RegionNames]: RegionProps<Name>;
 };
 
 export interface LayoutCommonProps extends ComponentCommonProps {
     type: ComponentType.Layout | ComponentType.Page;
     descriptor: LayoutType;
-    regions?: { [key: string]: RegionProps };
+    regions?: Regions<string>;
     config?: any;
 }
 

--- a/src/types/component-props/layouts/areapage-situations.ts
+++ b/src/types/component-props/layouts/areapage-situations.ts
@@ -1,0 +1,8 @@
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
+
+export interface AreapageSituations extends LayoutCommonProps {
+    type: ComponentType.Layout;
+    descriptor: LayoutType.AreapageSituations;
+    regions: Regions<'situations'>;
+}

--- a/src/types/component-props/layouts/areapage-situations.ts
+++ b/src/types/component-props/layouts/areapage-situations.ts
@@ -1,8 +1,11 @@
 import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
 import { ComponentType } from '../_component-common';
 
-export interface AreapageSituations extends LayoutCommonProps {
+export interface AreapageSituationsProps extends LayoutCommonProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.AreapageSituations;
     regions: Regions<'situations'>;
+    config: {
+        title: string;
+    };
 }

--- a/src/types/component-props/layouts/fixed-cols.ts
+++ b/src/types/component-props/layouts/fixed-cols.ts
@@ -1,5 +1,5 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 import { LayoutCommonConfigMixin } from '../_mixins';
 
 type DynamicColRegions = 'dynamic-1' | 'dynamic-2' | 'dynamic-3' | 'dynamic-4';
@@ -11,12 +11,7 @@ export interface FixedColsLayoutProps extends LayoutCommonProps {
         | LayoutType.Fixed2Col
         | LayoutType.Fixed3Col
         | LayoutType.Fixed4Col;
-    regions: {
-        [key in DynamicColRegions]: {
-            components: ComponentProps[];
-            name: DynamicColRegions;
-        };
-    };
+    regions: Regions<DynamicColRegions>;
     config: {
         distribution: string;
     } & LayoutCommonConfigMixin;

--- a/src/types/component-props/layouts/flex-cols.ts
+++ b/src/types/component-props/layouts/flex-cols.ts
@@ -1,16 +1,11 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 import { LayoutCommonConfigMixin } from '../_mixins';
 
 export interface FlexColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.FlexCols;
-    regions: {
-        flexcols: {
-            components: ComponentProps[];
-            name: 'flexcols';
-        };
-    };
+    regions: Regions<'flexcols'>;
     config: {
         numCols?: number;
         justifyContent: 'flex-start' | 'center' | 'flex-end';

--- a/src/types/component-props/layouts/legacy-layout.ts
+++ b/src/types/component-props/layouts/legacy-layout.ts
@@ -1,5 +1,5 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 
 type LegacyRegions = 'first' | 'second';
 
@@ -9,10 +9,5 @@ export interface LegacyLayoutProps extends LayoutCommonProps {
         | LayoutType.LegacyMain
         | LayoutType.LegacyMain1Col
         | LayoutType.MainPage;
-    regions: {
-        [key in LegacyRegions]: {
-            components: ComponentProps[];
-            name: LegacyRegions;
-        };
-    };
+    regions: Regions<LegacyRegions>;
 }

--- a/src/types/component-props/layouts/product-flex-cols.ts
+++ b/src/types/component-props/layouts/product-flex-cols.ts
@@ -1,16 +1,10 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 import { HeaderWithAnchorMixin } from '../_mixins';
-import { FlexColsLayoutProps } from './flex-cols';
 
 export interface ProductPageFlexColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.ProductPageFlexCols;
-    regions: {
-        flexcols: {
-            components: ComponentProps[];
-            name: 'flexcols';
-        };
-    };
+    regions: Regions<'flexcols'>;
     config: { usageContext: string } & HeaderWithAnchorMixin;
 }

--- a/src/types/component-props/layouts/section-with-header.ts
+++ b/src/types/component-props/layouts/section-with-header.ts
@@ -1,21 +1,12 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 import { HeaderWithAnchorMixin, LayoutCommonConfigMixin } from '../_mixins';
 import { XpImageProps } from '../../media';
 
 export interface SectionWithHeaderProps extends LayoutCommonProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.SectionWithHeader;
-    regions: {
-        intro: {
-            components: ComponentProps[];
-            name: 'intro';
-        };
-        content: {
-            components: ComponentProps[];
-            name: 'content';
-        };
-    };
+    regions: Regions<'intro' | 'content'>;
     config: {
         icon?: {
             icon: XpImageProps;

--- a/src/types/component-props/layouts/situation-flex-cols.ts
+++ b/src/types/component-props/layouts/situation-flex-cols.ts
@@ -1,17 +1,12 @@
-import { LayoutCommonProps, LayoutType } from '../layouts';
-import { ComponentProps, ComponentType } from '../_component-common';
+import { LayoutCommonProps, LayoutType, Regions } from '../layouts';
+import { ComponentType } from '../_component-common';
 import { HeaderWithAnchorMixin } from '../_mixins';
 import { FlexColsLayoutProps } from './flex-cols';
 
 export interface SituationPageFlexColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.SituationPageFlexCols;
-    regions: {
-        flexcols: {
-            components: ComponentProps[];
-            name: 'flexcols';
-        };
-    };
+    regions: Regions<'flexcols'>;
     config: Pick<
         FlexColsLayoutProps['config'],
         'justifyContent' | 'numCols' | 'bgColor'

--- a/src/types/component-props/parts.ts
+++ b/src/types/component-props/parts.ts
@@ -33,6 +33,7 @@ export enum PartType {
     ProductDetails = 'no.nav.navno:product-details',
     ContactOption = 'no.nav.navno:contact-option',
     PayoutDates = 'no.nav.navno:payout-dates',
+    AreapageSituationCard = 'no.nav.navno:areapage-situation-card',
 }
 
 export type PartDeprecated =
@@ -71,4 +72,5 @@ export type PartWithOwnData =
     | PartType.ContactOption
     | PartType.ProductDetails
     | PartType.AlertPanel
-    | PartType.PayoutDates;
+    | PartType.PayoutDates
+    | PartType.AreapageSituationCard;

--- a/src/types/component-props/parts/areapage-situation-card.ts
+++ b/src/types/component-props/parts/areapage-situation-card.ts
@@ -1,0 +1,11 @@
+import { PartComponentProps } from '../_component-common';
+import { PartType } from '../parts';
+import { SituationPageProps } from '../../content-props/dynamic-page-props';
+
+export interface AreapageSituationCardPartProps extends PartComponentProps {
+    descriptor: PartType.AreapageSituationCard;
+    config: {
+        disabled: boolean;
+        target: SituationPageProps;
+    };
+}

--- a/src/types/content-props/index-pages-props.ts
+++ b/src/types/content-props/index-pages-props.ts
@@ -3,9 +3,11 @@ import { ContentType, ContentCommonProps } from './_content-common';
 import { Area } from '../areas';
 import { ProcessedHtmlProps } from '../processed-html-props';
 import { IndexPageProps } from '../component-props/pages/index-page';
+import { Audience } from '../component-props/_mixins';
 
 type CommonData = {
     areasRefs: AreaPageProps[];
+    audience: Audience;
 } & DynamicPageData;
 
 export type FrontPageData = {


### PR DESCRIPTION
Juicy bits er på XP-siden: https://github.com/navikt/nav-enonicxp/pull/1407

- Layout og part for å liste ut situasjoner på områdesider. Bruker LargeCard som placeholder for situasjonskort inntil videre
- Refactor typer for Regions
- Setter max-width for nye sidetyper ut fra skisse
- Fjerner redirect til gammel forside i testmiljøer
- Tweaker animasjoner

![area-situations](https://user-images.githubusercontent.com/18137669/174397420-c3214d2d-5dca-4157-8cf5-1f545db46207.png)