### PR TITLE
Bruker useLayoutEffectClientSide for å hindre irriterende react-feil

### DIFF
--- a/src/components/_common/auth-dependant-render/AuthDependantRender.tsx
+++ b/src/components/_common/auth-dependant-render/AuthDependantRender.tsx
@@ -1,15 +1,12 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useAuthState } from '../../../store/hooks/useAuthState';
 import { AuthStateType } from '../../../store/slices/authState';
 import { usePageConfig } from '../../../store/hooks/usePageConfig';
+import { useLayoutEffectClientSide } from 'utils/react';
 
 // eslint does not understand bracket notation
 // eslint-disable-next-line css-modules/no-unused-class
 import style from './AuthDependantRender.module.scss';
-
-// Hack to prevent irrelevant React warning for useLayoutEffect server-side
-const useLayoutEffectClientSide =
-    typeof window !== 'undefined' ? useLayoutEffect : () => {};
 
 export const editorAuthstateClassname = (authState: AuthStateType) =>
     style[authState];

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from 'react';
+import { useState } from 'react';
 import { translator } from 'translations';
 import { Heading, BodyLong, Alert, BodyShort } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
@@ -18,6 +18,7 @@ import {
 } from '../contact-details/contactHelpers';
 import { analyticsEvents } from '../../../utils/amplitude';
 import { useLayoutConfig } from '../../layouts/useLayoutConfig';
+import { useLayoutEffectClientSide } from '../../../utils/react';
 
 import style from './ContactOption.module.scss';
 
@@ -149,7 +150,7 @@ export const CallOption = (props: CallOptionProps) => {
             : null;
     const isCurrentlyClosed = getIsCurrentyClosed(todaysOpeningHour);
 
-    useLayoutEffect(() => {
+    useLayoutEffectClientSide(() => {
         setIsClosed(isCurrentlyClosed);
     }, [isCurrentlyClosed]);
 

--- a/src/utils/react.ts
+++ b/src/utils/react.ts
@@ -1,0 +1,5 @@
+import { useLayoutEffect } from 'react';
+
+// Hack to prevent irrelevant React warning for useLayoutEffect server-side
+export const useLayoutEffectClientSide =
+    typeof window !== 'undefined' ? useLayoutEffect : () => {};


### PR DESCRIPTION
React liker ikke når useLayoutEffect brukes server-side og spammer masse warnings ved lokal kjøring. 