### PR TITLE
Setter role="presentation" for StaticImage

### DIFF
--- a/src/components/_common/image/StaticImage.tsx
+++ b/src/components/_common/image/StaticImage.tsx
@@ -10,5 +10,14 @@ type Props = {
 export const StaticImage = (props: Props) => {
     const { imageData, alt, ...imgAttribs } = props;
 
-    return <NextImage {...imgAttribs} src={imageData.src} alt={alt} />;
+    const ariaRole = imgAttribs.role || !alt ? 'presentation' : null;
+
+    return (
+        <NextImage
+            {...imgAttribs}
+            src={imageData.src}
+            alt={alt}
+            role={ariaRole}
+        />
+    );
 };


### PR DESCRIPTION
Siteimprove klager på manglende role="presentation", selv når alt="". I teorien skal skjermlesere se bort ifra bilder hvor alt eksplissit er satt til tom streng, men ifølge UU så er ikke dette alltid tilfelle.

Foreslår derfor å sette default role="presentation" hvis:
- role ikke allerede er satt
- OG !alt