### PR TITLE
Fjerner falsk negativ for sjekk av flere filtere i preview mode

### DIFF
--- a/src/components/parts/filters-menu/helpers.ts
+++ b/src/components/parts/filters-menu/helpers.ts
@@ -10,17 +10,24 @@ interface Props {
 export const checkIfFilterFirstInPage = ({ path, page }: Props) => {
     const regions = page?.regions;
 
+    // If no regions, the part is used inside the ComponentPreview.
+    // Assume that the filter is first for now and any duplicate
+    // filters will end up giving a warning when editor pressed "Mark as ready"
     if (!regions) {
-        return false;
+        return true;
     }
 
-    const allComponents = Object.values(regions).reduce((collection, regionObject) => {
-        const { components } = regionObject;
-        return [...collection, ...components]
-    }, [])
+    const allComponents = Object.values(regions).reduce(
+        (collection, regionObject) => {
+            const { components } = regionObject;
+            return [...collection, ...components];
+        },
+        []
+    );
 
     const allFilterMenus = allComponents.filter(
-        (component: PartComponentProps) => component.descriptor === PartType.FiltersMenu
+        (component: PartComponentProps) =>
+            component.descriptor === PartType.FiltersMenu
     );
 
     if (allFilterMenus.length === 0) {


### PR DESCRIPTION
Når filtermenyen settes inn i en side (eller oppdateres) bruker ComponentPreview. Denne fiksen unngår at denne feilaktig rapporterer at filtermenyen er satt inn flere ganger.