### PR TITLE
Ekspanderer panel ved hashchange i klienten

### DIFF
--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -33,6 +33,17 @@ export const Expandable = ({
         setIsOpen(!isOpen);
     };
 
+    const checkForOpen = () => {
+        if (anchorId && window.location.hash === `#${anchorId}`) {
+            console.log('setting open');
+            setIsOpen(true);
+        }
+    };
+
+    const hashChangeHandler = () => {
+        checkForOpen();
+    };
+
     useEffect(() => {
         const openOnBrowserSearch = (e: KeyboardEvent) => {
             if (e.ctrlKey && e.code === 'KeyF') {
@@ -41,13 +52,16 @@ export const Expandable = ({
         };
 
         window.addEventListener('keydown', openOnBrowserSearch);
-        return () => window.removeEventListener('keydown', openOnBrowserSearch);
+        window.addEventListener('hashchange', hashChangeHandler);
+
+        return () => {
+            window.removeEventListener('keydown', openOnBrowserSearch);
+            window.removeEventListener('hashchange', hashChangeHandler);
+        };
     }, []);
 
     useEffect(() => {
-        if (anchorId && window.location.hash === `#${anchorId}`) {
-            setIsOpen(true);
-        }
+        checkForOpen();
     }, [anchorId]);
 
     return (

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -35,7 +35,6 @@ export const Expandable = ({
 
     const checkAndOpenPanel = () => {
         if (anchorId && window.location.hash === `#${anchorId}`) {
-            console.log('setting open');
             setIsOpen(true);
         }
     };

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -33,7 +33,7 @@ export const Expandable = ({
         setIsOpen(!isOpen);
     };
 
-    const checkForOpen = () => {
+    const checkAndOpenPanel = () => {
         if (anchorId && window.location.hash === `#${anchorId}`) {
             console.log('setting open');
             setIsOpen(true);
@@ -41,7 +41,7 @@ export const Expandable = ({
     };
 
     const hashChangeHandler = () => {
-        checkForOpen();
+        checkAndOpenPanel();
     };
 
     useEffect(() => {
@@ -61,7 +61,7 @@ export const Expandable = ({
     }, []);
 
     useEffect(() => {
-        checkForOpen();
+        checkAndOpenPanel();
     }, [anchorId]);
 
     return (


### PR DESCRIPTION
Ved intern navigasjon og direktelenking innenfor samme produktside ekspanderes ikke panel med tilhørende anchorId. Denne fiksen setter opp Expandable til å lytte på hashchange.