### PR TITLE
Fikser client-side error rendering

### DIFF
--- a/src/components/_top-container/version-history/selector/VersionSelector.tsx
+++ b/src/components/_top-container/version-history/selector/VersionSelector.tsx
@@ -41,7 +41,7 @@ export const VersionSelector = ({
     useEffect(() => {
         fetchWithTimeout(
             `${publishedVersionsServiceUrl}?id=${content._id}`,
-            5000
+            15000
         )
             .then((res) => {
                 if (res.ok) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ const vars = {
 
 const urls = {
     prodOrigin: 'https://www.nav.no',
-    errorFeedback: '/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler',
+    errorFeedback: `${process.env.APP_ORIGIN}/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler`,
 };
 
 const Config = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,9 @@ const vars = {
 
 const urls = {
     prodOrigin: 'https://www.nav.no',
-    errorFeedback: `${process.env.APP_ORIGIN}/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler`,
+    errorFeedback: `https://www${
+        process.env.ENV !== 'prod' ? '.dev' : ''
+    }.nav.no/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler`,
 };
 
 const Config = {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,9 +1,43 @@
-import { makeErrorProps } from '../utils/make-error-props';
-import { PageBase } from '../components/PageBase';
-import { ContentProps } from '../types/content-props/_content-common';
+import React from 'react';
+import { makeErrorProps } from 'utils/make-error-props';
+import { PageBase } from 'components/PageBase';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { v4 as uuid } from 'uuid';
-import { logPageLoadError } from '../utils/errors';
-import { fetchWithTimeout } from '../utils/fetch/fetch-utils';
+import { logPageLoadError } from 'utils/errors';
+import { fetchWithTimeout } from 'utils/fetch/fetch-utils';
+
+// Workaround for next.js bug which fail to propagate error props from the server for client-side rendering
+// See related issue: https://github.com/vercel/next.js/issues/39616
+const getClientsideProps = (path: string) => {
+    if (typeof document === undefined) {
+        console.error(
+            `document was unexpectedly not defined in client-side error controller on ${path}`
+        );
+        return null;
+    }
+
+    const nextData = document.getElementById('__NEXT_DATA__')?.textContent;
+    if (!nextData) {
+        console.error(`__NEXT_DATA__ not found on ${path}`);
+        return null;
+    }
+
+    try {
+        const contentProps = JSON.parse(nextData)?.props
+            ?.pageProps as ContentProps;
+        if (contentProps.__typename !== ContentType.Error) {
+            console.error(
+                `Unexpected __NEXT_DATA__ contentProps on ${path} - ${contentProps._id} ${contentProps.__typename}`
+            );
+            return null;
+        }
+
+        return contentProps;
+    } catch (e) {
+        console.error(`Failed to parse __NEXT_DATA__ on ${path} - ${e}`);
+        return null;
+    }
+};
 
 const fetchFailoverHtml = async (path: string) => {
     const url = `${process.env.FAILOVER_ORIGIN}${path}`;
@@ -30,11 +64,11 @@ const fetchFailoverHtml = async (path: string) => {
 
 const Error = (props: ContentProps) => <PageBase content={props} />;
 
-Error.getInitialProps = async (context): Promise<ContentProps> => {
-    const { res, err, asPath } = context;
-
+Error.getInitialProps = async ({ res, err, asPath }): Promise<ContentProps> => {
+    // the res object is undefined on the client-side
     if (!res) {
-        return err?.content || makeErrorProps();
+        const pageProps = getClientsideProps(asPath);
+        return pageProps || makeErrorProps(asPath, 'Unknown client-side error');
     }
 
     if (process.env.IS_FAILOVER_INSTANCE !== 'true') {


### PR DESCRIPTION
Er en bug i next.js som har ført til at alle feilsider rendres som 500-feil (unntatt 404, som har separat håndtering). Pageprops for error-sidene ser ikke ut til å propageres fra servereren. Legger inn en workaround for dette.

Se https://github.com/vercel/next.js/issues/39616

Andre endringer:
- Øker en timeout på versjonsvelgeren som var litt kort
- Bruker absolute url for tilbakemeldinger, slik at denne routes korrekt (ligger i separat app)