### PR TITLE
Sorterer nyheter etter publisering

### DIFF
--- a/src/components/_common/press-landing/PressNews.tsx
+++ b/src/components/_common/press-landing/PressNews.tsx
@@ -25,9 +25,13 @@ export const PressNews = (props: PressNewsProps) => {
     }
 
     const pressNewsItems = pressNews.data.sectionContents
-        .sort((a: MainArticleProps, b: MainArticleProps) =>
-            a.createdTime < b.createdTime ? 1 : -1
-        )
+        .sort((a: MainArticleProps, b: MainArticleProps) => {
+            if (!a?.publish?.first || !b?.publish?.first) {
+                return 0;
+            }
+
+            return a.publish.first < b.publish.first ? 1 : -1;
+        })
         .slice(0, parseInt(maxNewsCount, 10) || 5);
 
     return (

--- a/src/components/_common/press-landing/PressNewsItem.tsx
+++ b/src/components/_common/press-landing/PressNewsItem.tsx
@@ -50,7 +50,7 @@ export const PressNewsItem = ({ newsItem }: PressNewsItemProps) => {
                 <Detail className={styles.publishDate}>
                     {getTranslations('published')}{' '}
                     {formatDate({
-                        datetime: newsItem.createdTime,
+                        datetime: newsItem.publish.first,
                         language,
                         short: true,
                         year: true,


### PR DESCRIPTION
Sorterer nyheter etter publish.first. Denne brukes for å vise publiseringsdato i artikkel også.