### PR TITLE
Fikser feil i oversettelse for åpningstid på engelsk

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -115,7 +115,7 @@ export const translationsBundleEn: Translations = {
         ],
         relatives: {
             today: 'today',
-            tomorrow: 'i morgen',
+            tomorrow: 'tomorrow',
         },
         day: 'day',
         date: 'date',


### PR DESCRIPTION
Ørliten skrivefeil på betegnelse av relasjon til åpningstid. Deployer uten code review.