### PR TITLE
Margin forside omradeside fiks

### DIFF
--- a/src/components/_top-container/TopContainer.module.scss
+++ b/src/components/_top-container/TopContainer.module.scss
@@ -15,8 +15,4 @@
     &.widgetsOffset {
         margin-top: -0.75rem;
     }
-
-    &:empty {
-        display: none;
-    }
 }

--- a/src/components/_top-container/TopContainer.module.scss
+++ b/src/components/_top-container/TopContainer.module.scss
@@ -15,4 +15,8 @@
     &.widgetsOffset {
         margin-top: -0.75rem;
     }
+
+    &:empty {
+        display: none;
+    }
 }

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.module.scss
@@ -2,7 +2,7 @@
 
 .container {
     @include common.full-width-mixin();
-    padding-top: 2rem;
+    padding-top: 2.5rem;
     padding-bottom: 2rem;
     background-color: common.$navds-global-color-deepblue-50;
 
@@ -32,5 +32,5 @@
 }
 
 .header {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 }

--- a/src/components/layouts/index-page/navigation/IndexPageNavigation.module.scss
+++ b/src/components/layouts/index-page/navigation/IndexPageNavigation.module.scss
@@ -1,8 +1,6 @@
 @use 'src/common' as common;
 
 .centerNavigation {
-    padding-top: 2rem;
-    padding-bottom: 2rem;
     background-color: #fff;
     @include common.full-width-mixin();
 }

--- a/src/components/layouts/index-page/navigation/area-page-navigation/AreaPageNavigationBar.module.scss
+++ b/src/components/layouts/index-page/navigation/area-page-navigation/AreaPageNavigationBar.module.scss
@@ -6,6 +6,7 @@
     opacity: 1;
     padding-bottom: 1rem;
     padding-top: 2px; // In order not to clip focus outline
+    margin-top: 1.5rem;
     visibility: visible;
 
     transition-property: max-height, visibility, padding, opacity;

--- a/src/components/layouts/index-page/navigation/area-panels/IndexPageAreaPanels.module.scss
+++ b/src/components/layouts/index-page/navigation/area-panels/IndexPageAreaPanels.module.scss
@@ -1,8 +1,11 @@
 @use 'src/common' as common;
 
 .panels {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
     display: flex;
     flex-wrap: wrap;
     width: 100%;
     justify-content: space-between;
+    padding-bottom: 0.5rem;
 }


### PR DESCRIPTION
- Foreslår å flytte marginer fra IndexPageNavigation og inn til child-komponenter siden avstander er litt forskjellig fra forside til områdeside, så vi kan ikke sette 2rems rund baut.
- Skjuler TopContainer via css hvis den er :empty
- Forside-marginer/padding må justeres når area-cards har kommet inn.