### PR TITLE
Fikser bugs med område-grafikk ved enkelte kombinasjoner av touchskjerm og skjermbredde

### DIFF
--- a/src/components/_common/area-card/graphics/AreaCardGraphics.module.scss
+++ b/src/components/_common/area-card/graphics/AreaCardGraphics.module.scss
@@ -6,6 +6,7 @@
     width: 100%;
     height: 100%;
     border-radius: $border-radius;
+    overflow: hidden;
 
     & > * {
         @include transitionMixin;

--- a/src/components/_common/area-card/graphics/AreaCardGraphicsCommon.module.scss
+++ b/src/components/_common/area-card/graphics/AreaCardGraphicsCommon.module.scss
@@ -4,8 +4,16 @@ $expandGraphics: expandGraphics;
 // Set this class on an element to transition on hover to the expanded version of any contained graphics
 $expandOnHover: expandOnHover;
 
-@function onExpand($graphics-element) {
-    @return ':global(.#{$expandOnHover}):hover #{$graphics-element},:global(.#{$expandGraphics}) #{$graphics-element}';
+@mixin onExpandMixin($graphics-element) {
+    :global(.#{$expandOnHover}):hover #{$graphics-element} {
+        @media (hover) {
+            @content;
+        }
+    }
+
+    :global(.#{$expandGraphics}) #{$graphics-element} {
+        @content;
+    }
 }
 
 :export {

--- a/src/components/_common/area-card/graphics/logged-in/cases/CasesAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/logged-in/cases/CasesAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 122px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.shapes')} {
-        right: 203px;
-    }
+@include areaGraphics.onExpandMixin('.shapes') {
+    right: 203px;
 }
 
 .letterS {
@@ -22,10 +20,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterS')} {
-        right: 1px;
-    }
+@include areaGraphics.onExpandMixin('.letterS') {
+    right: 1px;
 }
 
 .mask {
@@ -40,10 +36,8 @@
     transform: rotate(22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        right: -184px;
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    right: -184px;
 }
 
 .document {
@@ -53,9 +47,7 @@
     top: 42px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.document')} {
-        right: 110px;
-        top: 85px;
-    }
+@include areaGraphics.onExpandMixin('.document') {
+    right: 110px;
+    top: 85px;
 }

--- a/src/components/_common/area-card/graphics/logged-in/employment-status-form/EmploymentStatusFormAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/logged-in/employment-status-form/EmploymentStatusFormAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 126px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.shapes')} {
-        right: 206px;
-    }
+@include areaGraphics.onExpandMixin('.shapes') {
+    right: 206px;
 }
 
 .letterPartOrange {
@@ -27,10 +25,8 @@
     transform: skewX(-22.5914deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartOrange')} {
-        right: 25px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartOrange') {
+    right: 25px;
 }
 
 .letterPartBlue {
@@ -44,10 +40,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 0;
 }
 
 .letterPartBlueTwo {
@@ -62,10 +56,8 @@
     transform: skewX(22.5914deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlueTwo')} {
-        right: 75px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlueTwo') {
+    right: 75px;
 }
 
 .mask {
@@ -80,15 +72,13 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 48px;
-        height: 160px;
-        right: 102px;
-        top: 0;
-        transform: skewX(0);
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 48px;
+    height: 160px;
+    right: 102px;
+    top: 0;
+    transform: skewX(0);
 }
 
 .letter {
@@ -98,9 +88,7 @@
     top: 44px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letter')} {
-        right: 102px;
-        top: 88px;
-    }
+@include areaGraphics.onExpandMixin('.letter') {
+    right: 102px;
+    top: 88px;
 }

--- a/src/components/_common/area-card/graphics/logged-in/payments/PaymentsAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/logged-in/payments/PaymentsAnimation.module.scss
@@ -9,11 +9,9 @@
     top: 49px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.shapes')} {
-        right: 190px;
-        top: 118px;
-    }
+@include areaGraphics.onExpandMixin('.shapes') {
+    right: 190px;
+    top: 118px;
 }
 
 .letterU {
@@ -23,10 +21,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterU')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterU') {
+    right: 0;
 }
 
 .mask {
@@ -41,10 +37,8 @@
     transform: rotate(22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        right: -184px;
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    right: -184px;
 }
 
 .wallet {
@@ -56,9 +50,7 @@
     top: 40px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.wallet')} {
-        right: 98.27px;
-        top: 89px;
-    }
+@include areaGraphics.onExpandMixin('.wallet') {
+    right: 98.27px;
+    top: 89px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/accessibility/AccessibilityAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/accessibility/AccessibilityAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 127px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.arrow')} {
-        right: 191px;
-    }
+@include areaGraphics.onExpandMixin('.arrow') {
+    right: 191px;
 }
 
 .letterPartOrange {
@@ -26,11 +24,9 @@
     top: 58px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartOrange')} {
-        right: 48px;
-        top: 58px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartOrange') {
+    right: 48px;
+    top: 58px;
 }
 
 .letterPartBlue {
@@ -44,10 +40,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 0;
 }
 
 .mask {
@@ -62,15 +56,13 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 48px;
-        height: 160px;
-        right: 100px;
-        top: 0;
-        transform: skewX(0);
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 48px;
+    height: 160px;
+    right: 100px;
+    top: 0;
+    transform: skewX(0);
 }
 
 .dog {
@@ -80,9 +72,7 @@
     top: 38px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.dog')} {
-        right: 71px;
-        top: 76px;
-    }
+@include areaGraphics.onExpandMixin('.dog') {
+    right: 71px;
+    top: 76px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/family/FamilyAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/family/FamilyAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 112px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.house')} {
-        right: 206px;
-    }
+@include areaGraphics.onExpandMixin('.house') {
+    right: 206px;
 }
 
 .letterPartOrange {
@@ -26,10 +24,8 @@
     top: 72px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartOrange')} {
-        right: 32px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartOrange') {
+    right: 32px;
 }
 
 .letterPartBlue {
@@ -43,10 +39,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 0;
 }
 
 .mask {
@@ -61,15 +55,13 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 48px;
-        height: 160px;
-        right: 100px;
-        top: 0;
-        transform: skewX(0);
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 48px;
+    height: 160px;
+    right: 100px;
+    top: 0;
+    transform: skewX(0);
 }
 
 .stroller {
@@ -79,9 +71,7 @@
     top: 40px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.stroller')} {
-        right: 105.23px;
-        top: 76px;
-    }
+@include areaGraphics.onExpandMixin('.stroller') {
+    right: 105.23px;
+    top: 76px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/health/HealthAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/health/HealthAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 115px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.pill')} {
-        right: 208px;
-    }
+@include areaGraphics.onExpandMixin('.pill') {
+    right: 208px;
 }
 
 .letterPartOrange {
@@ -26,11 +24,9 @@
     top: 58px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartOrange')} {
-        right: 48px;
-        top: 58px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartOrange') {
+    right: 48px;
+    top: 58px;
 }
 
 .letterPartBlue {
@@ -44,10 +40,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 0;
 }
 
 .mask {
@@ -62,15 +56,13 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 48px;
-        height: 160px;
-        right: 100px;
-        top: 0;
-        transform: skewX(0);
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 48px;
+    height: 160px;
+    right: 100px;
+    top: 0;
+    transform: skewX(0);
 }
 
 .stethoscope {
@@ -80,9 +72,7 @@
     top: 33px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.stethoscope')} {
-        right: 82px;
-        top: 59px;
-    }
+@include areaGraphics.onExpandMixin('.stethoscope') {
+    right: 82px;
+    top: 59px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/pension/PensionAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/pension/PensionAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 108px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.shapes')} {
-        right: 201px;
-    }
+@include areaGraphics.onExpandMixin('.shapes') {
+    right: 201px;
 }
 
 .letterPartBlue {
@@ -22,10 +20,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 0;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 0;
 }
 
 .mask {
@@ -40,15 +36,13 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 48px;
-        height: 160px;
-        right: 100px;
-        top: 0;
-        transform: skewX(0);
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 48px;
+    height: 160px;
+    right: 100px;
+    top: 0;
+    transform: skewX(0);
 }
 
 .piggyBank {
@@ -58,11 +52,9 @@
     top: 41px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.piggyBank')} {
-        right: 101px;
-        top: 82px;
-    }
+@include areaGraphics.onExpandMixin('.piggyBank') {
+    right: 101px;
+    top: 82px;
 }
 
 .coin {
@@ -77,8 +69,6 @@
     top: -32px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.coin')} {
-        top: 80px;
-    }
+@include areaGraphics.onExpandMixin('.coin') {
+    top: 80px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/social-counselling/SocialCounsellingAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/social-counselling/SocialCounsellingAnimation.module.scss
@@ -10,11 +10,9 @@
     transform: rotate(-45deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.compass')} {
-        right: 201px;
-        transform: rotate(0deg);
-    }
+@include areaGraphics.onExpandMixin('.compass') {
+    right: 201px;
+    transform: rotate(0deg);
 }
 
 .letterS {
@@ -24,10 +22,8 @@
     top: 0;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterS')} {
-        right: 1px;
-    }
+@include areaGraphics.onExpandMixin('.letterS') {
+    right: 1px;
 }
 
 .mask {
@@ -42,11 +38,9 @@
     transform: rotate(22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        right: -184px;
-        visibility: hidden;
-    }
+@include areaGraphics.onExpandMixin('.mask') {
+    right: -184px;
+    visibility: hidden;
 }
 
 .heart {
@@ -58,13 +52,11 @@
     top: 30px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.heart')} {
-        width: 56px;
-        height: 48px;
-        right: 94px;
-        top: 91px;
-    }
+@include areaGraphics.onExpandMixin('.heart') {
+    width: 56px;
+    height: 48px;
+    right: 94px;
+    top: 91px;
 }
 
 .hand {
@@ -76,9 +68,7 @@
     top: 80.08px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.hand')} {
-        right: 75px;
-        top: 114px;
-    }
+@include areaGraphics.onExpandMixin('.hand') {
+    right: 75px;
+    top: 114px;
 }

--- a/src/components/_common/area-card/graphics/open-pages/work/WorkAnimation.module.scss
+++ b/src/components/_common/area-card/graphics/open-pages/work/WorkAnimation.module.scss
@@ -9,10 +9,8 @@
     top: 124px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.shapes')} {
-        right: 190px;
-    }
+@include areaGraphics.onExpandMixin('.shapes') {
+    right: 190px;
 }
 
 .letterPartOrange {
@@ -26,11 +24,9 @@
     top: 53px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartOrange')} {
-        right: 51px;
-        top: 73px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartOrange') {
+    right: 51px;
+    top: 73px;
 }
 
 .letterPartBlue {
@@ -45,10 +41,8 @@
     transform: skewX(18.8967deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.letterPartBlue')} {
-        right: 27px;
-    }
+@include areaGraphics.onExpandMixin('.letterPartBlue') {
+    right: 27px;
 }
 
 .mask {
@@ -63,16 +57,14 @@
     transform: skewX(-22.09deg);
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.mask')} {
-        background-color: #ffb8b8;
-        width: 49.23px;
-        height: 160px;
-        right: 82px;
-        top: 0;
+@include areaGraphics.onExpandMixin('.mask') {
+    background-color: #ffb8b8;
+    width: 49.23px;
+    height: 160px;
+    right: 82px;
+    top: 0;
 
-        transform: skewX(-18.8967deg);
-    }
+    transform: skewX(-18.8967deg);
 }
 
 .briefcase {
@@ -82,9 +74,7 @@
     top: 39px;
 }
 
-@media (hover) {
-    #{areaGraphics.onExpand('.briefcase')} {
-        right: 102px;
-        top: 83px;
-    }
+@include areaGraphics.onExpandMixin('.briefcase') {
+    right: 102px;
+    top: 83px;
 }


### PR DESCRIPTION
- Media query for (hover) skal ikke hindre alltid-ekspandert grafikk fra å vises
- Setter overflow: hidden på grafikk-container for å hindre at visse grafikk-elementer tar opp plass når de skal være skjult