### PR TITLE
Fikser page-template visning og skriver om __typename -> type

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -73,14 +73,14 @@ const contentToReactComponent: Partial<{
 };
 
 export const isContentTypeImplemented = (content: ContentProps) =>
-    contentToReactComponent.hasOwnProperty(content.__typename);
+    contentToReactComponent.hasOwnProperty(content.type);
 
 type Props = {
     content: ContentProps;
 };
 
 export const ContentMapper = ({ content }: Props) => {
-    const Component = contentToReactComponent[content.__typename];
+    const Component = contentToReactComponent[content.type];
 
     return Component ? (
         <Component {...content} />

--- a/src/components/_common/card/card-utils.ts
+++ b/src/components/_common/card/card-utils.ts
@@ -67,10 +67,10 @@ export const getCardProps = (
         return null;
     }
 
-    const { data, __typename, _path, displayName } = content;
+    const { data, type, _path, displayName } = content;
     const { title, ingress, illustration, externalProductUrl } = data;
 
-    const cardType = cardTypeMap[__typename];
+    const cardType = cardTypeMap[type];
     const cardUrl = externalProductUrl || _path;
     const cardTitle = title || displayName;
 

--- a/src/components/_common/chatbot/LegacyPageChatbot.tsx
+++ b/src/components/_common/chatbot/LegacyPageChatbot.tsx
@@ -23,7 +23,7 @@ type Props = {
 export const LegacyPageChatbot = ({ content }: Props) => {
     if (
         content.data?.chatbotToggle === false ||
-        !showOnContentTypes[content.__typename] ||
+        !showOnContentTypes[content.type] ||
         !showOnLanguage[content.language]
     ) {
         return null;

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -37,12 +37,7 @@ export const ThemedPageHeader = ({
     contentProps,
     showTimeStamp = true,
 }: Props) => {
-    const {
-        __typename: pageType,
-        displayName,
-        modifiedTime,
-        data,
-    } = contentProps;
+    const { type: pageType, displayName, modifiedTime, data } = contentProps;
     const {
         title,
         illustration,

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -36,7 +36,7 @@ const getDescription = (content: ContentProps) => {
 
 const shouldNotIndex = (content: ContentProps) =>
     content.isPagePreview ||
-    content.__typename === ContentType.Error ||
+    content.type === ContentType.Error ||
     content.data?.noindex;
 
 const getCanonicalUrl = (content: ContentProps) => {

--- a/src/components/_common/press-landing/PressNewsItem.tsx
+++ b/src/components/_common/press-landing/PressNewsItem.tsx
@@ -19,7 +19,7 @@ export const PressNewsItem = ({ newsItem }: PressNewsItemProps) => {
     const getTranslations = translator('pressLanding', language);
 
     const getTaglineElements = (newsItem: ContentProps) => {
-        if (newsItem.__typename === ContentType.MainArticle) {
+        if (newsItem.type === ContentType.MainArticle) {
             const isNews = newsItem?.data?.contentType === 'news';
             const icon = isNews ? newsIcon : pressIcon;
             const tagName = getTranslations(isNews ? 'news' : 'press');

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
@@ -66,7 +66,7 @@ export const hookDispatchEventForBatchContentServerEvent = ({
     setExternalContentChange;
     setExternalUpdateEvent;
 }) => {
-    const { _id: contentId, __typename: contentType } = content;
+    const { _id: contentId, type: contentType } = content;
 
     // Some content types use a custom editor. This hack only applies to built-in CS functionality
     if (ignoredContentTypes[contentType]) {

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -26,17 +26,17 @@ type Props = {
 };
 
 export const checkForWhiteHeader = (content: ContentProps) => {
-    const { __typename } = content;
+    const { type } = content;
 
     if (
-        __typename === ContentType.MainArticle &&
+        type === ContentType.MainArticle &&
         (content.data?.contentType === 'news' ||
             content.data?.contentType === 'pressRelease')
     ) {
         return true;
     }
 
-    return contentTypesWithWhiteHeader[__typename];
+    return contentTypesWithWhiteHeader[type];
 };
 
 export const TopContainer = ({ content }: Props) => {

--- a/src/components/layouts/index-page/IndexPage.tsx
+++ b/src/components/layouts/index-page/IndexPage.tsx
@@ -24,10 +24,10 @@ type Props = {
 };
 
 export const IndexPage = ({ pageProps, layoutProps }: Props) => {
-    const { __typename } = pageProps;
+    const { type } = pageProps;
     const { regions } = layoutProps;
 
-    const MiddleComponent = contentTypeSpecificComponent[__typename];
+    const MiddleComponent = contentTypeSpecificComponent[type];
 
     return (
         <LayoutContainer
@@ -37,7 +37,7 @@ export const IndexPage = ({ pageProps, layoutProps }: Props) => {
         >
             <>
                 {/* We don't use this region on the AreaPage atm */}
-                {__typename !== ContentType.AreaPage && (
+                {type !== ContentType.AreaPage && (
                     <Region
                         pageProps={pageProps}
                         regionProps={regions.contentTop}

--- a/src/components/pages/global-values-page/GlobalValuesPage.tsx
+++ b/src/components/pages/global-values-page/GlobalValuesPage.tsx
@@ -20,10 +20,7 @@ import style from './GlobalValuesPage.module.scss';
 
 type ListOrder = 'custom' | 'sorted';
 
-const GlobalValuesDisplay = ({
-    displayName,
-    __typename,
-}: GlobalValuesProps) => {
+const GlobalValuesDisplay = ({ displayName, type }: GlobalValuesProps) => {
     const { valueItems } = useGvEditorState();
     const [listOrder, setListOrder] = useState<ListOrder>('custom');
 
@@ -60,7 +57,7 @@ const GlobalValuesDisplay = ({
             </Head>
             <div className={style.headerRow}>
                 <Heading level="1" size="large">
-                    {__typename === ContentType.GlobalCaseTimeSet
+                    {type === ContentType.GlobalCaseTimeSet
                         ? 'Saksbehandlingstider'
                         : 'Globale verdier'}
                 </Heading>
@@ -92,7 +89,7 @@ const GlobalValuesDisplay = ({
                         </Heading>
                         <GVAddItem
                             type={
-                                __typename === ContentType.GlobalCaseTimeSet
+                                type === ContentType.GlobalCaseTimeSet
                                     ? 'caseTime'
                                     : 'numberValue'
                             }

--- a/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
+++ b/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
@@ -5,7 +5,7 @@ import { DynamicPage } from '../dynamic-page/DynamicPage';
 import { MainArticleChapterProps } from '../../../types/content-props/main-article-chapter-props';
 
 export const MainArticleChapterPage = (props: MainArticleChapterProps) => {
-    if (props.data?.article?.__typename !== ContentType.MainArticle) {
+    if (props.data?.article?.type !== ContentType.MainArticle) {
         return <RedirectPage {...props} />;
     }
 

--- a/src/components/pages/overview-page/product-elements/ProductDetailsPanel.tsx
+++ b/src/components/pages/overview-page/product-elements/ProductDetailsPanel.tsx
@@ -75,7 +75,7 @@ export const ProductDetailsPanel = ({
             .then((contentFromCache) => {
                 if (
                     !contentFromCache ||
-                    contentFromCache.__typename !== ContentType.ProductDetails
+                    contentFromCache.type !== ContentType.ProductDetails
                 ) {
                     setError(
                         `Teknisk feil: Kunne ikke laste ${detailTypeStrings(

--- a/src/components/pages/template-page/TemplatePage.tsx
+++ b/src/components/pages/template-page/TemplatePage.tsx
@@ -5,11 +5,10 @@ import { linkPanelsDataMock } from './mocks/linkPanelsDataMock';
 import { mainArticleDataMock } from './mocks/mainArticleDataMock';
 import { mainPanelDataMock } from './mocks/mainPanelsDataMock';
 import { officeInformationMock } from './mocks/officeInformationMock';
-import {
-    ContentType,
-    ContentProps,
-} from '../../../types/content-props/_content-common';
+import { ContentType } from 'types/content-props/_content-common';
 import ErrorPage404 from '../../../pages/404';
+import { TemplateProps } from 'types/content-props/template-props';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 const legacyMockData = {
     ...linkListDataMock,
@@ -30,17 +29,24 @@ const legacyTemplateTypes = {
     [ContentType.PublishingCalendar]: true,
 };
 
-export const TemplatePage = (props: ContentProps) => {
+export const TemplatePage = (props: TemplateProps) => {
     if (!props.editorView) {
         return <ErrorPage404 />;
     }
 
-    if (legacyTemplateTypes[props.__typename]) {
+    const templateSupportsType = props.data.supports?.[0];
+
+    if (!templateSupportsType) {
+        return <EditorHelp text={'Template må støtte minst en innholdstype'} />;
+    }
+
+    if (legacyTemplateTypes[templateSupportsType]) {
         const propsWithMocks = {
             ...props,
             data: { ...legacyMockData, ...props?.data },
         };
 
+        console.log(propsWithMocks);
         // @ts-ignore (templates for these old types will never ever be changed)
         return <DynamicPage {...propsWithMocks} />;
     }

--- a/src/components/pages/template-page/mocks/linkListDataMock.ts
+++ b/src/components/pages/template-page/mocks/linkListDataMock.ts
@@ -4,7 +4,7 @@ import { SectionPageData } from '../../../../types/content-props/section-page-pr
 export const linkListDataMock: SectionPageData = {
     ntkContents: {
         _id: 'mock-id',
-        __typename: ContentType.ContentList,
+        type: ContentType.ContentList,
         _path: '#',
         createdTime: '2019-10-31T12:51:49Z',
         modifiedTime: '2019-12-12T13:40:51.919815Z',
@@ -13,7 +13,7 @@ export const linkListDataMock: SectionPageData = {
         data: {
             sectionContents: [
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'cd3c1fc5-53e9-4cdd-8287-ef69405832bd',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -26,7 +26,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.PageList,
+                    type: ContentType.PageList,
                     _id: '5c33bb94-5d8e-4a11-88de-39ff388206b5',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -36,7 +36,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'a24afc59-41f2-4c19-b976-1cc722df75b7',
                     _path: '#',
                     createdTime: '2015-02-03T08:33:59Z',
@@ -49,7 +49,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: '74f92237-781a-43bd-94b7-5f91d0335e0f',
                     _path: '#',
                     createdTime: '2019-11-15T07:12:00Z',
@@ -62,7 +62,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: '4c298da7-9d8d-4e25-ab3a-661216c34725',
                     _path: '#',
                     createdTime: '2014-11-10T13:59:33Z',
@@ -75,7 +75,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'e8b0e763-84ec-46e3-af12-033ec20f9dd7',
                     _path: '#',
                     createdTime: '2014-11-10T13:59:33Z',
@@ -91,7 +91,7 @@ export const linkListDataMock: SectionPageData = {
         },
     },
     newsContents: {
-        __typename: ContentType.ContentList,
+        type: ContentType.ContentList,
         _id: 'a1ef2199-9e05-40f4-8b6e-13fbef6f05ee',
         _path: '#',
         createdTime: '2016-04-15T08:57:58Z',
@@ -101,7 +101,7 @@ export const linkListDataMock: SectionPageData = {
         data: {
             sectionContents: [
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'b5f5822b-d4a6-4c5c-b67d-44629b4198d6',
                     _path: '#',
                     createdTime: '2019-12-12T12:06:41.407671Z',
@@ -114,7 +114,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'e567043e-2ae6-4635-a9d5-fa6338264438',
                     _path: '#',
                     createdTime: '2019-12-13T13:38:07.402648Z',
@@ -127,7 +127,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: 'f3af0498-2822-45c4-8e76-af1815affe20',
                     _path: '#',
                     createdTime: '2019-12-13T08:20:51.220550Z',
@@ -143,7 +143,7 @@ export const linkListDataMock: SectionPageData = {
         },
     },
     scContents: {
-        __typename: ContentType.ContentList,
+        type: ContentType.ContentList,
         _id: '70958273-9c20-41e3-92c2-ff1375e98be6',
         _path: '#',
         createdTime: '2019-10-31T12:51:49Z',
@@ -153,7 +153,7 @@ export const linkListDataMock: SectionPageData = {
         data: {
             sectionContents: [
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: '5b1dbf9d-9287-4cf8-937b-58dc4ce7f7e0',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -166,7 +166,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.InternalLink,
+                    type: ContentType.InternalLink,
                     _id: '996c0747-45d3-4b95-90b0-afe96a87ec2b',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -176,7 +176,7 @@ export const linkListDataMock: SectionPageData = {
                     data: { target: { _path: '' } },
                 },
                 {
-                    __typename: ContentType.ExternalLink,
+                    type: ContentType.ExternalLink,
                     _id: 'c049707a-1883-4914-a625-26077995af0d',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -186,7 +186,7 @@ export const linkListDataMock: SectionPageData = {
                     data: { url: '', description: '' },
                 },
                 {
-                    __typename: ContentType.MainArticle,
+                    type: ContentType.MainArticle,
                     _id: '1ded1d83-055b-470f-81dd-f0bdc742482b',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',
@@ -199,7 +199,7 @@ export const linkListDataMock: SectionPageData = {
                     data: {},
                 },
                 {
-                    __typename: ContentType.ExternalLink,
+                    type: ContentType.ExternalLink,
                     _id: '07f22eb4-fddd-4f22-b48e-b8df23e6634f',
                     _path: '#',
                     createdTime: '2019-10-31T12:51:49Z',

--- a/src/components/pages/template-page/mocks/mainPanelsDataMock.ts
+++ b/src/components/pages/template-page/mocks/mainPanelsDataMock.ts
@@ -4,7 +4,7 @@ import { SectionPageData } from '../../../../types/content-props/section-page-pr
 export const mainPanelDataMock: SectionPageData = {
     tableContents: [
         {
-            __typename: ContentType.TransportPage,
+            type: ContentType.TransportPage,
             _path: '/',
             _id: '',
             createdTime: '',
@@ -16,7 +16,7 @@ export const mainPanelDataMock: SectionPageData = {
             },
         },
         {
-            __typename: ContentType.ExternalLink,
+            type: ContentType.ExternalLink,
             _path: '/',
             _id: '',
             createdTime: '',
@@ -29,7 +29,7 @@ export const mainPanelDataMock: SectionPageData = {
             },
         },
         {
-            __typename: ContentType.ExternalLink,
+            type: ContentType.ExternalLink,
             _path: '/',
             _id: '',
             createdTime: '',

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -15,16 +15,16 @@ import style from './MainArticleChapterNavigation.module.scss';
 // as a chapter
 const getChapterPath = (chapter: MainArticleChapterNavigationData) =>
     !chapter.data?.article ||
-    chapter.data.article.__typename === ContentType.MainArticle
+    chapter.data.article.type === ContentType.MainArticle
         ? chapter._path
         : chapter.data.article._path;
 
 const getChapters = (contentProps: ContentProps) => {
-    if (contentProps.__typename === ContentType.MainArticle) {
+    if (contentProps.type === ContentType.MainArticle) {
         return contentProps.data?.chapters;
     }
 
-    if (contentProps.__typename === ContentType.MainArticleChapter) {
+    if (contentProps.type === ContentType.MainArticleChapter) {
         return contentProps.parent?.data?.chapters;
     }
 

--- a/src/components/parts/_legacy/main-article/MainArticle.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticle.tsx
@@ -8,9 +8,9 @@ import { MainArticlePermanent } from './MainArticlePermanent';
 type Props = MainArticleProps | MainArticleChapterProps;
 
 export const MainArticle = (propsInitial: Props) => {
-    const { __typename } = propsInitial;
+    const { type } = propsInitial;
     if (
-        __typename === ContentType.MainArticle &&
+        type === ContentType.MainArticle &&
         (propsInitial.data.contentType === 'news' ||
             propsInitial.data.contentType === 'pressRelease')
     ) {

--- a/src/components/parts/_legacy/main-article/MainArticleNewsPress.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticleNewsPress.tsx
@@ -21,13 +21,13 @@ type Props = MainArticleProps | MainArticleChapterProps;
 
 // Get props from the chapter article if the content is a chapter
 const getPropsToRender = (propsInitial: Props) => {
-    if (propsInitial.__typename !== ContentType.MainArticleChapter) {
+    if (propsInitial.type !== ContentType.MainArticleChapter) {
         return propsInitial;
     }
 
     const articleProps = propsInitial.data?.article;
 
-    if (articleProps?.__typename === ContentType.MainArticle) {
+    if (articleProps?.type === ContentType.MainArticle) {
         return articleProps;
     }
 
@@ -84,7 +84,7 @@ export const MainArticleNewsPress = (propsInitial: Props) => {
 
     if (!props) {
         console.error(
-            `Misplaced MainArticle part on content type ${propsInitial.__typename} - ${propsInitial._path} - ${propsInitial._id}`
+            `Misplaced MainArticle part on content type ${propsInitial.type} - ${propsInitial._path} - ${propsInitial._id}`
         );
         return <ErrorPage404 />;
     }

--- a/src/components/parts/_legacy/main-article/MainArticlePermanent.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticlePermanent.tsx
@@ -19,13 +19,13 @@ type Props = MainArticleProps | MainArticleChapterProps;
 
 // Get props from the chapter article if the content is a chapter
 const getPropsToRender = (propsInitial: Props) => {
-    if (propsInitial.__typename !== ContentType.MainArticleChapter) {
+    if (propsInitial.type !== ContentType.MainArticleChapter) {
         return propsInitial;
     }
 
     const articleProps = propsInitial.data?.article;
 
-    if (articleProps?.__typename === ContentType.MainArticle) {
+    if (articleProps?.type === ContentType.MainArticle) {
         return articleProps;
     }
 
@@ -38,7 +38,7 @@ export const MainArticlePermanent = (propsInitial: Props) => {
     const props = getPropsToRender(propsInitial);
     if (!props) {
         console.error(
-            `Misplaced MainArticle part on content type ${propsInitial.__typename} - ${propsInitial._path} - ${propsInitial._id}`
+            `Misplaced MainArticle part on content type ${propsInitial.type} - ${propsInitial._path} - ${propsInitial._id}`
         );
         return <ErrorPage404 />;
     }

--- a/src/components/parts/_legacy/main-panels/MainPanels.tsx
+++ b/src/components/parts/_legacy/main-panels/MainPanels.tsx
@@ -21,7 +21,7 @@ const getLinkData = (content: ContentProps | null): TableData | null => {
         return null;
     }
 
-    switch (content.__typename) {
+    switch (content.type) {
         case ContentType.InternalLink:
             return {
                 url: getInternalLinkUrl(content.data),

--- a/src/components/parts/_legacy/menu-list/MenuList.tsx
+++ b/src/components/parts/_legacy/menu-list/MenuList.tsx
@@ -13,7 +13,7 @@ import style from './MenuList.module.scss';
 export const MenuList = (
     props: MainArticleProps | MainArticleChapterProps | PageListProps
 ) => {
-    const { __typename: type, language } = props;
+    const { type: type, language } = props;
 
     const propsActual =
         type === ContentType.MainArticleChapter ? props.data?.article : props;

--- a/src/components/parts/_legacy/page-heading/PageHeading.tsx
+++ b/src/components/parts/_legacy/page-heading/PageHeading.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { Heading, Ingress } from '@navikt/ds-react';
-import {
-    ContentProps,
-    ContentType,
-} from 'types/content-props/_content-common';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 
 import style from './PageHeading.module.scss';
 
 const PageHeading = (props: ContentProps) => {
     const displayName = props.displayName;
     const ingress =
-        props.__typename !== ContentType.SectionPage && props.data?.ingress;
+        props.type !== ContentType.SectionPage && props.data?.ingress;
 
     return (
         <header className={style.pageHeading}>

--- a/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
+++ b/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
@@ -29,7 +29,7 @@ export const FrontpageContactPart = ({
 
     const contactUsUrl =
         contactUsLink &&
-        (contactUsLink.__typename === ContentType.ExternalLink
+        (contactUsLink.type === ContentType.ExternalLink
             ? contactUsLink.data.url
             : contactUsLink._path);
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -27,9 +27,9 @@ const getClientsideProps = (path: string) => {
     try {
         const contentProps = JSON.parse(nextData)?.props
             ?.pageProps as ContentProps;
-        if (contentProps.__typename !== ContentType.Error) {
+        if (contentProps.type !== ContentType.Error) {
             console.error(
-                `Unexpected __NEXT_DATA__ contentProps on ${path} - ${contentProps._id} ${contentProps.__typename}`
+                `Unexpected __NEXT_DATA__ contentProps on ${path} - ${contentProps._id} ${contentProps.type}`
             );
             return null;
         }
@@ -115,7 +115,7 @@ Error.getInitialProps = async ({
     const errorId = uuid();
     const errorContent = parseErrorContent(err, asPath);
 
-    if (errorContent?.__typename === ContentType.Error) {
+    if (errorContent?.type === ContentType.Error) {
         res.statusCode = errorContent.data.errorCode;
         logPageLoadError(
             errorId,

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -15,7 +15,7 @@ import { apiErrorHandler } from '../../utils/api-error-handler';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const dummyPageProps: ContentProps = {
-    __typename: ContentType.DynamicPage,
+    type: ContentType.DynamicPage,
     _id: '',
     _path: '',
     createdTime: '',

--- a/src/types/component-props/parts/frontpage-contact.ts
+++ b/src/types/component-props/parts/frontpage-contact.ts
@@ -3,12 +3,12 @@ import { PartType } from '../parts';
 import { ContentType } from '../../content-props/_content-common';
 
 type InternalContactUs = {
-    __typename: ContentType.GenericPage;
+    type: ContentType.GenericPage;
     _path: string;
 };
 
 type ExternalContactUs = {
-    __typename: ContentType.ExternalLink;
+    type: ContentType.ExternalLink;
     data: {
         url: string;
     };

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -7,7 +7,7 @@ import { ErrorProps } from './error-props';
 import { LargeTableProps } from './large-table-props';
 import { SectionPageProps } from './section-page-props';
 import { TransportPageProps } from './transport-page-props';
-import { Language } from '../../translations';
+import { Language } from 'translations';
 import { LayoutProps } from '../component-props/layouts';
 import { MainArticleChapterProps } from './main-article-chapter-props';
 import { OfficeInformationProps } from './office-information-props';
@@ -42,50 +42,51 @@ import { LanguageProps } from '../language';
 import { FragmentPageProps } from './fragment-page-props';
 import { AreaPageProps, FrontPageProps } from './index-pages-props';
 import { Audience } from '../component-props/_mixins';
-import { PressLandingPage } from 'components/pages/press-landing-page/PressLandingPage';
+import { TemplateProps } from 'types/content-props/template-props';
+import { SiteProps } from 'types/content-props/site-props';
 
 export enum ContentType {
     Error = 'error',
-    Site = 'portal_Site',
-    Fragment = 'portal_Fragment',
-    TemplatePage = 'portal_PageTemplate',
-    InternalLink = 'no_nav_navno_InternalLink',
-    ExternalLink = 'no_nav_navno_ExternalLink',
-    Url = 'no_nav_navno_Url',
-    SectionPage = 'no_nav_navno_SectionPage',
-    TransportPage = 'no_nav_navno_TransportPage',
-    DynamicPage = 'no_nav_navno_DynamicPage',
-    ContentList = 'no_nav_navno_ContentList',
-    ContactInformationPage = 'no_nav_navno_ContactInformation',
-    GenericPage = 'no_nav_navno_GenericPage',
-    PageList = 'no_nav_navno_PageList',
-    MainArticle = 'no_nav_navno_MainArticle',
-    MainArticleChapter = 'no_nav_navno_MainArticleChapter',
-    Melding = 'no_nav_navno_Melding',
-    LargeTable = 'no_nav_navno_LargeTable',
-    OfficeInformation = 'no_nav_navno_OfficeInformation',
-    PublishingCalendar = 'no_nav_navno_PublishingCalendar',
-    PublishingCalendarEntry = 'no_nav_navno_PublishingCalendarEntry',
-    GlobalNumberValuesSet = 'no_nav_navno_GlobalValueSet',
-    ProductPage = 'no_nav_navno_ContentPageWithSidemenus',
-    ProductDetails = 'no_nav_navno_ProductDetails',
-    GuidePage = 'no_nav_navno_GuidePage',
-    ThemedArticlePage = 'no_nav_navno_ThemedArticlePage',
-    CurrentTopicPage = 'no_nav_navno_CurrentTopicPage',
-    SituationPage = 'no_nav_navno_SituationPage',
-    AnimatedIcons = 'no_nav_navno_AnimatedIcons',
-    ToolsPage = 'no_nav_navno_ToolsPage',
-    Calculator = 'no_nav_navno_Calculator',
-    Overview = 'no_nav_navno_Overview',
-    GlobalCaseTimeSet = 'no_nav_navno_GlobalCaseTimeSet',
-    PayoutDates = 'no_nav_navno_PayoutDates',
-    FrontPage = 'no_nav_navno_FrontPage',
-    AreaPage = 'no_nav_navno_AreaPage',
-    PressLandingPage = 'no_nav_navno_PressLandingPage',
+    Site = 'portal:site',
+    Fragment = 'portal:fragment',
+    TemplatePage = 'portal:page-template',
+    InternalLink = 'no.nav.navno:internal-link',
+    ExternalLink = 'no.nav.navno:external-link',
+    Url = 'no.nav.navno:url',
+    SectionPage = 'no.nav.navno:section-page',
+    TransportPage = 'no.nav.navno:transport-page',
+    DynamicPage = 'no.nav.navno:dynamic-page',
+    ContentList = 'no.nav.navno:content-list',
+    ContactInformationPage = 'no.nav.navno:contact-information',
+    GenericPage = 'no.nav.navno:generic-page',
+    PageList = 'no.nav.navno:page-list',
+    MainArticle = 'no.nav.navno:main-article',
+    MainArticleChapter = 'no.nav.navno:main-article-chapter',
+    Melding = 'no.nav.navno:melding',
+    LargeTable = 'no.nav.navno:large-table',
+    OfficeInformation = 'no.nav.navno:office-information',
+    PublishingCalendar = 'no.nav.navno:publishing-calendar',
+    PublishingCalendarEntry = 'no.nav.navno:publishing-calendar-entry',
+    GlobalNumberValuesSet = 'no.nav.navno:global-value-set',
+    ProductPage = 'no.nav.navno:content-page-with-sidemenus',
+    ProductDetails = 'no.nav.navno:product-details',
+    GuidePage = 'no.nav.navno:guide-page',
+    ThemedArticlePage = 'no.nav.navno:themed-article-page',
+    CurrentTopicPage = 'no.nav.navno:current-topic-page',
+    SituationPage = 'no.nav.navno:situation-page',
+    AnimatedIcons = 'no.nav.navno:animated-icons',
+    ToolsPage = 'no.nav.navno:tools-page',
+    Calculator = 'no.nav.navno:calculator',
+    Overview = 'no.nav.navno:overview',
+    GlobalCaseTimeSet = 'no.nav.navno:global-case-time-set',
+    PayoutDates = 'no.nav.navno:payout-dates',
+    FrontPage = 'no.nav.navno:front-page',
+    AreaPage = 'no.nav.navno:area-page',
+    PressLandingPage = 'no.nav.navno:press-landing-page',
 }
 
 export type ContentAndMediaCommonProps = {
-    __typename: ContentType | MediaType;
+    type: ContentType | MediaType;
     _id: string;
     _path: string;
     createdTime: string;
@@ -116,8 +117,8 @@ type ContentCommonData = Partial<{
 }>;
 
 export type ContentCommonProps = {
-    __typename: ContentType;
-    originalType?: string;
+    type: ContentType;
+    originalType?: ContentType;
     children?: ContentCommonProps[];
     parent?: ContentCommonProps;
     data?: ContentCommonData;
@@ -129,17 +130,6 @@ export type ContentCommonProps = {
     isPagePreview?: boolean;
     languages?: LanguageProps[];
 } & ContentAndMediaCommonProps;
-
-type SiteProps = {
-    __typename: ContentType.Site;
-} & ContentCommonProps;
-
-type TemplateProps = {
-    __typename: ContentType.TemplatePage;
-    data: {
-        supports?: string | string[];
-    };
-} & ContentCommonProps;
 
 type SpecificContentProps =
     | SiteProps

--- a/src/types/content-props/animated-icons.ts
+++ b/src/types/content-props/animated-icons.ts
@@ -14,6 +14,6 @@ export type AnimatedIconsData = {
 };
 
 export interface AnimatedIconsProps {
-    __typename: ContentType.AnimatedIcons;
+    type: ContentType.AnimatedIcons;
     data: AnimatedIconsData;
 }

--- a/src/types/content-props/contact-information-props.ts
+++ b/src/types/content-props/contact-information-props.ts
@@ -14,6 +14,6 @@ export interface ContactInformationData {
 }
 
 export interface ContactInformationProps extends ContentCommonProps {
-    __typename: ContentType.ContactInformationPage;
+    type: ContentType.ContactInformationPage;
     data: ContactInformationData;
 }

--- a/src/types/content-props/content-list-props.ts
+++ b/src/types/content-props/content-list-props.ts
@@ -11,6 +11,6 @@ export type ContentListData = Partial<{
 }>;
 
 export interface ContentListProps extends ContentCommonProps {
-    __typename: ContentType.ContentList;
+    type: ContentType.ContentList;
     data: ContentListData;
 }

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -44,53 +44,53 @@ export type PressLandingPageData = Partial<{
     DynamicPageData;
 
 export interface DynamicPageProps extends ContentCommonProps {
-    __typename: ContentType.DynamicPage;
+    type: ContentType.DynamicPage;
     data: DynamicPageData;
 }
 
 export interface ProductPageProps extends ContentCommonProps {
-    __typename: ContentType.ProductPage;
+    type: ContentType.ProductPage;
     data: ProductPageData;
 }
 
 export interface ProductDetailsProps extends ContentCommonProps {
-    __typename: ContentType.ProductDetails;
+    type: ContentType.ProductDetails;
     data: ProductDetailsData;
 }
 
 export interface ThemedArticlePageProps extends ContentCommonProps {
-    __typename: ContentType.ThemedArticlePage;
+    type: ContentType.ThemedArticlePage;
     data: ThemedArticlePageData;
 }
 
 export interface GuidePageProps extends ContentCommonProps {
-    __typename: ContentType.GuidePage;
+    type: ContentType.GuidePage;
     data: GuidePageData;
 }
 export interface SituationPageProps extends ContentCommonProps {
-    __typename: ContentType.SituationPage;
+    type: ContentType.SituationPage;
     data: SituationPageData;
 }
 export interface CurrentTopicPageProps extends ContentCommonProps {
-    __typename: ContentType.CurrentTopicPage;
+    type: ContentType.CurrentTopicPage;
     data: CurrentTopicPageData;
 }
 
 export interface ToolsPageProps extends ContentCommonProps {
-    __typename: ContentType.ToolsPage;
+    type: ContentType.ToolsPage;
     data: ToolsPageData;
 }
 
 export interface GenericPageProps extends ContentCommonProps {
-    __typename: ContentType.GenericPage;
+    type: ContentType.GenericPage;
     data: GenericPageData;
 }
 
 export interface OverviewPageProps extends ContentCommonProps {
-    __typename: ContentType.Overview;
+    type: ContentType.Overview;
     data: OverviewPageData;
 }
 export interface PressLandingPageProps extends ContentCommonProps {
-    __typename: ContentType.PressLandingPage;
+    type: ContentType.PressLandingPage;
     data: PressLandingPageData;
 }

--- a/src/types/content-props/error-props.ts
+++ b/src/types/content-props/error-props.ts
@@ -9,6 +9,6 @@ export type ErrorData = {
 };
 
 export interface ErrorProps extends ContentCommonProps {
-    __typename: ContentType.Error;
+    type: ContentType.Error;
     data: ErrorData;
 }

--- a/src/types/content-props/external-link-props.ts
+++ b/src/types/content-props/external-link-props.ts
@@ -7,6 +7,6 @@ export type ExternalLinkData = {
 };
 
 export interface ExternalLinkProps extends ContentCommonProps {
-    __typename: ContentType.ExternalLink;
+    type: ContentType.ExternalLink;
     data: ExternalLinkData;
 }

--- a/src/types/content-props/fragment-page-props.ts
+++ b/src/types/content-props/fragment-page-props.ts
@@ -2,6 +2,6 @@ import { ContentType, ContentCommonProps } from './_content-common';
 import { ComponentProps } from '../component-props/_component-common';
 
 export interface FragmentPageProps extends ContentCommonProps {
-    __typename: ContentType.Fragment;
+    type: ContentType.Fragment;
     fragment: ComponentProps;
 }

--- a/src/types/content-props/global-values-props.ts
+++ b/src/types/content-props/global-values-props.ts
@@ -30,12 +30,12 @@ export type GlobalValuesData = {
 };
 
 export type GlobalCaseTimeSetProps = ContentCommonProps & {
-    __typename: ContentType.GlobalCaseTimeSet;
+    type: ContentType.GlobalCaseTimeSet;
     data: GlobalCaseTimeSetData;
 };
 
 export type GlobalNumberValuesSetProps = ContentCommonProps & {
-    __typename: ContentType.GlobalNumberValuesSet;
+    type: ContentType.GlobalNumberValuesSet;
     data: GlobalValuesData;
 };
 

--- a/src/types/content-props/index-pages-props.ts
+++ b/src/types/content-props/index-pages-props.ts
@@ -19,7 +19,7 @@ export type FrontPageData = {
 } & CommonData;
 
 export interface FrontPageProps extends ContentCommonProps {
-    __typename: ContentType.FrontPage;
+    type: ContentType.FrontPage;
     data: FrontPageData;
     page: IndexPageProps;
 }
@@ -31,7 +31,7 @@ export type AreaPageData = {
 } & CommonData;
 
 export interface AreaPageProps extends ContentCommonProps {
-    __typename: ContentType.AreaPage;
+    type: ContentType.AreaPage;
     data: AreaPageData;
     page: IndexPageProps;
 }

--- a/src/types/content-props/internal-link-props.ts
+++ b/src/types/content-props/internal-link-props.ts
@@ -10,6 +10,6 @@ export type InternalLinkData = {
 };
 
 export interface InternalLinkProps extends ContentCommonProps {
-    __typename: ContentType.InternalLink;
+    type: ContentType.InternalLink;
     data: InternalLinkData;
 }

--- a/src/types/content-props/large-table-props.ts
+++ b/src/types/content-props/large-table-props.ts
@@ -6,6 +6,6 @@ export type LargeTableData = {
 };
 
 export interface LargeTableProps extends ContentCommonProps {
-    __typename: ContentType.LargeTable;
+    type: ContentType.LargeTable;
     data: LargeTableData;
 }

--- a/src/types/content-props/main-article-chapter-props.ts
+++ b/src/types/content-props/main-article-chapter-props.ts
@@ -25,7 +25,7 @@ type ParentProps = {
 } & ContentProps;
 
 export interface MainArticleChapterProps extends ContentCommonProps {
-    __typename: ContentType.MainArticleChapter;
+    type: ContentType.MainArticleChapter;
     parent: ParentProps;
     data: MainArticleChapterData;
 }

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -31,6 +31,6 @@ export type MainArticleData = Partial<{
 }>;
 
 export interface MainArticleProps extends ContentCommonProps {
-    __typename: ContentType.MainArticle;
+    type: ContentType.MainArticle;
     data: MainArticleData;
 }

--- a/src/types/content-props/office-information-props.ts
+++ b/src/types/content-props/office-information-props.ts
@@ -66,6 +66,6 @@ export type OfficeInformationData = {
 };
 
 export interface OfficeInformationProps extends ContentCommonProps {
-    __typename: ContentType.OfficeInformation;
+    type: ContentType.OfficeInformation;
     data: OfficeInformationData;
 }

--- a/src/types/content-props/page-list-props.ts
+++ b/src/types/content-props/page-list-props.ts
@@ -17,6 +17,6 @@ export type PageListData = Partial<{
 }>;
 
 export interface PageListProps extends ContentCommonProps {
-    __typename: ContentType.PageList;
+    type: ContentType.PageList;
     data: PageListData;
 }

--- a/src/types/content-props/payout-dates.ts
+++ b/src/types/content-props/payout-dates.ts
@@ -20,6 +20,6 @@ export type PayoutDatesData = {
 };
 
 export interface PayoutDatesProps extends ContentCommonProps {
-    __typename: ContentType.PayoutDates;
+    type: ContentType.PayoutDates;
     data: PayoutDatesData;
 }

--- a/src/types/content-props/publishing-calendar-props.ts
+++ b/src/types/content-props/publishing-calendar-props.ts
@@ -1,8 +1,7 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
-export type PublishingCalendarEntryProps
-    = ContentCommonProps & {
-    __typename: ContentType.PublishingCalendarEntry;
+export type PublishingCalendarEntryProps = ContentCommonProps & {
+    type: ContentType.PublishingCalendarEntry;
     displayName: string;
     data: {
         date: string;
@@ -15,7 +14,7 @@ export type PublishingCalendarData = Partial<{
 }>;
 
 export interface PublishingCalendarProps extends ContentCommonProps {
-    __typename: ContentType.PublishingCalendar;
+    type: ContentType.PublishingCalendar;
     children: PublishingCalendarEntryProps[];
     data: PublishingCalendarData;
 }

--- a/src/types/content-props/section-page-props.ts
+++ b/src/types/content-props/section-page-props.ts
@@ -19,6 +19,6 @@ export type SectionPageData = Partial<{
 }>;
 
 export interface SectionPageProps extends ContentCommonProps {
-    __typename: ContentType.SectionPage;
+    type: ContentType.SectionPage;
     data: SectionPageData;
 }

--- a/src/types/content-props/site-props.ts
+++ b/src/types/content-props/site-props.ts
@@ -1,5 +1,5 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
 export interface SiteProps extends ContentCommonProps {
-    __typename: ContentType.Site;
+    type: ContentType.Site;
 }

--- a/src/types/content-props/template-props.ts
+++ b/src/types/content-props/template-props.ts
@@ -1,5 +1,8 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
 export interface TemplateProps extends ContentCommonProps {
-    __typename: ContentType.TemplatePage;
+    type: ContentType.TemplatePage;
+    data: {
+        supports?: ContentType[];
+    };
 }

--- a/src/types/content-props/transport-page-props.ts
+++ b/src/types/content-props/transport-page-props.ts
@@ -7,6 +7,6 @@ export type TransportPageData = Partial<{
 }>;
 
 export interface TransportPageProps extends ContentCommonProps {
-    __typename: ContentType.TransportPage;
+    type: ContentType.TransportPage;
     data: TransportPageData;
 }

--- a/src/types/content-props/url-props.ts
+++ b/src/types/content-props/url-props.ts
@@ -5,6 +5,6 @@ export type UrlData = {
 };
 
 export interface UrlProps extends ContentCommonProps {
-    __typename: ContentType.Url;
+    type: ContentType.Url;
     data: UrlData;
 }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -18,17 +18,17 @@ export enum MediaType {
 }
 
 export type MediaProps = {
-    __typename: MediaType;
+    type: MediaType;
     mediaUrl: string;
 } & ContentAndMediaCommonProps;
 
 export type VectorImage = {
-    __typename: MediaType.Vector;
+    type: MediaType.Vector;
     mediaUrl?: string;
 };
 
 export type BitmapImage = {
-    __typename: MediaType.Image;
+    type: MediaType.Image;
     imageUrl?: string;
     mediaUrl?: string;
     imageInfo?: {
@@ -43,4 +43,4 @@ export type XpImageProps = VectorImage | BitmapImage;
 export const isMediaContent = (
     content: XpResponseProps
 ): content is MediaProps =>
-    Object.values(MediaType).includes(content.__typename as MediaType);
+    Object.values(MediaType).includes(content.type as MediaType);

--- a/src/utils/appearance.ts
+++ b/src/utils/appearance.ts
@@ -6,8 +6,8 @@ export const hasWhiteBackground = (content: ContentProps) => {
         ContentType.MainArticle,
     ];
 
-    if (content.__typename === ContentType.MainArticle) {
+    if (content.type === ContentType.MainArticle) {
         return content.data.contentType !== 'lastingContent';
     }
-    return contentTypeWithWhiteBackground.includes(content.__typename);
+    return contentTypeWithWhiteBackground.includes(content.type);
 };

--- a/src/utils/decorator/decorator-utils.ts
+++ b/src/utils/decorator/decorator-utils.ts
@@ -77,7 +77,7 @@ const taSurveys = {
 };
 
 export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
-    if (!content || content.__typename === ContentType.Error) {
+    if (!content || content.type === ContentType.Error) {
         return errorParams(content);
     }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,12 +10,11 @@ export const logPageLoadError = (errorId: string, message: string) =>
     console.error(`[Page load error] ${errorId} - ${stripLineBreaks(message)}`);
 
 const isEmptyMainArticleChapter = (content: ContentProps) =>
-    content.__typename === ContentType.MainArticleChapter &&
-    !content.data?.article;
+    content.type === ContentType.MainArticleChapter && !content.data?.article;
 
 export const isNotFound = (content: ContentProps) => {
     return (
-        (content.__typename === ContentType.Error &&
+        (content.type === ContentType.Error &&
             content.data.errorCode === 404) ||
         !isContentTypeImplemented(content) ||
         isEmptyMainArticleChapter(content)

--- a/src/utils/fetch/fetch-content.ts
+++ b/src/utils/fetch/fetch-content.ts
@@ -196,7 +196,7 @@ export const fetchPage = async ({
         locale,
     });
 
-    if (!content?.__typename) {
+    if (!content?.type) {
         const errorId = uuid();
         logPageLoadError(
             errorId,

--- a/src/utils/fetch/fetch-page-props.ts
+++ b/src/utils/fetch/fetch-page-props.ts
@@ -81,7 +81,7 @@ export const fetchPageProps = async ({
         };
     }
 
-    if (content.__typename === ContentType.Error) {
+    if (content.type === ContentType.Error) {
         return errorHandler(content);
     }
 

--- a/src/utils/links-from-content.ts
+++ b/src/utils/links-from-content.ts
@@ -29,12 +29,12 @@ export const getUrlFromContent = (content: ContentProps) => {
     if (!content) {
         return '';
     }
-    if (content.__typename === ContentType.InternalLink) {
+    if (content.type === ContentType.InternalLink) {
         return getInternalLinkUrl(content.data);
     }
     if (
-        content.__typename === ContentType.ExternalLink ||
-        content.__typename === ContentType.Url
+        content.type === ContentType.ExternalLink ||
+        content.type === ContentType.Url
     ) {
         return content.data?.url;
     }

--- a/src/utils/make-error-props.ts
+++ b/src/utils/make-error-props.ts
@@ -36,7 +36,7 @@ export const makeErrorProps = (
     const time = Date.now().toString();
 
     return {
-        __typename: ContentType.Error,
+        type: ContentType.Error,
         _path: idOrPath,
         _id: idOrPath,
         displayName: title,

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -25,7 +25,7 @@ const getTargetPath = (contentData: ContentProps) => {
         return contentData.isDraft ? null : contentData.data.externalProductUrl;
     }
 
-    switch (contentData?.__typename) {
+    switch (contentData?.type) {
         case ContentType.InternalLink:
             return getInternalLinkUrl(contentData.data);
         case ContentType.ExternalLink:
@@ -35,8 +35,7 @@ const getTargetPath = (contentData: ContentProps) => {
             // If the main article chapter content is anything other than a main article
             // we want to redirect to the actual content page. This is provided as a way
             // to gradually migrate individual pages from the chapter structure
-            return contentData.data.article.__typename !==
-                ContentType.MainArticle
+            return contentData.data.article.type !== ContentType.MainArticle
                 ? contentData.data.article._path
                 : null;
         default:
@@ -45,7 +44,7 @@ const getTargetPath = (contentData: ContentProps) => {
 };
 
 export const isRedirectType = (content: ContentProps) =>
-    redirectTypes[content.__typename];
+    redirectTypes[content.type];
 
 export const getTargetIfRedirect = (contentData: ContentProps) => {
     const targetPath = getTargetPath(contentData);
@@ -68,8 +67,8 @@ export const redirectPageProps = (
 
 export const isPermanentRedirect = (content: ContentProps) => {
     if (
-        content.__typename === ContentType.InternalLink ||
-        content.__typename === ContentType.ExternalLink
+        content.type === ContentType.InternalLink ||
+        content.type === ContentType.ExternalLink
     ) {
         return content.data.permanentRedirect;
     }


### PR DESCRIPTION
Denne må prodsettes først: https://github.com/navikt/nav-enonicxp/pull/1627

## Testing
Testet lokalt

## Oppsummering av hva som er gjort
- Fikser visning av page templates (sjekker `supports` feltet for innholdstype på template'et)
- Fikser en gammel synd, der jeg brukte graphql-feltet `__typename` for content-typer, istedenfor `type`-feltet som egentlig brukes av Enonic.