### PR TITLE
Fikser irritasjonsmomenter ved lokal kjøring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       API_UNLEASH_PROXY_URL: 'https://www.nav.no/person/pb-unleash-proxy'
       API_INNLOGGINGSLINJE_URL: "http://localhost:8095/innloggingsstatus"
       API_VARSELINNBOKS_URL: 'http://mocks:8080/person/varselinnboks'
+      API_DEKORATOREN_URL: 'http://localhost:8095/nav-dekoratoren-api'
       MINSIDE_ARBEIDSGIVER_URL: 'http://localhost:8080/min-side-arbeidsgiver/'
       DITT_NAV_URL: 'http://localhost:8080/person/dittnav/'
       LOGIN_URL: 'http://localhost:5000'

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,8 @@ const sentryConfig = {
     errorHandler: (err, invokeErr, compilation) => {
         compilation.warnings.push('Sentry CLI Plugin: ' + err.message);
     },
+    silent: process.env.NODE_ENV === 'development',
+    dryRun: process.env.ENV === 'localhost',
 };
 
 // Remove dashes from js variable names for classnames generated from CSS-modules

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -128,7 +128,7 @@ Error.getInitialProps = async ({
 
     logPageLoadError(
         errorId,
-        `Unhandled error on path ${asPath} - ${res.statusCode} ${errorMsg}`
+        `Unhandled error on path ${asPath} - ${res.statusCode} [${req.method}] ${errorMsg}`
     );
 
     return makeErrorProps(asPath, errorMsg, res.statusCode, errorId);

--- a/src/utils/make-error-props.ts
+++ b/src/utils/make-error-props.ts
@@ -10,6 +10,7 @@ const errorMessageByCode = {
     401: 'Ingen tilgang',
     403: 'Ingen tilgang',
     404: 'Fant ikke siden',
+    405: 'Ugyldig forespørsel',
     408: 'Tidsavbrudd',
 };
 


### PR DESCRIPTION
- Setter API_DEKORATOREN_URL for lokal docker-compose dekoratør
- Får Sentry til å holde kjeft i dev-mode 😄 