### PR TITLE
Fjerner ubrukte metadata-elementer for åpningstider på kontorsider

### DIFF
--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Reception from './reception/Reception';
+import { Reception } from './reception/Reception';
 import { SpecialInformation } from './SpecialInfo';
 import {
     formatAddress,
@@ -14,12 +14,12 @@ import { Heading, BodyLong, BodyShort } from '@navikt/ds-react';
 import {
     AudienceReception,
     OfficeInformationProps,
-} from '../../../../types/content-props/office-information-props';
-import { getInternalAbsoluteUrl } from '../../../../utils/urls';
+} from 'types/content-props/office-information-props';
+import { getInternalAbsoluteUrl } from 'utils/urls';
 import {
     GovernmentOfficeSchema,
     SpecialAnnouncementSchema,
-} from '../../../../types/structuredData';
+} from 'types/structuredData';
 import { LenkeInline } from '../../../_common/lenke/LenkeInline';
 
 import style from './OfficeInformation.module.scss';

--- a/src/components/parts/_legacy/office-information/reception/OpeningHours.tsx
+++ b/src/components/parts/_legacy/office-information/reception/OpeningHours.tsx
@@ -1,35 +1,6 @@
-import { OpeningHoursProps } from '../../../../../types/content-props/office-information-props';
 import React from 'react';
-import { Table } from '../../../../_common/table/Table';
-
-export const MetaOpeningHours = (props: {
-    openingHours: OpeningHoursProps[];
-    metaKey: string;
-}) => {
-    return (
-        <ul className="hidden">
-            {props.openingHours.map((opening, ix) => {
-                const compKey = `${props.metaKey}-${ix}`;
-                return (
-                    <li key={compKey}>
-                        <time dateTime={opening.isoDate}>{opening.dato}</time>
-                        <time dateTime={opening.isoDate}>{opening.dato}</time>
-                        {!opening.stengt && (
-                            <>
-                                <time dateTime={opening.fra}>
-                                    {opening.fra}
-                                </time>
-                                <time dateTime={opening.til}>
-                                    {opening.til}
-                                </time>
-                            </>
-                        )}
-                    </li>
-                );
-            })}
-        </ul>
-    );
-};
+import { OpeningHoursProps } from 'types/content-props/office-information-props';
+import { Table } from 'components/_common/table/Table';
 
 export const OpeningHours = (props: {
     openingHours: OpeningHoursProps[];

--- a/src/components/parts/_legacy/office-information/reception/Reception.tsx
+++ b/src/components/parts/_legacy/office-information/reception/Reception.tsx
@@ -5,9 +5,9 @@ import { translator, Language } from 'translations';
 import {
     AudienceReception,
     OpeningHoursProps,
-} from '../../../../../types/content-props/office-information-props';
+} from 'types/content-props/office-information-props';
 import { Heading, BodyShort } from '@navikt/ds-react';
-import { MetaOpeningHours, OpeningHours } from './OpeningHours';
+import { OpeningHours } from './OpeningHours';
 
 import style from './Reception.module.scss';
 
@@ -21,18 +21,6 @@ interface FormattedAudienceReception {
     openingHoursExceptions: FormattedOpeningHours[];
     openingHours: FormattedOpeningHours[];
 }
-
-const formatMetaOpeningHours = (el: OpeningHoursProps) => {
-    const days: { [key: string]: string } = {
-        Mandag: 'Mo',
-        Tirsdag: 'Tu',
-        Onsdag: 'We',
-        Torsdag: 'Th',
-        Fredag: 'Fr',
-    };
-    const day = days[el.dag];
-    return `${day} ${el.fra}-${el.til}`;
-};
 
 const sortOpeningHours = (a: OpeningHoursProps, b: OpeningHoursProps) => {
     const dagArr: string[] = [
@@ -62,10 +50,7 @@ const formatAudienceReception = (
                     dato,
                 });
             } else {
-                acc.regular.push({
-                    ...elem,
-                    meta: formatMetaOpeningHours(elem),
-                });
+                acc.regular.push(elem);
             }
             return acc;
         },
@@ -92,7 +77,7 @@ interface Props {
     language: Language;
 }
 
-const Reception = (props: Props) => {
+export const Reception = (props: Props) => {
     if (!props.receptions) {
         return null;
     }
@@ -119,12 +104,6 @@ const Reception = (props: Props) => {
                                 <Heading level="4" size="small">
                                     Spesielle åpningstider
                                 </Heading>
-                                <MetaOpeningHours
-                                    openingHours={
-                                        reception.openingHoursExceptions
-                                    }
-                                    metaKey="meta-exceptions"
-                                />
                                 <OpeningHours
                                     openingHours={
                                         reception.openingHoursExceptions
@@ -154,5 +133,3 @@ const Reception = (props: Props) => {
         </div>
     );
 };
-
-export default Reception;


### PR DESCRIPTION
Kan ikke se at disse brukes til noe. De vises til bruker i prod nå pga manglende global .hidden klasse.