### PR TITLE
fjern ekstra side-padding på mobil

### DIFF
--- a/src/components/parts/frontpage-contact/FrontpageContactPart.module.scss
+++ b/src/components/parts/frontpage-contact/FrontpageContactPart.module.scss
@@ -3,7 +3,6 @@
 .container {
     $padding-desktop: 2.75rem;
     $padding-mobile-y: 1rem;
-    $padding-mobile-x: 1.5rem;
     $whiteGap: 0.5rem;
 
     @include common.full-width-mixin();
@@ -15,8 +14,6 @@
     @media #{common.$mq-screen-mobile} {
         padding-top: $padding-mobile-y - $whiteGap;
         padding-bottom: $padding-mobile-y;
-        padding-right: $padding-mobile-x;
-        padding-left: $padding-mobile-x;
     }
 
     :global(.linkPanelNavnoLink) {

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.module.scss
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.module.scss
@@ -6,7 +6,8 @@
     @include common.full-width-mixin();
 
     @media #{common.$mq-screen-mobile} {
-        padding: 1.5rem 1rem;
+        padding-top: 1.5rem;
+        padding-bottom: 1.5rem;
     }
 }
 

--- a/src/components/parts/frontpage-shortcuts/FrontpageShortcuts.module.scss
+++ b/src/components/parts/frontpage-shortcuts/FrontpageShortcuts.module.scss
@@ -8,7 +8,8 @@
     @include common.full-width-mixin();
 
     @media #{common.$mq-screen-mobile} {
-        padding: 1.5rem 1rem;
+        padding-top: 1.5rem;
+        padding-bottom: 1.5rem;
     }
 }
 


### PR DESCRIPTION
Fjerner ekstra venstre og høyre padding på forsiden på mobil.

Padding 1rem -> 0.5rem: https://nav-it.slack.com/archives/C025MMK34LF/p1656665506666899

![image](https://user-images.githubusercontent.com/71373910/180141235-6d871413-4aa2-4020-bcdc-8756e67359ab.png)
