### PR TITLE
Fjerner bruk av Label-komponent fra ds-react ++

### DIFF
--- a/src/components/_common/card/Card.module.scss
+++ b/src/components/_common/card/Card.module.scss
@@ -14,13 +14,16 @@
         padding: 0.7rem 0;
         text-decoration: none;
     }
+
     &.inline:not(:last-child) {
         margin-bottom: 0;
     }
+
     .bed {
         transition: all 0.3s;
         height: 100%;
     }
+
     &:hover,
     &:focus-within {
         > :global(.situation) {
@@ -69,43 +72,6 @@
                 width: calc(100% - 8px);
                 margin: 4px;
             }
-        }
-        .bed:global(.mini) {
-            &:after {
-                box-shadow: 0 0 0 2px white;
-                height: calc(100% - 2px);
-                margin: 1px;
-                width: calc(100% - 2px);
-            }
-        }
-        .bed:global(.mini) {
-            &:after {
-                border-radius: 6px;
-            }
-        }
-    }
-
-    :global(.mini) {
-        align-items: center;
-        border-radius: 8px;
-        border: 1px solid #b0b0b0; // Don't exist in @navikt/ds
-        display: inline-flex; // Ensures margins don't collapse
-        padding: common.px-to-rem(12);
-        text-decoration: none;
-        width: 100%;
-
-        &:not(:hover):not(:active) {
-            box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
-                0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
-        }
-
-        &:hover {
-            box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
-                0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
-        }
-        &:hover,
-        &:focus {
-            border: 1px solid transparent;
         }
     }
 

--- a/src/components/_common/card/Card.module.scss
+++ b/src/components/_common/card/Card.module.scss
@@ -70,8 +70,7 @@
                 margin: 4px;
             }
         }
-        .bed:global(.mini),
-        .bed:global(.micro) {
+        .bed:global(.mini) {
             &:after {
                 box-shadow: 0 0 0 2px white;
                 height: calc(100% - 2px);
@@ -82,78 +81,6 @@
         .bed:global(.mini) {
             &:after {
                 border-radius: 6px;
-            }
-        }
-        .bed:global(.micro) {
-            &:after {
-                border-radius: 16px;
-            }
-        }
-    }
-
-    :global(.micro) {
-        border-radius: 16px;
-        border: 1px solid #b0b0b0;
-        box-shadow: 0 0 0 3px var(--navds-semantic-color-link);
-        color: var(--navds-global-color-gray-900);
-        display: inline-flex;
-        font-size: common.px-to-rem(14);
-        line-height: 1.5625rem;
-        margin: 0 0.5rem 0 0;
-        padding: 0 0.5rem;
-        position: relative;
-
-        &:not(:hover):not(:active) {
-            box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
-                0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
-        }
-        &:hover,
-        &:focus {
-            border: 1px solid transparent;
-        }
-        &:before {
-            content: '';
-            align-self: center;
-            position: relative;
-            display: flex;
-            width: 0.5rem;
-            height: 0.5rem;
-            border-radius: 0.5rem;
-            margin: 0 0.5rem 0 0;
-        }
-        &:global(.situation) {
-            &:before {
-                background-color: var(--navds-global-color-orange-500);
-            }
-        }
-        &:global(.product) {
-            &:before {
-                background-color: var(--navds-global-color-green-500);
-            }
-        }
-        &:global(.tool) {
-            &:before {
-                background-color: var(--navds-global-color-deepblue-500);
-            }
-        }
-        &:global(.themed-article) {
-            &:before {
-                background-color: var(--navds-global-color-limegreen-500);
-            }
-        }
-        &:global(.guide) {
-            &:before {
-                background-color: var(--navds-global-color-lightblue-500);
-            }
-        }
-        &:global(.overview) {
-            &:before {
-                background-color: var(--navds-global-color-deepblue-400);
-            }
-        }
-        &:global(.generic) {
-            &:before {
-                background-color: var(--navds-global-color-gray-600);
             }
         }
     }
@@ -221,16 +148,12 @@
     }
 }
 
-.cardHeader {
-    font-weight: common.$navds-font-weight-bold;
-    margin-bottom: 0.5rem;
-}
-
 .lenkeBaseOverride {
     &:focus {
         outline: 0;
     }
 }
+
 // Handle card-margin in layouts
 :global(.layout__situation-flex-cols),
 :global(.layout__product-flex-cols) {

--- a/src/components/_common/card/Card.module.scss
+++ b/src/components/_common/card/Card.module.scss
@@ -221,6 +221,11 @@
     }
 }
 
+.cardHeader {
+    font-weight: common.$navds-font-weight-bold;
+    margin-bottom: 0.5rem;
+}
+
 .lenkeBaseOverride {
     &:focus {
         outline: 0;

--- a/src/components/_common/card/MicroCard.module.scss
+++ b/src/components/_common/card/MicroCard.module.scss
@@ -1,0 +1,89 @@
+@use 'src/common' as common;
+
+.header {
+    font-weight: common.$navds-font-weight-bold;
+}
+
+.micro {
+    border-radius: 16px;
+    border: 1px solid #b0b0b0;
+    box-shadow: 0 0 0 3px var(--navds-semantic-color-link);
+    color: var(--navds-global-color-gray-900);
+    display: inline-flex;
+    font-size: common.px-to-rem(14);
+    line-height: 1.5625rem;
+    margin: 0 0.5rem 0 0;
+    padding: 0 0.5rem;
+    position: relative;
+
+    &:not(:hover):not(:active) {
+        box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
+            0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
+    }
+
+    &:hover,
+    &:focus {
+        border: 1px solid transparent;
+    }
+
+    &:before {
+        content: '';
+        align-self: center;
+        position: relative;
+        display: flex;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 0.5rem;
+        margin: 0 0.5rem 0 0;
+    }
+
+    &:after {
+        border-radius: 16px;
+        box-shadow: 0 0 0 2px white;
+        height: calc(100% - 2px);
+        margin: 1px;
+        width: calc(100% - 2px);
+    }
+
+    &:global(.situation) {
+        &:before {
+            background-color: var(--navds-global-color-orange-500);
+        }
+    }
+
+    &:global(.product) {
+        &:before {
+            background-color: var(--navds-global-color-green-500);
+        }
+    }
+
+    &:global(.tool) {
+        &:before {
+            background-color: var(--navds-global-color-deepblue-500);
+        }
+    }
+
+    &:global(.themed-article) {
+        &:before {
+            background-color: var(--navds-global-color-limegreen-500);
+        }
+    }
+
+    &:global(.guide) {
+        &:before {
+            background-color: var(--navds-global-color-lightblue-500);
+        }
+    }
+
+    &:global(.overview) {
+        &:before {
+            background-color: var(--navds-global-color-deepblue-400);
+        }
+    }
+
+    &:global(.generic) {
+        &:before {
+            background-color: var(--navds-global-color-gray-600);
+        }
+    }
+}

--- a/src/components/_common/card/MicroCard.tsx
+++ b/src/components/_common/card/MicroCard.tsx
@@ -7,7 +7,7 @@ import { classNames } from 'utils/classnames';
 import { TargetPage } from 'types/component-props/parts/product-card';
 import { getCardProps } from 'components/_common/card/card-utils';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { Label } from '@navikt/ds-react';
+import { BodyShort } from '@navikt/ds-react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
 import style from './Card.module.scss';
@@ -51,7 +51,11 @@ export const MicroCards = ({
 
     return (
         <>
-            {header && <Label size="medium" style={{ display: 'block' }}>{header}</Label>}
+            {header && (
+                <BodyShort size={'medium'} className={style.cardHeader}>
+                    {header}
+                </BodyShort>
+            )}
             {cardProps.map((card, index) => (
                 <MicroCard {...card} key={index} />
             ))}

--- a/src/components/_common/card/MicroCard.tsx
+++ b/src/components/_common/card/MicroCard.tsx
@@ -10,7 +10,8 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { BodyShort } from '@navikt/ds-react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
-import style from './Card.module.scss';
+import sharedStyle from './Card.module.scss';
+import style from './MicroCard.module.scss';
 
 const MicroCard = ({ link, type }: { link: LinkProps; type: CardType }) => {
     const { analyticsProps } = useCard({ type, size: CardSize.Micro, link });
@@ -18,22 +19,21 @@ const MicroCard = ({ link, type }: { link: LinkProps; type: CardType }) => {
         <LenkeBase
             href={link.url}
             {...analyticsProps}
-            className={classNames(style.card, style.inline)}
+            className={classNames(sharedStyle.card, sharedStyle.inline)}
         >
-            <div className={classNames(style.bed, type, CardSize.Micro)}>
+            <div className={classNames(sharedStyle.bed, style.micro, type)}>
                 {link.text}
             </div>
         </LenkeBase>
     );
 };
 
-export const MicroCards = ({
-    header,
-    card_list,
-}: {
+type Props = {
     header?: string;
     card_list: TargetPage[];
-}) => {
+};
+
+export const MicroCards = ({ header, card_list }: Props) => {
     const { language } = usePageConfig();
 
     const cardProps = card_list.reduce((acc, card) => {
@@ -52,7 +52,7 @@ export const MicroCards = ({
     return (
         <>
             {header && (
-                <BodyShort size={'medium'} className={style.cardHeader}>
+                <BodyShort size={'medium'} className={style.header}>
                     {header}
                 </BodyShort>
             )}

--- a/src/components/_common/card/MiniCard.module.scss
+++ b/src/components/_common/card/MiniCard.module.scss
@@ -1,11 +1,19 @@
 @use 'src/common' as common;
 
 $illustrationSize: common.px-to-rem(64);
+$illustrationSizeSmall: common.px-to-rem(48);
 
 .illustration {
     width: $illustrationSize;
+    min-width: $illustrationSize;
     height: $illustrationSize;
     margin-right: 1rem;
+
+    @media #{common.$mq-screen-mobile-small} {
+        width: $illustrationSizeSmall;
+        min-width: $illustrationSizeSmall;
+        height: $illustrationSizeSmall;
+    }
 }
 
 .title {
@@ -22,4 +30,37 @@ $illustrationSize: common.px-to-rem(64);
 .header {
     font-weight: common.$navds-font-weight-bold;
     margin-bottom: 0.5rem;
+}
+
+.mini {
+    align-items: center;
+    border-radius: 8px;
+    border: 1px solid #b0b0b0; // Don't exist in @navikt/ds
+    display: inline-flex; // Ensures margins don't collapse
+    padding: common.px-to-rem(12);
+    text-decoration: none;
+    width: 100%;
+
+    &:after {
+        box-shadow: 0 0 0 2px white;
+        height: calc(100% - 2px);
+        margin: 1px;
+        width: calc(100% - 2px);
+        border-radius: 6px;
+    }
+
+    &:not(:hover):not(:active) {
+        box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
+            0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
+    }
+
+    &:hover {
+        box-shadow: 0 1px 3px rgba(38, 38, 38, 0.2),
+            0 1px 6px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(38, 38, 38, 0.12);
+    }
+
+    &:hover,
+    &:focus {
+        border: 1px solid transparent;
+    }
 }

--- a/src/components/_common/card/MiniCard.module.scss
+++ b/src/components/_common/card/MiniCard.module.scss
@@ -19,3 +19,7 @@ $illustrationSize: common.px-to-rem(64);
     }
 }
 
+.header {
+    font-weight: common.$navds-font-weight-bold;
+    margin-bottom: 0.5rem;
+}

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -44,9 +44,7 @@ export const MiniCard = (props: MiniKortProps) => {
                 {...userEventProps}
                 className={classNames(sharedStyle.card, className)}
             >
-                <div
-                    className={classNames(sharedStyle.bed, type, CardSize.Mini)}
-                >
+                <div className={classNames(sharedStyle.bed, style.mini, type)}>
                     <Illustration
                         className={style.illustration}
                         illustration={illustration}

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+import { BodyShort } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
-
-import { AnimatedIconsProps } from '../../../types/content-props/animated-icons';
+import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { CardSize, CardType } from 'types/card';
 import { Illustration } from '../illustration/Illustration';
 import { IllustrationPlacements } from 'types/illustrationPlacements';
@@ -17,11 +18,12 @@ export type MiniKortProps = {
     illustration?: AnimatedIconsProps;
     link: LinkProps;
     type: CardType;
+    header?: string;
     className?: string;
 };
 
 export const MiniCard = (props: MiniKortProps) => {
-    const { link, illustration, type, className } = props;
+    const { link, illustration, type, header, className } = props;
     const { text } = link;
     const { isHovering, userEventProps, analyticsProps } = useCard({
         type,
@@ -32,29 +34,40 @@ export const MiniCard = (props: MiniKortProps) => {
     const { pageConfig } = usePageConfig();
 
     return (
-        <div
-            {...userEventProps}
-            className={classNames(sharedStyle.card, className)}
-        >
-            <div className={classNames(sharedStyle.bed, type, CardSize.Mini)}>
-                <Illustration
-                    className={style.illustration}
-                    illustration={illustration}
-                    isHovering={isHovering}
-                    placement={IllustrationPlacements.SMALL_CARD}
-                    preferStaticIllustration={pageConfig.editorView === 'edit'}
-                />
-                <LenkeBase
-                    className={classNames(
-                        sharedStyle.lenkeBaseOverride,
-                        style.title
-                    )}
-                    href={link.url}
-                    {...analyticsProps}
+        <>
+            {header && (
+                <BodyShort size={'medium'} className={sharedStyle.cardHeader}>
+                    {header}
+                </BodyShort>
+            )}
+            <div
+                {...userEventProps}
+                className={classNames(sharedStyle.card, className)}
+            >
+                <div
+                    className={classNames(sharedStyle.bed, type, CardSize.Mini)}
                 >
-                    {text}
-                </LenkeBase>
+                    <Illustration
+                        className={style.illustration}
+                        illustration={illustration}
+                        isHovering={isHovering}
+                        placement={IllustrationPlacements.SMALL_CARD}
+                        preferStaticIllustration={
+                            pageConfig.editorView === 'edit'
+                        }
+                    />
+                    <LenkeBase
+                        className={classNames(
+                            sharedStyle.lenkeBaseOverride,
+                            style.title
+                        )}
+                        href={link.url}
+                        {...analyticsProps}
+                    >
+                        {text}
+                    </LenkeBase>
+                </div>
             </div>
-        </div>
+        </>
     );
 };

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -36,7 +36,7 @@ export const MiniCard = (props: MiniKortProps) => {
     return (
         <>
             {header && (
-                <BodyShort size={'medium'} className={sharedStyle.cardHeader}>
+                <BodyShort size={'medium'} className={style.header}>
                     {header}
                 </BodyShort>
             )}

--- a/src/components/_common/page-navigation-menu/PageNavigationLink.module.scss
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.module.scss
@@ -9,3 +9,7 @@
         text-decoration: underline;
     }
 }
+
+.linkText {
+    font-weight: common.$navds-font-weight-bold;
+}

--- a/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label } from '@navikt/ds-react';
+import { BodyShort, Label } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from '../lenke/LenkeBase';
 import { PageNavViewStyle } from 'types/component-props/parts/page-navigation-menu';
@@ -66,7 +66,7 @@ export const PageNavigationLink = React.memo(
                         aria-hidden={true}
                     />
                 )}
-                <Label>{children}</Label>
+                <BodyShort className={style.linkText}>{children}</BodyShort>
             </LenkeBase>
         );
     }

--- a/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from '../lenke/LenkeBase';
 import { PageNavViewStyle } from 'types/component-props/parts/page-navigation-menu';

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.module.scss
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.module.scss
@@ -15,6 +15,7 @@
         padding: 0.5rem;
     }
 }
+
 .right {
     align-self: flex-end;
     width: 50%;
@@ -25,4 +26,3 @@
         min-height: common.$versionSelectorMinHeight;
     }
 }
-

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Checkbox, Label } from '@navikt/ds-react';
-import { ContentProps } from '../../../../../types/content-props/_content-common';
-import {
-    getCurrentDateAndTime,
-    getUtcTimeFromLocal,
-} from '../../../../../utils/datetime';
-import { Branch } from '../../../../../types/branch';
+import { ContentProps } from 'types/content-props/_content-common';
+import { getCurrentDateAndTime, getUtcTimeFromLocal } from 'utils/datetime';
+import { Branch } from 'types/branch';
 import { getVersionSelectorUrl } from '../versionSelectorUtils';
 import { VersionSelectorSubmitButton } from '../submit-button/VersionSelectorSubmitButton';
 
@@ -46,13 +43,16 @@ export const VersionSelectorDateTime = ({
     return (
         <>
             <div className={style.left}>
-                <Label>{'Velg tid og dato:'}</Label>
+                <Label id={'version-selector-label'}>
+                    {'Velg tid og dato:'}
+                </Label>
                 <input
                     type={'time'}
                     className={style.time}
                     onChange={(e) => {
                         setTimeSelected(e.target.value);
                     }}
+                    aria-labelledby={'version-selector-label'}
                     value={timeSelected.slice(0, 5)}
                 />
                 <input
@@ -61,6 +61,7 @@ export const VersionSelectorDateTime = ({
                     onChange={(e) => {
                         setDateSelected(e.target.value);
                     }}
+                    aria-labelledby={'version-selector-label'}
                     min={startDate}
                     max={initialDate}
                     value={dateSelected}

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.module.scss
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.module.scss
@@ -29,6 +29,7 @@ $decorWidth: 0.5rem;
             position: relative;
             text-decoration: none;
             z-index: 1;
+            font-weight: common.$navds-font-weight-bold;
 
             &:before {
                 content: ' ';

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Heading, Label } from '@navikt/ds-react';
+import { BodyShort, Heading } from '@navikt/ds-react';
 import { translator } from 'translations';
 import classNames from 'classnames';
 import { ContentType, ContentProps } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
-import { MainArticleChapterNavigationData } from '../../../../types/content-props/main-article-chapter-props';
+import { MainArticleChapterNavigationData } from 'types/content-props/main-article-chapter-props';
 import { LenkeBase } from '../../../_common/lenke/LenkeBase';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
@@ -54,15 +54,14 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
             <ul>
                 <li>
                     {parentSelected ? (
-                        <Label className={classNames(style.item, style.active)}>
-                            {parentTitle}
-                        </Label>
-                    ) : (
-                        <LenkeBase
-                            href={parentPath}
-                            className={classNames(style.item)}
+                        <BodyShort
+                            className={classNames(style.item, style.active)}
                         >
-                            <Label>{parentTitle}</Label>
+                            {parentTitle}
+                        </BodyShort>
+                    ) : (
+                        <LenkeBase href={parentPath} className={style.item}>
+                            {parentTitle}
                         </LenkeBase>
                     )}
                 </li>
@@ -75,20 +74,20 @@ export const MainArticleChapterNavigation = (props: ContentProps) => {
                     return (
                         <li key={chapter._path}>
                             {chapterSelected ? (
-                                <Label
+                                <BodyShort
                                     className={classNames(
                                         style.item,
                                         style.active
                                     )}
                                 >
                                     {chapter.displayName}
-                                </Label>
+                                </BodyShort>
                             ) : (
                                 <LenkeBase
                                     href={chapterPath}
-                                    className={classNames(style.item)}
+                                    className={style.item}
                                 >
-                                    <Label>{chapter.displayName}</Label>
+                                    {chapter.displayName}
                                 </LenkeBase>
                             )}
                         </li>

--- a/src/components/parts/product-card/ProductCard.tsx
+++ b/src/components/parts/product-card/ProductCard.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Label } from '@navikt/ds-react';
-import { usePageConfig } from '../../../store/hooks/usePageConfig';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 import { PartType } from 'types/component-props/parts';
 import {
     ProductCardMiniProps,
     ProductCardProps,
-} from '../../../types/component-props/parts/product-card';
+} from 'types/component-props/parts/product-card';
 import { getCardProps } from '../../_common/card/card-utils';
 import { MiniCard } from '../../_common/card/MiniCard';
 import { LargeCard } from '../../_common/card/LargeCard';
@@ -40,16 +39,7 @@ export const ProductCardPart = ({
     }
 
     if (descriptor === PartType.ProductCardMini) {
-        return (
-            <>
-                {header && (
-                    <Label size="medium" className="card-heading">
-                        {header}
-                    </Label>
-                )}
-                <MiniCard {...props} />
-            </>
-        );
+        return <MiniCard {...props} header={header} />;
     }
 
     return <EditorHelp type={'error'} text={'Kortet har ugyldig type'} />;

--- a/src/types/content-props/index-pages-props.ts
+++ b/src/types/content-props/index-pages-props.ts
@@ -10,11 +10,11 @@ import {
 } from '../component-props/_mixins';
 
 type CommonData = {
-    areasRefs: AreaPageProps[];
     audience: Audience;
 } & DynamicPageData;
 
 export type FrontPageData = {
+    areasRefs: AreaPageProps[];
     areasHeader: string;
 } & CommonData;
 


### PR DESCRIPTION
- Erstatter `<Label>` med `<BodyShort>` + bold styling der dette gir mening, ettersom Label nå bruker en faktisk `<label>`-tag i nyeste ds-react (var tidliger en `<p>` med bold tekst).
- Refactor minicard+microcard CSS til separate moduler
- Fikser inkonsistent bredde på minicard-illustrasjoner
- Fikser manglende avstand mellom header og card på minicards
- Fjerner ubrukt felt `areasRefs` i type for AreaPage (ble tidligere brukt til navigasjonsmeny som nå er fjernet)