### PR TITLE
Håndterer redirects med tom target

### DIFF
--- a/src/components/pages/redirect-page/RedirectPage.module.scss
+++ b/src/components/pages/redirect-page/RedirectPage.module.scss
@@ -6,3 +6,8 @@
     padding: common.$editorPaddingVertical common.$editorPaddingHorizontal;
     border: 4px solid common.$navds-global-color-green-200;
 }
+
+.loader {
+    display: flex;
+    justify-content: center;
+}

--- a/src/utils/fetch/fetch-page-props.ts
+++ b/src/utils/fetch/fetch-page-props.ts
@@ -6,12 +6,13 @@ import {
     stripXpPathPrefix,
 } from '../urls';
 import { fetchPage } from './fetch-content';
-import { isMediaContent } from '../../types/media';
+import { isMediaContent } from 'types/media';
 import { errorHandler, isNotFound } from '../errors';
-import { ContentType } from '../../types/content-props/_content-common';
+import { ContentType } from 'types/content-props/_content-common';
 import {
     getTargetIfRedirect,
     isPermanentRedirect,
+    isRedirectType,
     redirectPageProps,
 } from '../redirects';
 
@@ -62,11 +63,21 @@ export const fetchPageProps = async ({
 
     if (!noRedirect) {
         const redirectTarget = getTargetIfRedirect(content);
+
         if (redirectTarget) {
             return redirectPageProps(
                 getRelativePathIfInternal(redirectTarget, isDraft),
                 isPermanentRedirect(content)
             );
+        }
+
+        // If a content type which should always be a redirect did not have a
+        // valid target we just return 404
+        if (isRedirectType(content)) {
+            return {
+                props: {},
+                notFound: true,
+            };
         }
     }
 

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -1,9 +1,12 @@
-import {
-    ContentType,
-    ContentProps,
-} from '../types/content-props/_content-common';
+import { ContentType, ContentProps } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from './urls';
 import { getInternalLinkUrl } from './links-from-content';
+
+const redirectTypes: { [type in ContentType]?: boolean } = {
+    [ContentType.InternalLink]: true,
+    [ContentType.ExternalLink]: true,
+    [ContentType.Url]: true,
+};
 
 const getTargetPath = (contentData: ContentProps) => {
     switch (contentData?.__typename) {
@@ -32,6 +35,9 @@ const getTargetPath = (contentData: ContentProps) => {
             return null;
     }
 };
+
+export const isRedirectType = (content: ContentProps) =>
+    redirectTypes[content.__typename];
 
 export const getTargetIfRedirect = (contentData: ContentProps) => {
     const targetPath = getTargetPath(contentData);


### PR DESCRIPTION
Dersom en redirect-type (internal/external-link) ikke har et target/url felt, havner browser i en redirect-loop på en tom side. Denne PR'en skal fikse problemet, og viser heller 404-side for tomme redirects.