### PR TITLE
Version history UX forbedringer og bugfixes

### DIFF
--- a/src/components/_top-container/version-history/VersionHistory.tsx
+++ b/src/components/_top-container/version-history/VersionHistory.tsx
@@ -33,7 +33,10 @@ export const VersionHistory = ({ content }: Props) => {
     useEffect(() => {
         setSelectorIsOpen(false);
         if (versionUrlRequested) {
-            router.push(versionUrlRequested);
+            router.push(versionUrlRequested).catch((err) => {
+                console.log('Error during version history navigation: ', err);
+                setVersionUrlRequested(null);
+            });
         }
     }, [versionUrlRequested, router]);
 

--- a/src/components/_top-container/version-history/selector/VersionSelector.tsx
+++ b/src/components/_top-container/version-history/selector/VersionSelector.tsx
@@ -22,8 +22,14 @@ export const VersionSelector = ({
     setIsOpen,
     submitVersionUrl,
 }: Props) => {
+    const { editorView, timeRequested, versionTimestamps } = content;
+
     const [selectorType, setSelectorType] = useState<SelectorType>('datetime');
-    const { editorView } = content;
+
+    // Set the selection to a specific version if it was previously selected by the user
+    const selectedVersion = versionTimestamps.find(
+        (versionTimestamp) => versionTimestamp === timeRequested
+    );
 
     useEffect(() => {
         const closeSelector = (e: MouseEvent) => {
@@ -65,13 +71,14 @@ export const VersionSelector = ({
                     </RadioGroup>
                 </div>
                 <div className={style.input}>
-                    {selectorType === 'datetime' ? (
-                        <VersionSelectorDateTime
+                    {selectedVersion || selectorType === 'published' ? (
+                        <VersionSelectorPublished
                             content={content}
                             submitVersionUrl={submitVersionUrl}
+                            initialSelection={selectedVersion}
                         />
-                    ) : selectorType === 'published' ? (
-                        <VersionSelectorPublished
+                    ) : selectorType === 'datetime' ? (
+                        <VersionSelectorDateTime
                             content={content}
                             submitVersionUrl={submitVersionUrl}
                         />

--- a/src/components/_top-container/version-history/selector/VersionSelector.tsx
+++ b/src/components/_top-container/version-history/selector/VersionSelector.tsx
@@ -24,11 +24,13 @@ export const VersionSelector = ({
 }: Props) => {
     const { editorView, timeRequested, versionTimestamps } = content;
 
-    const [selectorType, setSelectorType] = useState<SelectorType>('datetime');
-
     // Set the selection to a specific version if it was previously selected by the user
     const selectedVersion = versionTimestamps.find(
         (versionTimestamp) => versionTimestamp === timeRequested
+    );
+
+    const [selectorType, setSelectorType] = useState<SelectorType>(
+        selectedVersion ? 'published' : 'datetime'
     );
 
     useEffect(() => {
@@ -71,16 +73,16 @@ export const VersionSelector = ({
                     </RadioGroup>
                 </div>
                 <div className={style.input}>
-                    {selectedVersion || selectorType === 'published' ? (
+                    {selectorType === 'datetime' ? (
+                        <VersionSelectorDateTime
+                            content={content}
+                            submitVersionUrl={submitVersionUrl}
+                        />
+                    ) : selectorType === 'published' ? (
                         <VersionSelectorPublished
                             content={content}
                             submitVersionUrl={submitVersionUrl}
                             initialSelection={selectedVersion}
-                        />
-                    ) : selectorType === 'datetime' ? (
-                        <VersionSelectorDateTime
-                            content={content}
-                            submitVersionUrl={submitVersionUrl}
                         />
                     ) : (
                         <div>{'Feil: velg en input-type'}</div>

--- a/src/components/_top-container/version-history/selector/VersionSelector.tsx
+++ b/src/components/_top-container/version-history/selector/VersionSelector.tsx
@@ -59,7 +59,7 @@ export const VersionSelector = ({
                 <div className={style.typeSelector}>
                     <RadioGroup
                         legend={'Velg tidspunkt'}
-                        defaultValue={selectorType}
+                        value={selectorType}
                         onChange={(value) => {
                             setSelectorType(value as SelectorType);
                         }}

--- a/src/components/_top-container/version-history/selector/VersionSelector.tsx
+++ b/src/components/_top-container/version-history/selector/VersionSelector.tsx
@@ -59,7 +59,7 @@ export const VersionSelector = ({
                 <div className={style.typeSelector}>
                     <RadioGroup
                         legend={'Velg tidspunkt'}
-                        defaultValue={'datetime'}
+                        defaultValue={selectorType}
                         onChange={(value) => {
                             setSelectorType(value as SelectorType);
                         }}

--- a/src/components/_top-container/version-history/selector/published-datetime/VersionSelectorPublished.tsx
+++ b/src/components/_top-container/version-history/selector/published-datetime/VersionSelectorPublished.tsx
@@ -25,11 +25,18 @@ export const VersionSelectorPublished = ({
     );
 
     useEffect(() => {
+        console.log(timeRequested, versionTimestamps);
         // Reset the current selection when receiving live content
         if (!timeRequested) {
             setSelectedDateTime(currentVersionTimestamp);
+        } else if (
+            versionTimestamps.some(
+                (versionTimestamp) => versionTimestamp === timeRequested
+            )
+        ) {
+            setSelectedDateTime(timeRequested);
         }
-    }, [timeRequested, currentVersionTimestamp]);
+    }, [timeRequested, currentVersionTimestamp, versionTimestamps]);
 
     if (!currentVersionTimestamp) {
         return <div>{'Fant ingen publiseringer for dette innholdet'}</div>;
@@ -47,7 +54,11 @@ export const VersionSelectorPublished = ({
                 className={style.select}
             >
                 {versionTimestamps.map((timestamp, index) => (
-                    <option value={timestamp} key={index}>
+                    <option
+                        value={timestamp}
+                        selected={timestamp === selectedDateTime}
+                        key={index}
+                    >
                         {formatDateTime(timestamp, 'nb', true)}
                     </option>
                 ))}

--- a/src/components/_top-container/version-history/selector/published-datetime/VersionSelectorPublished.tsx
+++ b/src/components/_top-container/version-history/selector/published-datetime/VersionSelectorPublished.tsx
@@ -10,35 +10,21 @@ import style from './VersionSelectorPublished.module.scss';
 type Props = {
     content: ContentProps;
     submitVersionUrl: (url: string) => void;
+    initialSelection?: string;
 };
 
 export const VersionSelectorPublished = ({
     content,
     submitVersionUrl,
+    initialSelection,
 }: Props) => {
-    const { versionTimestamps, editorView, timeRequested } = content;
-
-    const currentVersionTimestamp = versionTimestamps?.[0];
+    const { versionTimestamps = [], editorView } = content;
 
     const [selectedDateTime, setSelectedDateTime] = useState(
-        currentVersionTimestamp
+        initialSelection || versionTimestamps[0]
     );
 
-    useEffect(() => {
-        console.log(timeRequested, versionTimestamps);
-        // Reset the current selection when receiving live content
-        if (!timeRequested) {
-            setSelectedDateTime(currentVersionTimestamp);
-        } else if (
-            versionTimestamps.some(
-                (versionTimestamp) => versionTimestamp === timeRequested
-            )
-        ) {
-            setSelectedDateTime(timeRequested);
-        }
-    }, [timeRequested, currentVersionTimestamp, versionTimestamps]);
-
-    if (!currentVersionTimestamp) {
+    if (versionTimestamps.length === 0) {
         return <div>{'Fant ingen publiseringer for dette innholdet'}</div>;
     }
 

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { Checkbox, Label } from '@navikt/ds-react';
 import { ContentProps } from 'types/content-props/_content-common';
-import { getCurrentDateAndTime, getUtcTimeFromLocal } from 'utils/datetime';
+import {
+    getCurrentDateAndTime,
+    getCurrentISODate,
+    getUtcTimeFromLocal,
+} from 'utils/datetime';
 import { Branch } from 'types/branch';
 import { getVersionSelectorUrl } from '../versionSelectorUtils';
 import { VersionSelectorSubmitButton } from '../submit-button/VersionSelectorSubmitButton';
@@ -21,13 +25,11 @@ export const VersionSelectorDateTime = ({
 }: Props) => {
     const { editorView, timeRequested } = content;
 
-    const [currentDate, currentTime] = getCurrentDateAndTime();
-
     const nbTime = dayjs(timeRequested).locale('nb').format();
 
     const [initialDate, initialTime] = timeRequested
         ? nbTime.split('T')
-        : [currentDate, currentTime];
+        : getCurrentDateAndTime();
 
     const [dateSelected, setDateSelected] = useState(initialDate);
     const [timeSelected, setTimeSelected] = useState(initialTime);
@@ -62,7 +64,7 @@ export const VersionSelectorDateTime = ({
                     }}
                     aria-labelledby={'version-selector-label'}
                     min={startDate}
-                    max={currentDate}
+                    max={getCurrentISODate()}
                     value={dateSelected}
                 />
             </div>

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Checkbox, Label } from '@navikt/ds-react';
 import { ContentProps } from 'types/content-props/_content-common';
-import { getCurrentDateAndTime, getUtcTimeFromLocal } from 'utils/datetime';
+import {
+    getCurrentDateAndTime,
+    getLocaleTimeFromUtc,
+    getUtcTimeFromLocal,
+} from 'utils/datetime';
 import { Branch } from 'types/branch';
 import { getVersionSelectorUrl } from '../versionSelectorUtils';
 import { VersionSelectorSubmitButton } from '../submit-button/VersionSelectorSubmitButton';
@@ -20,9 +24,11 @@ export const VersionSelectorDateTime = ({
 }: Props) => {
     const { editorView, timeRequested } = content;
 
+    const [currentDate, currentTime] = getCurrentDateAndTime();
+
     const [initialDate, initialTime] = timeRequested
-        ? timeRequested.split('T')
-        : getCurrentDateAndTime();
+        ? getLocaleTimeFromUtc(timeRequested).split('T')
+        : [currentDate, currentTime];
 
     const [dateSelected, setDateSelected] = useState(initialDate);
     const [timeSelected, setTimeSelected] = useState(initialTime);
@@ -57,7 +63,7 @@ export const VersionSelectorDateTime = ({
                     }}
                     aria-labelledby={'version-selector-label'}
                     min={startDate}
-                    max={initialDate}
+                    max={currentDate}
                     value={dateSelected}
                 />
             </div>

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -37,6 +37,10 @@ export const VersionSelectorDateTime = ({
             const [currentDate, currentTime] = getCurrentDateAndTime();
             setDateSelected(currentDate);
             setTimeSelected(currentTime);
+        } else {
+            const [requestedDate, requestedTime] = timeRequested.split('T');
+            setDateSelected(requestedDate);
+            setTimeSelected(requestedTime);
         }
     }, [timeRequested]);
 

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -1,14 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Checkbox, Label } from '@navikt/ds-react';
 import { ContentProps } from 'types/content-props/_content-common';
-import {
-    getCurrentDateAndTime,
-    getLocaleTimeFromUtc,
-    getUtcTimeFromLocal,
-} from 'utils/datetime';
+import { getCurrentDateAndTime, getUtcTimeFromLocal } from 'utils/datetime';
 import { Branch } from 'types/branch';
 import { getVersionSelectorUrl } from '../versionSelectorUtils';
 import { VersionSelectorSubmitButton } from '../submit-button/VersionSelectorSubmitButton';
+import dayjs from 'dayjs';
 
 import style from './VersionSelectorDateTime.module.scss';
 
@@ -26,8 +23,10 @@ export const VersionSelectorDateTime = ({
 
     const [currentDate, currentTime] = getCurrentDateAndTime();
 
+    const nbTime = dayjs(timeRequested).locale('nb').format();
+
     const [initialDate, initialTime] = timeRequested
-        ? getLocaleTimeFromUtc(timeRequested).split('T')
+        ? nbTime.split('T')
         : [currentDate, currentTime];
 
     const [dateSelected, setDateSelected] = useState(initialDate);

--- a/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_top-container/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -18,31 +18,21 @@ export const VersionSelectorDateTime = ({
     content,
     submitVersionUrl,
 }: Props) => {
-    const [initialDate, initialTime] = getCurrentDateAndTime();
+    const { editorView, timeRequested } = content;
+
+    const [initialDate, initialTime] = timeRequested
+        ? timeRequested.split('T')
+        : getCurrentDateAndTime();
+
     const [dateSelected, setDateSelected] = useState(initialDate);
     const [timeSelected, setTimeSelected] = useState(initialTime);
     const [branchSelected, setBranchSelected] = useState<Branch>('master');
-
-    const { editorView, timeRequested } = content;
 
     const url = getVersionSelectorUrl(
         content,
         getUtcTimeFromLocal(`${dateSelected}T${timeSelected}`),
         branchSelected
     );
-
-    useEffect(() => {
-        // Reset the current date/time selection when receiving live content
-        if (!timeRequested) {
-            const [currentDate, currentTime] = getCurrentDateAndTime();
-            setDateSelected(currentDate);
-            setTimeSelected(currentTime);
-        } else {
-            const [requestedDate, requestedTime] = timeRequested.split('T');
-            setDateSelected(requestedDate);
-            setTimeSelected(requestedTime);
-        }
-    }, [timeRequested]);
 
     return (
         <>

--- a/src/components/_top-container/version-history/status/VersionStatus.tsx
+++ b/src/components/_top-container/version-history/status/VersionStatus.tsx
@@ -3,6 +3,7 @@ import { BodyLong } from '@navikt/ds-react';
 import { LenkeStandalone } from '../../../_common/lenke/LenkeStandalone';
 import { formatDateTime } from '../../../../utils/datetime';
 import { ContentProps } from '../../../../types/content-props/_content-common';
+import dayjs from 'dayjs';
 
 import style from './VersionStatus.module.scss';
 
@@ -14,15 +15,15 @@ type Props = {
 export const VersionStatus = ({ content, requestedDateTime }: Props) => {
     const contentDateTime = content.modifiedTime || content.createdTime;
 
-    const requestedUnixTime = new Date(requestedDateTime).getTime();
-    const contentUnixTime = new Date(contentDateTime).getTime();
-
     const requestedTimeFormatted = formatDateTime(
         requestedDateTime,
         'nb',
         true
     );
     const contentTimeFormatted = formatDateTime(contentDateTime, 'nb', true);
+
+    const requestedUnixTime = dayjs(requestedDateTime).startOf('minute').unix();
+    const contentUnixTime = dayjs(contentDateTime).startOf('minute').unix();
 
     return (
         <div className={style.versionStatus}>

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -64,6 +64,10 @@ export const getUtcTimeFromLocal = (datetime: string) => {
     return dayjs(datetime).utc().format();
 };
 
+export const getLocaleTimeFromUtc = (datetime: string, locale = 'nb') => {
+    return dayjs(datetime).locale(locale).format();
+};
+
 export const getDayNumberFromName = (dayToFind: string): number | null => {
     return days.findIndex((day) => day === dayToFind) || null;
 };

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -64,10 +64,6 @@ export const getUtcTimeFromLocal = (datetime: string) => {
     return dayjs(datetime).utc().format();
 };
 
-export const getLocaleTimeFromUtc = (datetime: string, locale = 'nb') => {
-    return dayjs(datetime).locale(locale).format();
-};
-
 export const getDayNumberFromName = (dayToFind: string): number | null => {
     return days.findIndex((day) => day === dayToFind) || null;
 };

--- a/src/utils/fetch/fetch-content.ts
+++ b/src/utils/fetch/fetch-content.ts
@@ -41,7 +41,7 @@ const fetchSiteContent = async ({
         id: idOrPath,
         ...(isDraft && { branch: 'draft' }),
         ...(time && { time }),
-        ...(!isDraft && getCacheKey()),
+        ...(!isDraft && !time && getCacheKey()), // We don't want to use backend-cache for version history or draft content requests
         ...(isPreview && { preview: true }),
     });
     const url = `${xpServiceUrl}/sitecontent${params}`;


### PR DESCRIPTION
- Default verdi på dato-/tid-/publiserings-velger settes nå til forrige valgte verdier
- Setter publiserings-velger som default dersom forrige valgte verdi var et eksakt publiseringstidspunkt
- Fikser avrundingsfeil i statusmelding for valgt versjon
- Forhindrer at versjonshistorikk hentes fra cache i backend