### PR TITLE
Fikser bug der IllustrationStatic får elementer med undefined src url

### DIFF
--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -25,7 +25,7 @@ const StaticIcon = ({
     icon,
     isEditorView,
 }: {
-    icon: string;
+    icon: AnimatedIcon;
     isEditorView: boolean;
 }) => (
     <span

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -25,7 +25,7 @@ const StaticIcon = ({
     icon,
     isEditorView,
 }: {
-    icon: AnimatedIcon;
+    icon: string;
     isEditorView: boolean;
 }) => (
     <span

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -36,7 +36,7 @@ const StaticIcon = ({
                 src: getMediaUrl(icon.icon.mediaUrl),
                 isEditorView,
             })})`,
-            transform: icon.transformStart || 'non',
+            transform: icon.transformStart || 'none',
         }}
     />
 );

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -1,11 +1,15 @@
-import { AnimatedIconsProps } from 'types/content-props/animated-icons';
+import React from 'react';
+import {
+    AnimatedIcon,
+    AnimatedIconsProps,
+} from 'types/content-props/animated-icons';
 import { getMediaUrl } from 'utils/urls';
-import { classNames } from '../../../utils/classnames';
+import { classNames } from 'utils/classnames';
 import { buildImageCacheUrl, NextImageProps } from '../image/NextImage';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 
 import styleCommon from './Illustration.module.scss';
 import styleStatic from './IllustrationStatic.module.scss';
-import { usePageConfig } from '../../../store/hooks/usePageConfig';
 
 interface IllustrationStaticProps {
     illustration: AnimatedIconsProps;
@@ -17,6 +21,26 @@ const nextImageProps: NextImageProps = {
     quality: 90,
 };
 
+const StaticIcon = ({
+    icon,
+    isEditorView,
+}: {
+    icon: AnimatedIcon;
+    isEditorView: boolean;
+}) => (
+    <span
+        className={styleStatic.icon}
+        style={{
+            backgroundImage: `url(${buildImageCacheUrl({
+                ...nextImageProps,
+                src: getMediaUrl(icon.icon.mediaUrl),
+                isEditorView,
+            })})`,
+            transform: icon.transformStart || 'non',
+        }}
+    />
+);
+
 export const IllustrationStatic = ({
     illustration,
     className,
@@ -27,58 +51,32 @@ export const IllustrationStatic = ({
         return null;
     }
 
-    const buildTransformStyling = (icon, defaultStyling) => {
-        if (!icon) {
-            return '';
-        }
-        return icon.transformStart || defaultStyling;
-    };
-
-    const { icons } = illustration?.data;
-
+    const { icons } = illustration.data;
     if (!Array.isArray(icons)) {
         return null;
     }
 
     const [icon1, icon2] = icons;
 
-    const icon1Url = icon1?.icon?.mediaUrl;
-    const icon2Url = icon2?.icon?.mediaUrl;
+    const hasIcon1 = !!icon1?.icon?.mediaUrl;
+    const hasIcon2 = !!icon2?.icon?.mediaUrl;
 
-    if (!icon1Url && !icon2Url) {
+    if (!hasIcon1 && !hasIcon2) {
         return null;
     }
+
+    const isEditorView = !!pageConfig.editorView;
 
     return (
         <span
             className={classNames(styleCommon.image, className)}
             aria-hidden="true"
         >
-            {icon1Url && (
-                <span
-                    className={styleStatic.icon}
-                    style={{
-                        backgroundImage: `url(${buildImageCacheUrl({
-                            ...nextImageProps,
-                            src: getMediaUrl(icon1Url),
-                            isEditorView: !!pageConfig.editorView,
-                        })})`,
-                        transform: buildTransformStyling(icon1, 'none'),
-                    }}
-                />
+            {hasIcon1 && (
+                <StaticIcon icon={icon1} isEditorView={isEditorView} />
             )}
-            {icon2Url && (
-                <span
-                    className={styleStatic.icon}
-                    style={{
-                        backgroundImage: `url(${buildImageCacheUrl({
-                            ...nextImageProps,
-                            src: getMediaUrl(icon2Url),
-                            isEditorView: !!pageConfig.editorView,
-                        })})`,
-                        transform: buildTransformStyling(icon2, 'none'),
-                    }}
-                />
+            {hasIcon2 && (
+                <StaticIcon icon={icon2} isEditorView={isEditorView} />
             )}
         </span>
     );

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -42,7 +42,10 @@ export const IllustrationStatic = ({
 
     const [icon1, icon2] = icons;
 
-    if (!icon1 || !icon2) {
+    const icon1Url = icon1?.icon?.mediaUrl;
+    const icon2Url = icon2?.icon?.mediaUrl;
+
+    if (!icon1Url && !icon2Url) {
         return null;
     }
 
@@ -51,27 +54,27 @@ export const IllustrationStatic = ({
             className={classNames(styleCommon.image, className)}
             aria-hidden="true"
         >
-            {icon1 && (
+            {icon1Url && (
                 <span
                     className={styleStatic.icon}
                     style={{
                         backgroundImage: `url(${buildImageCacheUrl({
-                            src: getMediaUrl(icon1.icon?.mediaUrl),
-                            isEditorView: !!pageConfig.editorView,
                             ...nextImageProps,
+                            src: getMediaUrl(icon1Url),
+                            isEditorView: !!pageConfig.editorView,
                         })})`,
                         transform: buildTransformStyling(icon1, 'none'),
                     }}
                 />
             )}
-            {icon2 && (
+            {icon2Url && (
                 <span
                     className={styleStatic.icon}
                     style={{
                         backgroundImage: `url(${buildImageCacheUrl({
-                            src: getMediaUrl(icon2.icon?.mediaUrl),
-                            isEditorView: !!pageConfig.editorView,
                             ...nextImageProps,
+                            src: getMediaUrl(icon2Url),
+                            isEditorView: !!pageConfig.editorView,
                         })})`,
                         transform: buildTransformStyling(icon2, 'none'),
                     }}

--- a/src/types/content-props/animated-icons.ts
+++ b/src/types/content-props/animated-icons.ts
@@ -1,11 +1,11 @@
 import { ContentType } from './_content-common';
 import { XpImageProps } from '../media';
 
-type AnimatedIcon = {
-    icon: XpImageProps;
-    transformStart: string;
-    transformEnd: string;
-    transformOrigin: string;
+export type AnimatedIcon = {
+    icon?: XpImageProps;
+    transformStart?: string;
+    transformEnd?: string;
+    transformOrigin?: string;
 };
 
 export type AnimatedIconsData = {


### PR DESCRIPTION
Fikser en bug som oppstår dersom et av Icon-elementene fra XP er definert, men ikke inneholder en mediaUrl. Det vil da rendres en icon-container med `url(undefined)` som background.

(+ litt refactoring)