### PR TITLE
Oppdaterer direktelenker til forskjellige kontaktoss-sider.

### DIFF
--- a/src/components/_common/contact-details/TelephoneDetails.tsx
+++ b/src/components/_common/contact-details/TelephoneDetails.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { CallOption } from '../contact-option/CallOption';
 import { TelephoneData } from 'types/component-props/parts/contact-option';
-import { Audience } from 'types/component-props/_mixins';
 
 export const TelephoneDetails = (props: TelephoneData) => {
     const {

--- a/src/components/_common/contact-details/TelephoneDetails.tsx
+++ b/src/components/_common/contact-details/TelephoneDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { CallOption } from '../contact-option/CallOption';
 import { TelephoneData } from 'types/component-props/parts/contact-option';
+import { Audience } from 'types/component-props/_mixins';
 
 export const TelephoneDetails = (props: TelephoneData) => {
     const {
@@ -14,7 +15,7 @@ export const TelephoneDetails = (props: TelephoneData) => {
     } = props;
 
     return (
-        <CallOption 
+        <CallOption
             title={title}
             alertText={alertText}
             ingress={text}

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -122,6 +122,9 @@ export const CallOption = (props: CallOptionProps) => {
 
     const getContactUrl = () => {
         const audienceUrls = contactURLs[audience];
+        if (!audienceUrls) {
+            return contactURLs.person.no;
+        }
         return language === 'no' || language === 'se'
             ? audienceUrls.no
             : audienceUrls.en;

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -24,13 +24,27 @@ import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import { useClientSide } from 'utils/useIsClientSide';
 
 import style from './ContactOption.module.scss';
+import { Audience } from 'types/component-props/_mixins';
 
-const contactUrlNO = '/person/kontakt-oss/nb#ring-oss';
-const contactUrlEN = '/person/kontakt-oss/en#ring-oss';
+const contactURLs = {
+    person: {
+        no: '/kontaktoss#ring-oss',
+        en: '/kontaktoss/en#call-us',
+    },
+    employer: {
+        no: '/arbeidsgiver/kontaktoss',
+        en: '/kontaktoss/en#call-us',
+    },
+    provider: {
+        no: '/kontaktoss#ring-oss',
+        en: '/kontaktoss/en#call-us',
+    },
+};
 
 interface CallOptionProps extends TelephoneData {
     _path?: string;
     ingress: string;
+    audience: Audience;
 }
 
 export const CallOption = (props: CallOptionProps) => {
@@ -42,6 +56,7 @@ export const CallOption = (props: CallOptionProps) => {
         regularOpeningHours,
         specialOpeningHours,
         text,
+        audience,
     } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
@@ -103,6 +118,13 @@ export const CallOption = (props: CallOptionProps) => {
         return opensTemplate
             .replace('{$1}', openingTemplate)
             .replace('{$2}', futureTime);
+    };
+
+    const getContactUrl = () => {
+        const audienceUrls = contactURLs[audience];
+        return language === 'no' || language === 'se'
+            ? audienceUrls.no
+            : audienceUrls.en;
     };
 
     const buildOpenInformationText = (openingHour: OpeningHour) => {
@@ -197,7 +219,7 @@ export const CallOption = (props: CallOptionProps) => {
             <LenkeBase
                 analyticsLinkGroup={layoutConfig.title}
                 className={style.moreLink}
-                href={language === 'no' ? contactUrlNO : contactUrlEN}
+                href={getContactUrl()}
             >
                 {sharedTranslations['seeMoreOptions']}
             </LenkeBase>

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -44,7 +44,7 @@ const contactURLs = {
 interface CallOptionProps extends TelephoneData {
     _path?: string;
     ingress: string;
-    audience: Audience;
+    audience?: Audience;
 }
 
 export const CallOption = (props: CallOptionProps) => {
@@ -56,7 +56,7 @@ export const CallOption = (props: CallOptionProps) => {
         regularOpeningHours,
         specialOpeningHours,
         text,
-        audience,
+        audience = Audience.PERSON,
     } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();

--- a/src/components/pages/contact-information-page/ContactInformationPage.tsx
+++ b/src/components/pages/contact-information-page/ContactInformationPage.tsx
@@ -6,7 +6,6 @@ import ErrorPage404 from 'pages/404';
 import { CallOption } from 'components/_common/contact-option/CallOption';
 import { WriteOption } from 'components/_common/contact-option/WriteOption';
 import { ChatOption } from 'components/_common/contact-option/ChatOption';
-import { DefaultOption } from 'components/_common/contact-option/DefaultOption';
 
 import style from './ContactInformationPage.module.scss';
 

--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -25,10 +25,14 @@ const getContactOptionComponent = (channel: string) => {
     return options || DefaultOption;
 };
 
-export const ContactOptionPart = ({ config }: ContactOptionProps) => {
+export const ContactOptionPart = ({
+    config,
+    pageProps,
+}: ContactOptionProps) => {
     const channel = config?.contactOptions?._selected;
     const { pageConfig } = usePageConfig();
     const { editorView } = pageConfig;
+    const { audience } = pageProps.data;
 
     if (!channel) {
         return <EditorHelp text={'Velg kontaktkanal fra listen til høyre'} />;
@@ -69,6 +73,7 @@ export const ContactOptionPart = ({ config }: ContactOptionProps) => {
             <OptionComponent
                 {...getSharedContactInformation(channel)}
                 _path={sharedContactInformation._path}
+                audience={audience}
                 {...overrideIngress}
             />
         );

--- a/src/types/component-props/parts/contact-option.ts
+++ b/src/types/component-props/parts/contact-option.ts
@@ -1,6 +1,6 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
-import { RenderOnAuthStateMixin } from '../_mixins';
+import { Audience, RenderOnAuthStateMixin } from '../_mixins';
 import { OptionSetSingle } from '../../util-types';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 
@@ -56,6 +56,7 @@ export interface TelephoneData {
         validTo: string;
         hours: OpeningHour[];
     };
+    audience?: Audience;
 }
 export interface WriteData extends DefaultContactData {
     alertText?: string;


### PR DESCRIPTION
Oppdaterer lenker til riktige kontaktoss-sider der det finnes for det aktuelle språket.

På sikt bør vi kanskje få til en bedre måte og unngå hardkoding av lenker, men for å få dette ut, så foreslår jeg å gjøre det på denne måten som første steg.