### PR TITLE
Fikser noen styling issues

### DIFF
--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export const FragmentComponent = ({ componentProps, pageProps }: Props) => {
-    if (!!pageProps.editorView) {
+    if (pageProps.editorView === 'edit') {
         const editorProps = {
             'data-portal-component-type': ComponentType.Fragment,
             'data-portal-component': componentProps.path,

--- a/src/components/layouts/product-details-layout/ProductDetailsLayout.module.scss
+++ b/src/components/layouts/product-details-layout/ProductDetailsLayout.module.scss
@@ -1,0 +1,5 @@
+.productDetails {
+    table {
+        table-layout: fixed;
+    }
+}

--- a/src/components/layouts/product-details-layout/ProductDetailsLayout.tsx
+++ b/src/components/layouts/product-details-layout/ProductDetailsLayout.tsx
@@ -5,6 +5,8 @@ import { LayoutContainer } from '../LayoutContainer';
 import { LegacyLayoutProps } from '../../../types/component-props/layouts/legacy-layout';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
+import style from './ProductDetailsLayout.module.scss';
+
 type Props = {
     pageProps: ContentProps;
     layoutProps?: LegacyLayoutProps;
@@ -24,7 +26,11 @@ export const ProductDetailsLayout = ({ pageProps, layoutProps }: Props) => {
     ];
 
     return (
-        <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
+        <LayoutContainer
+            pageProps={pageProps}
+            layoutProps={layoutProps}
+            className={style.productDetails}
+        >
             {Object.values(regions).map((regionProps, index) => {
                 return (
                     <Fragment key={index}>


### PR DESCRIPTION
- Fikser styling-bugs i CS preview/inline-preview for komponenter i fragmenter. Dette skyldes wrapper-containeren med `data-portal-component` attributes, som komponent-editoren krever.
- Gjør celle-bredde i tabeller for produktdetaljer mer konsistente ved å sette table-layout fixed.

Før:
![before](https://user-images.githubusercontent.com/18137669/187145067-d4646358-571c-4937-9486-79933d41e979.png)
Etter:
![after](https://user-images.githubusercontent.com/18137669/187145061-38cb83f4-f42d-4084-98fa-b1bb6f417cc8.png)
