### PR TITLE
Begrenser bredden på tittel i large card

### DIFF
--- a/src/components/_common/card/LargeCard.module.scss
+++ b/src/components/_common/card/LargeCard.module.scss
@@ -99,6 +99,8 @@
     font-size: var(--navds-font-size-heading-medium);
     line-height: var(--navds-font-line-height-heading-medium);
     font-weight: var(--navds-font-weight-bold);
+    max-width: 100%;
+    overflow: hidden;
 
     :global(.provider) & {
         color: var(--navds-semantic-color-link);

--- a/src/components/_common/card/LargeCard.module.scss
+++ b/src/components/_common/card/LargeCard.module.scss
@@ -99,8 +99,7 @@
     font-size: var(--navds-font-size-heading-medium);
     line-height: var(--navds-font-line-height-heading-medium);
     font-weight: var(--navds-font-weight-bold);
-    max-width: 100%;
-    overflow: hidden;
+    word-break: break-all;
 
     :global(.provider) & {
         color: var(--navds-semantic-color-link);

--- a/src/components/_common/card/LargeCard.module.scss
+++ b/src/components/_common/card/LargeCard.module.scss
@@ -99,7 +99,7 @@
     font-size: var(--navds-font-size-heading-medium);
     line-height: var(--navds-font-line-height-heading-medium);
     font-weight: var(--navds-font-weight-bold);
-    word-break: break-all;
+    word-break: break-word;
 
     :global(.provider) & {
         color: var(--navds-semantic-color-link);


### PR DESCRIPTION
- Lange titler blir delt opp på flere linjer
- Dersom en tittel er ETT langt ord, feks "Kvalifiseringsprogrammet", så redaktøren inn en "soft hyphen" for bedre kontroll på hvor tittelen brytes.