### PR TITLE
Fikser manglende padding i enkelte layouts

### DIFF
--- a/src/components/layouts/flex-cols/FlexColsLayoutGlobal.scss
+++ b/src/components/layouts/flex-cols/FlexColsLayoutGlobal.scss
@@ -57,10 +57,6 @@
             @include common.flex-cols-mixin(1);
         }
     }
-
-    &:last-of-type {
-        padding-bottom: 0;
-    }
 }
 
 .layout__situation-flex-cols {


### PR DESCRIPTION
Fjerner en css-regel som fører til padding-bottom 0 dersom visse layouts ligger sist i en container. Ser ingen tilfeller der vi ønsker denne oppførselen, mulig noe gammelt som har blitt liggende fra en tidligere løsning.
