### PR TITLE
AVVENTER BESKJED - PÅ HOLD: Fjerner midlertidig nede-melding for chatbot

### DIFF
--- a/src/components/_common/chatbot/ChatbotLinkPanel.module.scss
+++ b/src/components/_common/chatbot/ChatbotLinkPanel.module.scss
@@ -23,7 +23,3 @@ $chatPointerSize: 1.5rem;
         display: block;
     }
 }
-
-.alert {
-    margin-bottom: 0.5rem;
-}

--- a/src/components/_common/chatbot/ChatbotLinkPanel.tsx
+++ b/src/components/_common/chatbot/ChatbotLinkPanel.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import { translator } from 'translations';
 import { LinkPanelNavno } from '../linkpanel/LinkPanelNavno';
 import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 
 import style from './ChatbotLinkPanel.module.scss';
-import { usePageConfig } from 'store/hooks/usePageConfig';
-import { Alert } from '@navikt/ds-react';
 
 type Props = { analyticsGroup: string; linkText: string; ingress: string };
 
@@ -14,8 +11,6 @@ export const ChatbotLinkPanel = ({
     linkText,
     ingress,
 }: Props) => {
-    const { language } = usePageConfig();
-    const getTranslations = translator('contactPoint', language);
     return (
         <LinkPanelNavno
             className={style.chat}
@@ -27,9 +22,6 @@ export const ChatbotLinkPanel = ({
                 openChatbot();
             }}
         >
-            <Alert variant="warning" inline className={style.alert}>
-                {getTranslations('chat').downAlert}
-            </Alert>
             {ingress}
         </LinkPanelNavno>
     );

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+import { BodyLong, Heading } from '@navikt/ds-react';
 import {
     ChannelType,
     DefaultContactData,
@@ -118,11 +118,6 @@ export const DefaultOption = (props: DefaultContactProps) => {
                     </Heading>
                 </div>
             </LenkeBase>
-            {channel === 'chat' && (
-                <Alert variant="warning" inline className={style.alert}>
-                    {getTranslations('chat').downAlert}
-                </Alert>
-            )}
             <BodyLong className={style.text}>{getIngress()}</BodyLong>
         </div>
     );


### PR DESCRIPTION
Fjerner midlertidig varsel om chatbot igjen. Denne var lagt på som en hardkodet nødløsning. Etter nyttår skal vi få på plass en bedre løsning for chatbot-innganger.