### PR TITLE
Fikser diverse feil

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cat > .env <<EOF
           ENV=${{ inputs.ENV }}
-          NODE_ENV=production
+          NODE_ENV=development
           ADMIN_ORIGIN=${{ inputs.ADMIN_ORIGIN }}
           APP_ORIGIN=${{ inputs.APP_ORIGIN }}
           DECORATOR_FALLBACK_URL=${{ inputs.DECORATOR_FALLBACK_URL }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cat > .env <<EOF
           ENV=${{ inputs.ENV }}
-          NODE_ENV=development
+          NODE_ENV=production
           ADMIN_ORIGIN=${{ inputs.ADMIN_ORIGIN }}
           APP_ORIGIN=${{ inputs.APP_ORIGIN }}
           DECORATOR_FALLBACK_URL=${{ inputs.DECORATOR_FALLBACK_URL }}

--- a/next.config.js
+++ b/next.config.js
@@ -155,6 +155,7 @@ console.log(
 module.exports = withPlugins(
     [withTranspileModules, withBundleAnalyzer, withSentryConfig],
     {
+        productionBrowserSourceMaps: true,
         distDir: isFailover && isLocal ? '.next-static' : '.next',
         assetPrefix: isFailover
             ? process.env.FAILOVER_ORIGIN

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "browserslist": {
         "production": [
             ">0.2% in no",
+            "iOS >= 11",
+            "safari >= 11",
             "not dead",
             "not op_mini all",
             "not ie 11"

--- a/src/components/_common/image/NextImageBuildTime.tsx
+++ b/src/components/_common/image/NextImageBuildTime.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { usePageConfig } from '../../../store/hooks/usePageConfig';
+import { updateImageManifest } from '../../../utils/fetch/fetch-images';
+import { buildImageCacheUrl, ImageProps } from './NextImage';
+
+export const NextImageBuildTime = (props: ImageProps) => {
+    const { src, alt, maxWidth = 1440, quality = 90, ...imgAttribs } = props;
+    const { pageConfig } = usePageConfig();
+
+    if (!src) {
+        return null;
+    }
+
+    const cachedSrc = buildImageCacheUrl({
+        src,
+        maxWidth,
+        quality,
+        isEditorView: !!pageConfig.editorView,
+    });
+
+    // This should only run at build-time
+    updateImageManifest(cachedSrc);
+
+    return <img {...imgAttribs} src={cachedSrc} alt={alt} />;
+};

--- a/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/ArtikkelDato.tsx
@@ -15,29 +15,30 @@ interface Props {
 
 const ArtikkelDato = (props: Props) => {
     const { language } = usePageConfig();
-    const { publish, createdTime, modifiedTime, publishLabel, modifiedLabel} = props;
+    const { publish, createdTime, modifiedTime, publishLabel, modifiedLabel } =
+        props;
     const publishedDate = publish?.first ?? createdTime;
     const publishedString = `${publishLabel} ${formatDate(
-        publishedDate, language
+        publishedDate,
+        language
     )}`;
     let modifiedString = '';
     if (new Date(modifiedTime) > new Date(publishedDate)) {
         modifiedString = ` ${modifiedLabel} ${formatDate(
-            modifiedTime, language
+            modifiedTime,
+            language
         )}`;
     }
     return (
-        <time dateTime={publishedDate}>
-            <BodyLong className={'page-modified-info'}>
-                {publishedString}
-                {modifiedString &&
-                    <>
-                        <span aria-hidden='true'>{' |'}</span>
-                        {modifiedString}
-                    </>
-                }
-            </BodyLong>
-        </time>
+        <BodyLong as={'time'} dateTime={publishedDate}>
+            {publishedString}
+            {modifiedString && (
+                <>
+                    <span aria-hidden="true">{' |'}</span>
+                    {modifiedString}
+                </>
+            )}
+        </BodyLong>
     );
 };
 export default ArtikkelDato;

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.module.scss
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.module.scss
@@ -17,24 +17,23 @@
     }
 
     table {
-
         th {
             padding: 0;
             visibility: hidden;
         }
 
         td {
-            padding: 1rem 0;
-
             time {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
                 width: 4.5rem;
                 height: 4.5rem;
-                display: block;
                 font-weight: 600;
                 padding: 1rem;
                 border-radius: 50%;
                 background-color: #d1d1d1;
-                text-align: center;
 
                 p {
                     text-transform: uppercase;
@@ -44,12 +43,8 @@
                 }
             }
 
-            &.eventInfo {
-                padding-left: 1.6rem;
-
-                .dateInfo {
-                    text-transform: uppercase;
-                }
+            .dateInfo {
+                text-transform: uppercase;
             }
         }
     }

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -63,12 +63,8 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
             <Table>
                 <thead>
                     <tr>
-                        <th scope="col">
-                            {getLabel('publishdate')}
-                        </th>
-                        <th scope="col">
-                            {getLabel('event')}
-                        </th>
+                        <th scope="col">{getLabel('publishdate')}</th>
+                        <th scope="col">{getLabel('event')}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -77,11 +73,11 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
                             <tr key={`${item.displayName}_${index}`}>
                                 <td>
                                     <time>
-                                        <div>{item.day}</div>
-                                        <div>{item.month}</div>
+                                        <span>{item.day}</span>
+                                        <span>{item.month}</span>
                                     </time>
                                 </td>
-                                <td className={style.eventInfo}>
+                                <td>
                                     <BodyLong className={style.dateInfo}>
                                         {item.period}
                                     </BodyLong>

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -45,7 +45,7 @@ Error.getInitialProps = async (context): Promise<ContentProps> => {
         }
     }
 
-    res.statusCode = err.content?.data?.errorCode || res.statusCode;
+    res.statusCode = err?.content?.data?.errorCode || res.statusCode;
 
     const errorId = uuid();
     const errorMsg = err?.toString() || 'Empty error message';

--- a/src/utils/decorator/decorator-utils-serverside.tsx
+++ b/src/utils/decorator/decorator-utils-serverside.tsx
@@ -8,8 +8,20 @@ import { Params as DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
 import { objectToQueryString } from '../fetch/fetch-utils';
 
 const decoratorUrl = process.env.DECORATOR_FALLBACK_URL;
-const decoratorEnv = process.env.ENV as Props['env'];
 const decoratorLocalPort = process.env.DECORATOR_LOCAL_PORT || 8100;
+
+type AppEnv = typeof process.env.ENV;
+type DecoratorEnv = Props['env'];
+
+const envMap: { [Key in AppEnv]: DecoratorEnv } = {
+    localhost: 'localhost',
+    dev1: 'dev',
+    dev2: 'dev',
+    prod: 'prod',
+};
+
+const decoratorEnv = envMap[process.env.ENV] || 'prod';
+
 const fetchTimeoutMs = 15000;
 
 // Client-side rendered decorator is used as a fallback if the server-side


### PR DESCRIPTION
- Fikser client-side null-feil i error-page (`err` er ikke alltid definert)
- Fikser nesting feil (p og div kan ikke nestes i time)
- Fikser noen små styling-feil på publiseringskalender (feil-sentrert tekst)
- Hindrer client-side import av `NextImageBuildTime` ("noe" i denne ser ut til å krasje eldre versjoner av Safari, tror det er pLimit-pakka)
- Setter ios/safari 11+ ekplisitt i browserslist
- Enable source-maps i prod
- Setter riktig dekoratør-miljø i dev1/dev2