### PR TITLE
Fikser enkelte lenker i editoren

### DIFF
--- a/src/components/_editor-only/custom-selector-usage-link/CustomSelectorUsageLink.tsx
+++ b/src/components/_editor-only/custom-selector-usage-link/CustomSelectorUsageLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { editorPathPrefix } from '../../../utils/urls';
+import { adminOrigin, editorPathPrefix } from '../../../utils/urls';
 import { LenkeInline } from '../../_common/lenke/LenkeInline';
 import { EditorLinkWrapper } from '../editor-link-wrapper/EditorLinkWrapper';
 
@@ -16,7 +16,7 @@ export const CustomSelectorUsageLink = ({
     name,
     path,
 }: CustomSelectorUsageData) => {
-    const editorUrl = `${editorPathPrefix}/${id}`;
+    const editorUrl = `${adminOrigin}${editorPathPrefix}/${id}`;
 
     return (
         <div className={style.usageLink} key={id}>

--- a/src/components/pages/global-values-page/utils.tsx
+++ b/src/components/pages/global-values-page/utils.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { GlobalValueItem } from '../../../types/content-props/global-values-props';
 import { GVMessageProps } from './components/messages/GVMessages';
 import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
-import { editorPathPrefix, xpDraftPathPrefix } from '../../../utils/urls';
+import {
+    adminOrigin,
+    editorPathPrefix,
+    xpDraftPathPrefix,
+} from '../../../utils/urls';
 import { EditorLinkWrapper } from '../../_editor-only/editor-link-wrapper/EditorLinkWrapper';
 
 export const gvNameExists = (
@@ -25,10 +29,10 @@ const getUsageMessages = (usage) => {
                 <>
                     <EditorLinkWrapper>
                         <LenkeStandalone
-                            href={content.path.replace(
+                            href={`${adminOrigin}${content.path.replace(
                                 '/www.nav.no',
                                 xpDraftPathPrefix
-                            )}
+                            )}`}
                             target={'_blank'}
                             withChevron={false}
                             onClick={(e) => {
@@ -41,7 +45,7 @@ const getUsageMessages = (usage) => {
                     {' // '}
                     <EditorLinkWrapper>
                         <LenkeStandalone
-                            href={`${editorPathPrefix}/${content.id}`}
+                            href={`${adminOrigin}${editorPathPrefix}/${content.id}`}
                             target={'_blank'}
                             withChevron={false}
                             onClick={(e) => {


### PR DESCRIPTION
Pga nylig endring av måten relative url'er behandles på, må lenker til content studio nå være absolutte (se https://github.com/navikt/nav-enonicxp-frontend/pull/1061 og https://github.com/navikt/nav-enonicxp-frontend/pull/1062). Denne skal fikse det.
