### PR TITLE
Fikser next.js routing edgecase for indexpage

### DIFF
--- a/src/components/_common/content-list/ContentList.tsx
+++ b/src/components/_common/content-list/ContentList.tsx
@@ -7,6 +7,7 @@ import { getUrlFromContent } from 'utils/links-from-content';
 import { DateTimeKey } from 'types/datetime';
 import { ContentProps } from 'types/content-props/_content-common';
 import { getNestedValueFromKeyString } from 'utils/objects';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 const getDate = (content: ContentProps, dateLabelKey: DateTimeKey) =>
     getNestedValueFromKeyString(content, dateLabelKey) ||
@@ -17,6 +18,7 @@ const getDate = (content: ContentProps, dateLabelKey: DateTimeKey) =>
 type Props = {
     content: ContentListProps;
     title?: string;
+    hideTitle?: boolean;
     showDateLabel?: boolean;
     withChevron?: boolean;
     className?: string;
@@ -25,12 +27,13 @@ type Props = {
 export const ContentList = ({
     content,
     title,
+    hideTitle,
     showDateLabel,
     withChevron,
     className,
 }: Props) => {
     if (!content?.data?.sectionContents) {
-        return null;
+        return <EditorHelp text={'Tom lenkeliste'} />;
     }
 
     const { sectionContents, sortedBy } = content.data;
@@ -45,12 +48,12 @@ export const ContentList = ({
         }))
         .filter(({ url, text }) => url && text);
 
-    return lenkeData?.length > 0 ? (
+    return (
         <Lenkeliste
             lenker={lenkeData}
-            tittel={title || content.displayName}
+            tittel={!hideTitle && (title || content.displayName)}
             withChevron={withChevron}
             className={className}
         />
-    ) : null;
+    );
 };

--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -3,6 +3,7 @@ import { Heading } from '@navikt/ds-react';
 import { LinkProps } from 'types/link-props';
 import { LenkeStandalone } from '../lenke/LenkeStandalone';
 import style from './Lenkeliste.module.scss';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 type Props = {
     lenker: LinkProps[];
@@ -18,7 +19,7 @@ export const Lenkeliste = ({
     className,
 }: Props) => {
     if (!lenker || lenker.length === 0) {
-        return null;
+        return <EditorHelp text={'Tom lenkeliste'} />;
     }
 
     return (

--- a/src/components/layouts/index-page/useIndexPageRouting.tsx
+++ b/src/components/layouts/index-page/useIndexPageRouting.tsx
@@ -102,16 +102,18 @@ export const useIndexPageRouting = (pageProps: IndexPageContentProps) => {
         };
     }, [router, localPageCache]);
 
+    // Handle regular next.js routing to the initial page
     useEffect(() => {
         const handler = (url, { shallow }) => {
-            console.log(`Navigated to ${url} - ${shallow}`);
-            if (url === basePath) {
+            if (url === basePath && !shallow) {
                 navigate(url);
             }
         };
 
         router.events.on('routeChangeComplete', handler);
-        return router.events.off('routeChangeComplete', handler);
+        return () => {
+            router.events.off('routeChangeComplete', handler);
+        };
     }, [pageProps]);
 
     return { currentPageProps, navigate };

--- a/src/components/layouts/index-page/useIndexPageRouting.tsx
+++ b/src/components/layouts/index-page/useIndexPageRouting.tsx
@@ -102,5 +102,17 @@ export const useIndexPageRouting = (pageProps: IndexPageContentProps) => {
         };
     }, [router, localPageCache]);
 
+    useEffect(() => {
+        const handler = (url, { shallow }) => {
+            console.log(`Navigated to ${url} - ${shallow}`);
+            if (url === basePath) {
+                navigate(url);
+            }
+        };
+
+        router.events.on('routeChangeComplete', handler);
+        return router.events.off('routeChangeComplete', handler);
+    }, [pageProps]);
+
     return { currentPageProps, navigate };
 };

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -22,8 +22,8 @@ import {
 import { ContentProps } from '../../types/content-props/_content-common';
 import { OfficeInformation } from './_legacy/office-information/OfficeInformation';
 import { HeaderPart } from './header/HeaderPart';
-import { LinkList } from './link-list/LinkList';
-import { NewsList } from './news-list/NewsList';
+import { LinkListPart } from './link-list/LinkListPart';
+import { NewsListPart } from './news-list/NewsListPart';
 import PublishingCalendar from './_legacy/publishing-calendar/PublishingCalendar';
 import { BEM, classNames } from '../../utils/classnames';
 import { HtmlArea } from './html-area/HtmlArea';
@@ -69,8 +69,8 @@ const partsWithOwnData: {
     [PartType.AlertBox]: AlertBoxPart,
     [PartType.Header]: HeaderPart,
     [PartType.LinkPanel]: LinkPanelPart,
-    [PartType.LinkList]: LinkList,
-    [PartType.NewsList]: NewsList,
+    [PartType.LinkList]: LinkListPart,
+    [PartType.NewsList]: NewsListPart,
     [PartType.HtmlArea]: HtmlArea,
     [PartType.Calculator]: CalculatorPart,
     [PartType.PageHeader]: PageHeaderPart,

--- a/src/components/parts/link-list/LinkListPart.tsx
+++ b/src/components/parts/link-list/LinkListPart.tsx
@@ -4,11 +4,12 @@ import { Lenkeliste } from '../../_common/lenkeliste/Lenkeliste';
 import { ContentList } from '../../_common/content-list/ContentList';
 import { getSelectableLinkProps } from '../../../utils/links-from-content';
 import { ExpandableComponentWrapper } from '../../_common/expandable/ExpandableComponentWrapper';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 import style from './LinkList.module.scss';
 
 const getListComponent = (config: DynamicLinkListProps['config']) => {
-    const { title, list, chevron } = config;
+    const { title, list, chevron, hideTitle } = config;
     const { _selected } = list;
 
     if (_selected === 'contentList') {
@@ -17,6 +18,7 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
             <ContentList
                 content={contentList?.target}
                 title={title}
+                hideTitle={hideTitle}
                 withChevron={chevron}
             />
         );
@@ -26,16 +28,20 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
         const { linkList } = list;
         const links = linkList?.links?.map(getSelectableLinkProps);
         return (
-            <Lenkeliste tittel={title} lenker={links} withChevron={chevron} />
+            <Lenkeliste
+                tittel={!hideTitle && title}
+                lenker={links}
+                withChevron={chevron}
+            />
         );
     }
 
     return null;
 };
 
-export const LinkList = ({ config }: DynamicLinkListProps) => {
-    if (!config?.list) {
-        return <h2>{'Tom lenkeliste'}</h2>;
+export const LinkListPart = ({ config }: DynamicLinkListProps) => {
+    if (!config?.list?._selected) {
+        return <EditorHelp text={'Klikk og velg lenker i panelet til høyre'} />;
     }
 
     const ListComponent = getListComponent(config);

--- a/src/components/parts/news-list/NewsListPart.tsx
+++ b/src/components/parts/news-list/NewsListPart.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { DynamicNewsList } from '../../../types/component-props/parts/news-list';
+import { DynamicNewsListProps } from '../../../types/component-props/parts/news-list';
 import { ContentList } from '../../_common/content-list/ContentList';
 import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
 import { ExpandableComponentWrapper } from '../../_common/expandable/ExpandableComponentWrapper';
+import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 import style from './NewsList.module.scss';
 
-export const NewsList = ({ config }: DynamicNewsList) => {
-    if (!config?.contentList) {
-        return <h2>{'Tom nyhetsliste'}</h2>;
+export const NewsListPart = ({ config }: DynamicNewsListProps) => {
+    if (!config?.contentList?.target) {
+        return <EditorHelp text={'Tom nyhetsliste'} />;
     }
 
-    const { title, contentList, moreNews } = config;
+    const { title, contentList, moreNews, hideTitle } = config;
 
     return (
         <ExpandableComponentWrapper {...config}>
@@ -20,6 +21,7 @@ export const NewsList = ({ config }: DynamicNewsList) => {
                     showDateLabel={true}
                     content={contentList.target}
                     title={title}
+                    hideTitle={hideTitle}
                     withChevron={true}
                 />
                 {moreNews && (

--- a/src/types/component-props/parts/link-list.ts
+++ b/src/types/component-props/parts/link-list.ts
@@ -12,6 +12,7 @@ export interface DynamicLinkListProps extends PartComponentProps {
     descriptor: PartType.LinkList;
     config: {
         title?: string;
+        hideTitle?: boolean;
         chevron?: boolean;
         list: OptionSetSingle<{
             contentList: ContentListMixin;

--- a/src/types/component-props/parts/news-list.ts
+++ b/src/types/component-props/parts/news-list.ts
@@ -7,10 +7,11 @@ import {
     RenderOnAuthStateMixin,
 } from '../_mixins';
 
-export interface DynamicNewsList extends PartComponentProps {
+export interface DynamicNewsListProps extends PartComponentProps {
     descriptor: PartType.NewsList;
     config: {
         title?: string;
+        hideTitle?: boolean;
         contentList: ContentListMixin;
         moreNews?: LinkProps;
     } & ExpandableMixin &


### PR DESCRIPTION
Fikser en case der en f.eks. starter på forsiden, navigerer til en områdeside, og så klikker på en lenke tilbake til forside (f.eks i dekoratøren). I dette tilfellet tror next at bruker fortsatt er på forsiden (ettersom vi har custom routing for disse sidetypene). Vi må derfor håndtere denne navigeringen selv.

Legger også inn mulighet for å skjule tittel på lenkelistekomponenter