### PR TITLE
Sorterer nyheter på landingsside etter nyeste først

### DIFF
--- a/src/components/_common/press-landing/PressNews.tsx
+++ b/src/components/_common/press-landing/PressNews.tsx
@@ -24,10 +24,11 @@ export const PressNews = (props: PressNewsProps) => {
         return null;
     }
 
-    const pressNewsItems = pressNews.data.sectionContents.slice(
-        0,
-        parseInt(maxNewsCount, 10) || 5
-    );
+    const pressNewsItems = pressNews.data.sectionContents
+        .sort((a: MainArticleProps, b: MainArticleProps) =>
+            a.createdTime < b.createdTime ? 1 : -1
+        )
+        .slice(0, parseInt(maxNewsCount, 10) || 5);
 
     return (
         <div className={styles.pressNews}>


### PR DESCRIPTION
Sorterer nyheter på landingsside for presse uavhengig av rekkefølgen som er satt i Content Studio