### PR TITLE
Avstander i formattert innhold

### DIFF
--- a/src/components/_common/filter-bar/FilterBar.module.scss
+++ b/src/components/_common/filter-bar/FilterBar.module.scss
@@ -6,7 +6,7 @@
 }
 
 .header {
-    margin-bottom: 0.5rem !important; // Would otherwise be override
+    margin-bottom: 0.5rem;
 }
 
 .container {

--- a/src/components/parts/html-area/HtmlArea.module.scss
+++ b/src/components/parts/html-area/HtmlArea.module.scss
@@ -37,10 +37,6 @@
         }
     }
 
-    h3 {
-        margin-top: 2.75rem;
-    }
-
     // pull lists upward to text above if any.
     :global(.navds-body-long + ul),
     :global(.navds-body-long + ol) {


### PR DESCRIPTION
Foreslår å fjerne generell margin-top for H3 i html-area. Fører til for mye avstand når det kombineres med margin-bottom for body-long fra Designsystemet. Kan ses på https://www.nav.no/overgangsstonad-enslig#aktivitet