### PR TITLE
PublishingCalendarEntry som egen komponent som kan sidevises alene

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -22,6 +22,7 @@ import { MainArticleChapterPage } from './pages/main-article-chapter-page/MainAr
 import { PayoutDatesPage } from './pages/payout-dates-page/PayoutDatesPage';
 import { GenericPage } from './pages/generic-page/GenericPage';
 import { CurrentTopicPage } from './pages/current-topic-page/CurrentTopicPage';
+import PublishingCalendarEntryPage from './parts/_legacy/publishing-calendar/PublishingCalendarEntryPage';
 
 const contentToReactComponent: Partial<{
     [key in ContentType]: React.FunctionComponent<ContentProps>;
@@ -57,7 +58,7 @@ const contentToReactComponent: Partial<{
     [ContentType.SectionPage]: DynamicPage,
     [ContentType.TransportPage]: DynamicPage,
     [ContentType.PublishingCalendar]: DynamicPage,
-    [ContentType.PublishingCalendarEntry]: DynamicPage,
+    [ContentType.PublishingCalendarEntry]: PublishingCalendarEntryPage,
     [ContentType.Melding]: DynamicPage,
 
     [ContentType.ExternalLink]: RedirectPage,

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -57,6 +57,7 @@ const contentToReactComponent: Partial<{
     [ContentType.SectionPage]: DynamicPage,
     [ContentType.TransportPage]: DynamicPage,
     [ContentType.PublishingCalendar]: DynamicPage,
+    [ContentType.PublishingCalendarEntry]: DynamicPage,
     [ContentType.Melding]: DynamicPage,
 
     [ContentType.ExternalLink]: RedirectPage,

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -29,8 +29,8 @@ export const checkForWhiteHeader = (content: ContentProps) => {
 
     if (
         __typename === ContentType.MainArticle &&
-        (content.data.contentType === 'news' ||
-            content.data.contentType === 'pressRelease')
+        (content.data?.contentType === 'news' ||
+            content.data?.contentType === 'pressRelease')
     ) {
         return true;
     }

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -25,6 +25,7 @@ import { HeaderPart } from './header/HeaderPart';
 import { LinkListPart } from './link-list/LinkListPart';
 import { NewsListPart } from './news-list/NewsListPart';
 import PublishingCalendar from './_legacy/publishing-calendar/PublishingCalendar';
+import PublishingCalendarEntry from './_legacy/publishing-calendar/PublishingCalendarEntry';
 import { BEM, classNames } from '../../utils/classnames';
 import { HtmlArea } from './html-area/HtmlArea';
 import { CalculatorPart } from './calculator/Calculator';
@@ -65,6 +66,7 @@ const partsWithPageData: {
     [PartType.PageHeading]: PageHeading,
     [PartType.PageList]: PageList,
     [PartType.PublishingCalendar]: PublishingCalendar,
+    [PartType.PublishingCalendarEntry]: PublishingCalendarEntry,
 };
 
 const partsWithOwnData: {

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -3,7 +3,7 @@ import { Heading, Ingress } from '@navikt/ds-react';
 import { translator } from '../../../../translations';
 import { PublishingCalendarProps } from '../../../../types/content-props/publishing-calendar-props';
 import PublishingCalendarEntry, { sortEntries } from './PublishingCalendarEntry';
-import { Table } from '../../../_common/table/Table';
+import { Table } from 'components/_common/table/Table';
 
 import style from './PublishingCalendar.module.scss';
 

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -1,52 +1,15 @@
 import * as React from 'react';
-import { Heading, BodyLong, Ingress } from '@navikt/ds-react';
+import { Heading, Ingress } from '@navikt/ds-react';
 import { translator } from '../../../../translations';
-import {
-    PublishingCalendarChildren,
-    PublishingCalendarEntries,
-    PublishingCalendarProps,
-} from '../../../../types/content-props/publishing-calendar-props';
+import { PublishingCalendarProps } from '../../../../types/content-props/publishing-calendar-props';
+import PublishingCalendarEntry, { sortEntries } from './PublishingCalendarEntry';
 import { Table } from '../../../_common/table/Table';
 
 import style from './PublishingCalendar.module.scss';
 
-const monthShortName = [
-    'JAN',
-    'FEB',
-    'MAR',
-    'APR',
-    'MAI',
-    'JUN',
-    'JUL',
-    'AUG',
-    'SEP',
-    'OKT',
-    'NOV',
-    'DES',
-];
-
-const processEntries = (
-    children: PublishingCalendarChildren[]
-): PublishingCalendarEntries[] => {
-    return (
-        children
-            ?.map((item) => {
-                const publDate = new Date(item.data.date);
-                return {
-                    displayName: item.displayName,
-                    period: item.data.period,
-                    publDate,
-                    day: publDate.getDate().toString() + '.',
-                    month: monthShortName[publDate.getMonth()],
-                };
-            })
-            .sort((a, b) => a.publDate.getTime() - b.publDate.getTime()) || []
-    ); // Dato for publisering: stigende
-};
-
 const PublishingCalendar = (props: PublishingCalendarProps) => {
     const getLabel = translator('publishingCalendar', props.language);
-    const items = processEntries(props.children);
+    const items = sortEntries(props.children);
 
     return (
         <div className={style.publishingCalendar}>
@@ -68,27 +31,13 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {items.map((item, index) => {
-                        return (
-                            <tr key={`${item.displayName}_${index}`}>
-                                <td>
-                                    <time>
-                                        <span>{item.day}</span>
-                                        <span>{item.month}</span>
-                                    </time>
-                                </td>
-                                <td>
-                                    <BodyLong className={style.dateInfo}>
-                                        {item.period}
-                                    </BodyLong>
-                                    <BodyLong>{item.displayName}</BodyLong>
-                                </td>
-                            </tr>
-                        );
-                    })}
+                    {items.map((item, index) =>
+                        <PublishingCalendarEntry key={index} {...item} />
+                    )}
                 </tbody>
             </Table>
         </div>
     );
 };
+
 export default PublishingCalendar;

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Heading, Ingress } from '@navikt/ds-react';
+import { Heading, Ingress, Table } from '@navikt/ds-react';
 import { translator } from '../../../../translations';
 import { PublishingCalendarProps } from '../../../../types/content-props/publishing-calendar-props';
 import PublishingCalendarEntry, { sortEntries } from './PublishingCalendarEntry';
-import { Table } from 'components/_common/table/Table';
 
 import style from './PublishingCalendar.module.scss';
 
@@ -23,18 +22,18 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
                     </Ingress>
                 )}
             </header>
-            <Table>
-                <thead>
-                    <tr>
-                        <th scope="col">{getLabel('publishdate')}</th>
-                        <th scope="col">{getLabel('event')}</th>
-                    </tr>
-                </thead>
-                <tbody>
+            <Table zebraStripes>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">{getLabel('publishdate')}</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">{getLabel('event')}</Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
                     {items.map((item, index) =>
                         <PublishingCalendarEntry key={index} {...item} />
                     )}
-                </tbody>
+                </Table.Body>
             </Table>
         </div>
     );

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BodyLong } from '@navikt/ds-react';
-import { PublishingCalendarEntryProps } from '../../../../types/content-props/publishing-calendar-props';
+import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
 
 import style from './PublishingCalendar.module.scss';
 
@@ -26,9 +26,7 @@ const monthShortName = [
     'DES',
 ];
 
-export const sortEntries = (
-    children: PublishingCalendarEntryProps[]
-): PublishingCalendarEntryProps[] => {
+export const sortEntries = (children: PublishingCalendarEntryProps[]): PublishingCalendarEntryProps[] => {
     return (
         children.sort((a, b) => {
             const aDate = new Date(a.data.date);
@@ -38,9 +36,7 @@ export const sortEntries = (
     ); // Dato for publisering: stigende
 };
 
-const processEntry = (
-    item: PublishingCalendarEntryProps
-): PublishingCalendarEntryData => {
+const processEntry = (item: PublishingCalendarEntryProps): PublishingCalendarEntryData => {
     const publDate = new Date(item.data.date);
     return {
         displayName: item.displayName,
@@ -65,7 +61,9 @@ const PublishingCalendarEntry = (props: PublishingCalendarEntryProps) => {
                 <BodyLong className={style.dateInfo}>
                     {entry.period}
                 </BodyLong>
-                <BodyLong>{entry.displayName}</BodyLong>
+                <BodyLong>
+                    {entry.displayName}
+                </BodyLong>
             </td>
         </tr>
     );

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { BodyLong } from '@navikt/ds-react';
+import { PublishingCalendarEntryProps } from '../../../../types/content-props/publishing-calendar-props';
+
+import style from './PublishingCalendar.module.scss';
+
+interface PublishingCalendarEntryData {
+    displayName: string;
+    period: string;
+    publDate: Date;
+    day: string;
+    month: string;
+}
+const monthShortName = [
+    'JAN',
+    'FEB',
+    'MAR',
+    'APR',
+    'MAI',
+    'JUN',
+    'JUL',
+    'AUG',
+    'SEP',
+    'OKT',
+    'NOV',
+    'DES',
+];
+
+export const sortEntries = (
+    children: PublishingCalendarEntryProps[]
+): PublishingCalendarEntryProps[] => {
+    return (
+        children.sort((a, b) => {
+            const aDate = new Date(a.data.date);
+            const bDate = new Date(b.data.date);
+            return aDate.getTime() - bDate.getTime()
+        })
+    ); // Dato for publisering: stigende
+};
+
+const processEntry = (
+    item: PublishingCalendarEntryProps
+): PublishingCalendarEntryData => {
+    const publDate = new Date(item.data.date);
+    return {
+        displayName: item.displayName,
+        period: item.data.period,
+        publDate,
+        day: publDate.getDate().toString() + '.',
+        month: monthShortName[publDate.getMonth()],
+    };
+};
+
+const PublishingCalendarEntry = (props: PublishingCalendarEntryProps) => {
+    const entry = processEntry(props);
+    return (
+        <tr key={`${entry.displayName}`}>
+            <td>
+                <time>
+                    <span>{entry.day}</span>
+                    <span>{entry.month}</span>
+                </time>
+            </td>
+            <td>
+                <BodyLong className={style.dateInfo}>
+                    {entry.period}
+                </BodyLong>
+                <BodyLong>{entry.displayName}</BodyLong>
+            </td>
+        </tr>
+    );
+};
+
+export default PublishingCalendarEntry;

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BodyLong } from '@navikt/ds-react';
+import { Table, BodyLong } from '@navikt/ds-react';
 import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
 
 import style from './PublishingCalendar.module.scss';
@@ -50,22 +50,22 @@ const processEntry = (item: PublishingCalendarEntryProps): PublishingCalendarEnt
 const PublishingCalendarEntry = (props: PublishingCalendarEntryProps) => {
     const entry = processEntry(props);
     return (
-        <tr key={`${entry.displayName}`}>
-            <td>
+        <Table.Row>
+            <Table.DataCell>
                 <time>
                     <span>{entry.day}</span>
                     <span>{entry.month}</span>
                 </time>
-            </td>
-            <td>
+            </Table.DataCell>
+            <Table.DataCell>
                 <BodyLong className={style.dateInfo}>
                     {entry.period}
                 </BodyLong>
                 <BodyLong>
                     {entry.displayName}
                 </BodyLong>
-            </td>
-        </tr>
+            </Table.DataCell>
+        </Table.Row>
     );
 };
 

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
+import PublishingCalendarEntry from './PublishingCalendarEntry';
+import { Table } from 'components/_common/table/Table';
+
+import style from './PublishingCalendar.module.scss';
+
+// For preview only
+const PublishingCalendarEntryPage = (props: PublishingCalendarEntryProps) => {
+    return (
+        <div className={'content'}>
+            <div className={style.publishingCalendar}>
+                <Table>
+                    <tbody>
+                        <PublishingCalendarEntry {...props} />
+                    </tbody>
+                </Table>
+            </div>
+        </div>
+    );
+};
+export default PublishingCalendarEntryPage;

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
+import { classNames } from 'utils/classnames';
 import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
 import PublishingCalendarEntry from './PublishingCalendarEntry';
-import { Table } from 'components/_common/table/Table';
+import { Table } from '@navikt/ds-react';
 
 import style from './PublishingCalendar.module.scss';
 
-// For preview only
+// For preview only - hacks layout from PublishingCalendar
 const PublishingCalendarEntryPage = (props: PublishingCalendarEntryProps) => {
     return (
-        <div className={'content'}>
-            <div className={style.publishingCalendar}>
-                <Table>
-                    <tbody>
-                        <PublishingCalendarEntry {...props} />
-                    </tbody>
-                </Table>
+        <div className = {classNames('layout', 'layout__main')}>
+            <div className={classNames('region', 'region region__first')}>
+                <div className={style.publishingCalendar}>
+                    <Table>
+                        <Table.Body>
+                            <PublishingCalendarEntry {...props} />
+                        </Table.Body>
+                    </Table>
+                </div>
+            </div>
+            <div className={classNames('region', 'region region__second')}>
             </div>
         </div>
     );

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { classNames } from 'utils/classnames';
+import ErrorPage404 from 'pages/404';
 import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
 import PublishingCalendarEntry from './PublishingCalendarEntry';
 import { Table } from '@navikt/ds-react';
@@ -8,6 +9,10 @@ import style from './PublishingCalendar.module.scss';
 
 // For preview only - hacks layout from PublishingCalendar
 const PublishingCalendarEntryPage = (props: PublishingCalendarEntryProps) => {
+    if (!props.editorView) {
+        return <ErrorPage404 />;
+    }
+
     return (
         <div className = {classNames('layout', 'layout__main')}>
             <div className={classNames('region', 'region region__first')}>

--- a/src/types/component-props/parts.ts
+++ b/src/types/component-props/parts.ts
@@ -13,6 +13,7 @@ export enum PartType {
     OfficeInformation = 'no.nav.navno:office-information',
     PageList = 'no.nav.navno:page-list',
     PublishingCalendar = 'no.nav.navno:publishing-calendar',
+    PublishingCalendarEntry = 'no.nav.navno:publishing-calendar-entry',
 
     AreaCard = 'no.nav.navno:area-card',
     AlertPanel = 'no.nav.navno:alert-panel',
@@ -56,7 +57,8 @@ export type PartWithPageData =
     | PartType.MenuList
     | PartType.OfficeInformation
     | PartType.PageList
-    | PartType.PublishingCalendar;
+    | PartType.PublishingCalendar
+    | PartType.PublishingCalendarEntry;
 
 export type PartWithOwnData =
     | PartType.LinkPanel

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -24,7 +24,7 @@ import {
     ThemedArticlePageProps,
     ToolsPageProps,
 } from './dynamic-page-props';
-import { PublishingCalendarProps } from './publishing-calendar-props';
+import { PublishingCalendarProps, PublishingCalendarEntryProps } from './publishing-calendar-props';
 import { Params as DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
 import { AnimatedIconsProps } from './animated-icons';
 import {
@@ -60,6 +60,7 @@ export enum ContentType {
     LargeTable = 'no_nav_navno_LargeTable',
     OfficeInformation = 'no_nav_navno_OfficeInformation',
     PublishingCalendar = 'no_nav_navno_PublishingCalendar',
+    PublishingCalendarEntry = 'no_nav_navno_PublishingCalendarEntry',
     GlobalNumberValuesSet = 'no_nav_navno_GlobalValueSet',
     ProductPage = 'no_nav_navno_ContentPageWithSidemenus',
     ProductDetails = 'no_nav_navno_ProductDetails',
@@ -148,6 +149,7 @@ type SpecificContentProps =
     | SectionPageProps
     | TransportPageProps
     | PublishingCalendarProps
+    | PublishingCalendarEntryProps
     | ProductPageProps
     | SituationPageProps
     | AnimatedIconsProps

--- a/src/types/content-props/publishing-calendar-props.ts
+++ b/src/types/content-props/publishing-calendar-props.ts
@@ -2,6 +2,7 @@ import { ContentType, ContentCommonProps } from './_content-common';
 
 export type PublishingCalendarEntryProps
     = ContentCommonProps & {
+    __typename: ContentType.PublishingCalendarEntry;
     displayName: string;
     data: {
         date: string;

--- a/src/types/content-props/publishing-calendar-props.ts
+++ b/src/types/content-props/publishing-calendar-props.ts
@@ -1,6 +1,7 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
-export type PublishingCalendarChildren = ContentCommonProps & {
+export type PublishingCalendarEntryProps
+    = ContentCommonProps & {
     displayName: string;
     data: {
         date: string;
@@ -12,16 +13,8 @@ export type PublishingCalendarData = Partial<{
     ingress: string;
 }>;
 
-export interface PublishingCalendarEntries {
-    displayName: string;
-    period: string;
-    publDate: Date;
-    day: string;
-    month: string;
-}
-
 export interface PublishingCalendarProps extends ContentCommonProps {
     __typename: ContentType.PublishingCalendar;
-    children: PublishingCalendarChildren[];
+    children: PublishingCalendarEntryProps[];
     data: PublishingCalendarData;
 }


### PR DESCRIPTION
Sørger for forhåndsvisning av kalenderhenselser i Content Studio