### PR TITLE
Senker antall kall til Sentry

### DIFF
--- a/.github/workflows/deploy-failover.prod.yml
+++ b/.github/workflows/deploy-failover.prod.yml
@@ -17,6 +17,7 @@ jobs:
       DECORATOR_FALLBACK_URL: https://www.nav.no/dekoratoren
       XP_ORIGIN: https://www.nav.no
       INNLOGGINGSSTATUS_URL: https://www.nav.no/person/innloggingsstatus/auth
+      NAVNO_API_URL: https://www.nav.no/person/navno-api
       FAILOVER_ORIGIN: https://www-failover.nav.no
       IS_FAILOVER_INSTANCE: true
     secrets:

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -3,7 +3,7 @@ import { CaptureConsole } from '@sentry/integrations';
 
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.25,
     environment: process.env.ENV,
     integrations: [new CaptureConsole({ levels: ['error'] })],
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,7 +3,7 @@ import { CaptureConsole } from '@sentry/integrations';
 
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 1,
     environment: process.env.ENV,
-    integrations: [new CaptureConsole()],
+    integrations: [new CaptureConsole({ levels: ['error'] })],
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,7 +3,7 @@ import { CaptureConsole } from '@sentry/integrations';
 
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    tracesSampleRate: 1,
+    tracesSampleRate: 1.0,
     environment: process.env.ENV,
     integrations: [new CaptureConsole({ levels: ['error'] })],
 });


### PR DESCRIPTION
- Logger kun errors fra console på serveren
- Logger med 0.25 rate fra browser
- Fikser feil i workflow for prod-failover (manglende env-var)