### PR TITLE
Setter connect-src direktiv

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -81,6 +81,7 @@ const csp = async () => {
             'font-src': [...internalHosts, DATA],
             'img-src': [...internalHosts, DATA],
             'frame-src': [qbrickHost],
+            'connect-src': internalHosts,
         },
         { env: envMap[process.env.ENV], port: process.env.DECORATOR_LOCAL_PORT }
     );


### PR DESCRIPTION
Denne settes nå fra dekoratøren. Tidligere satte vi ikke denne i det hele tatt, så da ble default-src brukt som fallback.