### PR TITLE
Fjerner inline styling fra html (bortsett fra tabell-celler)

### DIFF
--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -92,11 +92,13 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
     const parserOptions = {
         replace: (element: Element) => {
-            //Remove all inline styling from source
-            delete element?.attribs?.style;
-
-            const { name, attribs, children } = element;
+            const { name } = element;
             const tag = name?.toLowerCase();
+            //Remove all inline styling except in table cells
+            if (tag !== 'td') {
+                delete element?.attribs?.style;
+            }
+            const { attribs, children } = element;
             const props = !!attribs && attributesToProps(attribs);
             const validChildren = getNonEmptyChildren(element);
 

--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -92,6 +92,9 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
     const parserOptions = {
         replace: (element: Element) => {
+            //Fjern all eventuell inline styling
+            delete element?.attribs?.style;
+
             const { name, attribs, children } = element;
             const tag = name?.toLowerCase();
             const props = !!attribs && attributesToProps(attribs);
@@ -210,7 +213,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
             // Replace empty rows with stylable element
             if (tag === 'tr' && !validChildren) {
-                return <tr {...props} className={'spacer-row'} />;
+                return <tr {...props} role="none" className={'spacer-row'} />;
             }
 
             // Remove empty divs

--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -1,27 +1,27 @@
 import React, { Fragment } from 'react';
+import { Provider } from 'react-redux';
+import { store } from 'store/store';
+import ReactDOMServer from 'react-dom/server';
+import { isTag, isText } from 'domhandler';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 import { NextImage } from '../image/NextImage';
-import { BodyLong, Heading } from '@navikt/ds-react';
 import htmlReactParser, {
     Element,
     domToReact,
     attributesToProps,
 } from 'html-react-parser';
-import { isTag, isText } from 'domhandler';
-import { LenkeInline } from '../lenke/LenkeInline';
-import { getMediaUrl } from '../../../utils/urls';
+import { getMediaUrl } from 'utils/urls';
 import {
     processedHtmlMacroTag,
     ProcessedHtmlProps,
-} from '../../../types/processed-html-props';
+} from 'types/processed-html-props';
+import { headingToLevel, headingToSize } from 'types/typo-style';
+import { MacroType } from 'types/macro-props/_macros-common';
 import { MacroMapper } from '../../macros/MacroMapper';
-import { headingToLevel, headingToSize } from '../../../types/typo-style';
-import { MacroType } from '../../../types/macro-props/_macros-common';
-import { usePageConfig } from '../../../store/hooks/usePageConfig';
 import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
-import ReactDOMServer from 'react-dom/server';
-import { store } from '../../../store/store';
-import { Provider } from 'react-redux';
+import { LenkeInline } from '../lenke/LenkeInline';
 import { Table } from '../table/Table';
+import { BodyLong, Heading } from '@navikt/ds-react';
 
 const blockLevelMacros: { [macroType in MacroType]?: boolean } = {
     [MacroType.AlertBox]: true,
@@ -92,7 +92,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
     const parserOptions = {
         replace: (element: Element) => {
-            //Fjern all eventuell inline styling
+            //Remove all inline styling from source
             delete element?.attribs?.style;
 
             const { name, attribs, children } = element;

--- a/src/components/pages/large-table-page/LargeTablePage.module.scss
+++ b/src/components/pages/large-table-page/LargeTablePage.module.scss
@@ -76,9 +76,4 @@
     :global(.statFoot) {
         margin-top: 0.5rem;
     }
-
-    :global(.spacer-row) {
-        height: 1rem;
-        background-color: transparent;
-    }
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -82,6 +82,13 @@ figure {
     margin-right: 0;
 }
 
+table {
+    .spacer-row {
+        height: 1rem;
+        background-color: transparent;
+    }
+}
+
 // Catch-all to prevent unnecessary margin-bottom whitespace
 .region:last-child,
 .layout:last-child,

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -1,10 +1,12 @@
 import { ContentProps } from 'types/content-props/_content-common';
 import { LanguageProps } from 'types/language';
 
+// TODO: remove after backend changes are in production
+const legacyLanguages = (content: ContentProps) =>
+    Array.isArray(content.data?.languages) ? content.data.languages : null;
+
 export const getContentLanguages = (
     content: ContentProps
 ): LanguageProps[] | null => {
-    return content.languages || Array.isArray(content.data?.languages)
-        ? content.data.languages
-        : null;
+    return content.languages || legacyLanguages(content);
 };


### PR DESCRIPTION
## Testing

-   [x] Har testet selv i lokalt (q6 funker p.t. ikke)
-   [x] Har blitt testet i dev (av Eivind og Janne)

## Oppsummering av hva som er gjort

- Sletter style fra attributtene ved parsing av HTML, men beholder styling i tabell-celler
- spacer-row til luft i tabeller fungerer over alt og får role="none" for å tilfredstille krav om ingen tomme tabellrader

## Dette trenger jeg å få et ekstra blikk på
Kan dette ha andre bivirkninger for ferdig html?

## Evt lenke til oppgave eller Favro-kort
https://favro.com/organization/0aac56439eb0a59c92128abd/7756d109488ab703ef7af835?card=Tea-272
