### PR TITLE
Legger til engelsk url for finn NAV-kontor

### DIFF
--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -70,9 +70,9 @@ export const DefaultOption = (props: DefaultContactProps) => {
         if (channel === 'navoffice') {
             return {
                 href:
-                    language === 'en'
-                        ? 'https://www.nav.no/sok-nav-kontor/en'
-                        : 'https://www.nav.no/sok-nav-kontor',
+                    language === 'no' || language === 'nn' || language === 'se'
+                        ? 'https://www.nav.no/sok-nav-kontor'
+                        : 'https://www.nav.no/sok-nav-kontor/en',
                 target: '_blank',
             };
         }

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -69,7 +69,10 @@ export const DefaultOption = (props: DefaultContactProps) => {
         }
         if (channel === 'navoffice') {
             return {
-                href: 'https://www.nav.no/sok-nav-kontor',
+                href:
+                    language === 'en'
+                        ? 'https://www.nav.no/sok-nav-kontor/en'
+                        : 'https://www.nav.no/sok-nav-kontor',
                 target: '_blank',
             };
         }


### PR DESCRIPTION
Dersom språket på en side er satt til alt annet enn no, nn eller se (samisk) brukes engelsk lenke til Søk ditt NAV-kontor.