### PR TITLE
Endre datovisning

### DIFF
--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -94,7 +94,7 @@ export const CallOption = (props: CallOptionProps) => {
 
         if (daysToNextOpeningHour > 1) {
             return `${opensTemplate
-                .replace('{$1}', formatDate(futureDate, language))
+                .replace('{$1}', formatDate({ datetime: futureDate, language }))
                 .replace('{$2}', futureTime)}`;
         }
         const openingTemplate =

--- a/src/components/_common/content-list/ContentList.tsx
+++ b/src/components/_common/content-list/ContentList.tsx
@@ -43,7 +43,11 @@ export const ContentList = ({
             url: getUrlFromContent(scContent),
             text: scContent.displayName,
             label: showDateLabel
-                ? formatDate({ datetime: getDate(scContent, sortedBy) })
+                ? formatDate({
+                      datetime: getDate(scContent, sortedBy),
+                      short: true,
+                      year: true,
+                  })
                 : undefined,
         }))
         .filter(({ url, text }) => url && text);

--- a/src/components/_common/content-list/ContentList.tsx
+++ b/src/components/_common/content-list/ContentList.tsx
@@ -43,7 +43,7 @@ export const ContentList = ({
             url: getUrlFromContent(scContent),
             text: scContent.displayName,
             label: showDateLabel
-                ? formatDate(getDate(scContent, sortedBy))
+                ? formatDate({ datetime: getDate(scContent, sortedBy) })
                 : undefined,
         }))
         .filter(({ url, text }) => url && text);

--- a/src/components/_common/headers/featured-header/DateLine.tsx
+++ b/src/components/_common/headers/featured-header/DateLine.tsx
@@ -18,7 +18,12 @@ export const DateLine = ({
     const getDatesLabel = translator('dates', language);
 
     const buildDateString = (desc: string, date: string) => {
-        return `${desc}: ${formatDate(date, language, true, true)}`;
+        return `${desc}: ${formatDate({
+            datetime: date,
+            language,
+            short: true,
+            year: true,
+        })}`;
     };
 
     const publishedString = buildDateString(

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -158,21 +158,13 @@ export const ThemedPageHeader = ({
                             </BodyShort>
                         )}
                         {subTitle && modified && (
-                            <span
-                                aria-hidden="true"
-                                className={classNames(
-                                    'page-modified-info',
-                                    style.divider
-                                )}
-                            >
+                            <span aria-hidden="true" className={style.divider}>
                                 {'|'}
                             </span>
                         )}
                         {modified && (
                             <Detail size="small">
-                                <span className={'page-modified-info'}>
-                                    {modified}
-                                </span>
+                                <span>{modified}</span>
                             </Detail>
                         )}
                     </div>

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -125,7 +125,12 @@ export const ThemedPageHeader = ({
         showTimeStamp &&
         getDatesLabel('lastChanged') +
             ' ' +
-            formatDate(modifiedTime, language, true, true);
+            formatDate({
+                datetime: modifiedTime,
+                language,
+                short: true,
+                year: true,
+            });
 
     // This is a temporaty fix, especially for "Arbeidsavklaringspenger".
     // Will work with design to find solution for how long titles and illustration can stack better on mobile.

--- a/src/components/_common/payout-dates/PayoutDates.tsx
+++ b/src/components/_common/payout-dates/PayoutDates.tsx
@@ -35,11 +35,11 @@ export const PayoutDates = ({ payoutDatesData, className }: Props) => {
                 {Object.entries(dates).map(([month, day]) => (
                     <tr key={month}>
                         <td>
-                            {formatDate(
-                                `${month} ${day} ${year || ''}`,
+                            {formatDate({
+                                datetime: `${month} ${day} ${year || ''}`,
                                 language,
-                                true
-                            )}
+                                short: true,
+                            })}
                         </td>
                     </tr>
                 ))}

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.module.scss
@@ -4,3 +4,7 @@
         color: var(--navds-semantic-color-text-muted);
     }
 }
+
+.divider {
+    padding: 0 0.5rem;
+}

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -40,7 +40,7 @@ const ArtikkelDato = (props: Props) => {
     )}`;
     let modifiedString = '';
     if (new Date(modifiedTime) > new Date(publishedDate)) {
-        modifiedString = ` ${modifiedLabel} ${formatDate(
+        modifiedString = `${modifiedLabel} ${formatDate(
             modifiedTime,
             language,
             hasMonthName,
@@ -56,8 +56,10 @@ const ArtikkelDato = (props: Props) => {
                 {publishedString}
                 {modifiedString && (
                     <>
-                        <span aria-hidden="true">{','}</span>
-                        {modifiedString.toLowerCase()}
+                        <span aria-hidden="true" className={styles.divider}>
+                            {'|'}
+                        </span>
+                        {modifiedString}
                     </>
                 )}
             </Detail>

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -47,33 +47,34 @@ const ArtikkelDato = (props: Props) => {
             hasYear
         )}`;
     }
+
+    const publishedAndModifiedString = (
+        <>
+            {publishedString}
+            {modifiedString && (
+                <>
+                    <span aria-hidden="true" className={styles.divider}>
+                        {'|'}
+                    </span>
+                    {modifiedString}
+                </>
+            )}
+        </>
+    );
+
     if (type === 'newsPress') {
         return (
             <Detail
                 className={classNames(styles.artikkelDato, styles.small)}
                 id="main-article-date-anchor"
             >
-                {publishedString}
-                {modifiedString && (
-                    <>
-                        <span aria-hidden="true" className={styles.divider}>
-                            {'|'}
-                        </span>
-                        {modifiedString}
-                    </>
-                )}
+                {publishedAndModifiedString}
             </Detail>
         );
     }
     return (
         <BodyLong as={'time'} dateTime={publishedDate}>
-            {publishedString}
-            {modifiedString && (
-                <>
-                    <span aria-hidden="true">{' |'}</span>
-                    {modifiedString}
-                </>
-            )}
+            {publishedAndModifiedString}
         </BodyLong>
     );
 };

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -68,27 +68,13 @@ const ArtikkelDato = (props: Props) => {
                 className={classNames(styles.artikkelDato, styles.small)}
                 id="main-article-date-anchor"
             >
-                {publishedString}
-                {modifiedString && (
-                    <>
-                        <span aria-hidden="true" className={styles.divider}>
-                            {'|'}
-                        </span>
-                        {modifiedString}
-                    </>
-                )}
+                {publishedAndModifiedString}
             </Detail>
         );
     }
     return (
         <BodyLong as={'time'} dateTime={publishedDate}>
-            {publishedString}
-            {modifiedString && (
-                <>
-                    <span aria-hidden="true">{' | '}</span>
-                    {modifiedString}
-                </>
-            )}
+            {publishedAndModifiedString}
         </BodyLong>
     );
 };

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -68,13 +68,27 @@ const ArtikkelDato = (props: Props) => {
                 className={classNames(styles.artikkelDato, styles.small)}
                 id="main-article-date-anchor"
             >
-                {publishedAndModifiedString}
+                {publishedString}
+                {modifiedString && (
+                    <>
+                        <span aria-hidden="true" className={styles.divider}>
+                            {'|'}
+                        </span>
+                        {modifiedString}
+                    </>
+                )}
             </Detail>
         );
     }
     return (
         <BodyLong as={'time'} dateTime={publishedDate}>
-            {publishedAndModifiedString}
+            {publishedString}
+            {modifiedString && (
+                <>
+                    <span aria-hidden="true">{' | '}</span>
+                    {modifiedString}
+                </>
+            )}
         </BodyLong>
     );
 };

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -48,6 +48,20 @@ const ArtikkelDato = (props: Props) => {
         })}`;
     }
 
+    const publishedAndModifiedString = (
+        <>
+            {publishedString}
+            {modifiedString && (
+                <>
+                    <span aria-hidden="true" className={styles.divider}>
+                        {'|'}
+                    </span>
+                    {modifiedString}
+                </>
+            )}
+        </>
+    );
+
     if (type === 'newsPress') {
         return (
             <Detail

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -32,20 +32,20 @@ const ArtikkelDato = (props: Props) => {
     const hasYear = type === 'newsPress';
 
     const publishedDate = publish?.first ?? createdTime;
-    const publishedString = `${publishLabel} ${formatDate(
-        publishedDate,
+    const publishedString = `${publishLabel} ${formatDate({
+        datetime: publishedDate,
         language,
-        hasMonthName,
-        hasYear
-    )}`;
+        short: hasMonthName,
+        year: hasYear,
+    })}`;
     let modifiedString = '';
     if (new Date(modifiedTime) > new Date(publishedDate)) {
-        modifiedString = `${modifiedLabel} ${formatDate(
-            modifiedTime,
+        modifiedString = `${modifiedLabel} ${formatDate({
+            datetime: modifiedTime,
             language,
-            hasMonthName,
-            hasYear
-        )}`;
+            short: hasMonthName,
+            year: hasYear,
+        })}`;
     }
 
     const publishedAndModifiedString = (

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -48,20 +48,6 @@ const ArtikkelDato = (props: Props) => {
         })}`;
     }
 
-    const publishedAndModifiedString = (
-        <>
-            {publishedString}
-            {modifiedString && (
-                <>
-                    <span aria-hidden="true" className={styles.divider}>
-                        {'|'}
-                    </span>
-                    {modifiedString}
-                </>
-            )}
-        </>
-    );
-
     if (type === 'newsPress') {
         return (
             <Detail

--- a/src/components/parts/_legacy/office-information/reception/Reception.tsx
+++ b/src/components/parts/_legacy/office-information/reception/Reception.tsx
@@ -54,7 +54,7 @@ const formatAudienceReception = (
         (acc, elem) => {
             if (elem.dato) {
                 const isoDate = elem.dato;
-                const dato = formatDate(elem.dato, language);
+                const dato = formatDate({ datetime: elem.dato, language });
 
                 acc.exceptions.push({
                     ...elem,

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
@@ -41,7 +41,12 @@ export const FrontpageCurrentTopics = ({
                             className={style.item}
                         >
                             <span className={style.date}>
-                                {formatDate(item.modifiedTime, language)}
+                                {formatDate({
+                                    datetime: item.modifiedTime,
+                                    language: language,
+                                    short: true,
+                                    year: true,
+                                })}
                             </span>
                         </LinkPanelNavno>
                     </li>

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -18,12 +18,19 @@ export const days = [
     'saturday',
 ];
 
-export const formatDate = (
-    datetime: string,
-    language: string = 'nb',
+interface FormatDateProps {
+    datetime: string;
+    language?: string;
+    short?: boolean;
+    year?: boolean;
+}
+
+export const formatDate = ({
+    datetime,
+    language = 'nb',
     short = false,
-    year = false
-) => {
+    year = false,
+}: FormatDateProps) => {
     const currentLocale = language === 'en' ? 'en-gb' : 'nb';
 
     let format: string;


### PR DESCRIPTION
- Bytter ut  "16.11.2022" med "16. november 2022" på Aktuelt på forsiden og på pressesiden
- Bytter ut komma med | på nye presse og nyhetsmaler 
- Bruker named arguments på formatDate for å gjøre den mer lesbar