### PR TITLE
Oppgraderer til typescript 4.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
                 "prettier": "2.8.2",
                 "sass": "1.57.1",
                 "ts-jest": "29.0.3",
-                "typescript": "4.8.4",
+                "typescript": "4.9.5",
                 "typescript-plugin-css-modules": "3.4.0"
             }
         },
@@ -12896,9 +12896,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -23103,9 +23103,9 @@
             "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ=="
         },
         "typescript": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "typescript-plugin-css-modules": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "prettier": "2.8.2",
         "sass": "1.57.1",
         "ts-jest": "29.0.3",
-        "typescript": "4.8.4",
+        "typescript": "4.9.5",
         "typescript-plugin-css-modules": "3.4.0"
     },
     "browserslist": {

--- a/src/types/content-props/contact-information-props.ts
+++ b/src/types/content-props/contact-information-props.ts
@@ -13,7 +13,7 @@ export interface ContactInformationData {
     };
 }
 
-export interface ContactInformationProps extends ContentCommonProps {
+export type ContactInformationProps = ContentCommonProps & {
     type: ContentType.ContactInformationPage;
     data: ContactInformationData;
-}
+};

--- a/src/types/content-props/content-list-props.ts
+++ b/src/types/content-props/content-list-props.ts
@@ -10,7 +10,7 @@ export type ContentListData = Partial<{
     sortedBy?: DateTimeKey;
 }>;
 
-export interface ContentListProps extends ContentCommonProps {
+export type ContentListProps = ContentCommonProps & {
     type: ContentType.ContentList;
     data: ContentListData;
-}
+};

--- a/src/types/content-props/error-props.ts
+++ b/src/types/content-props/error-props.ts
@@ -8,7 +8,7 @@ export type ErrorData = {
     feedback?: boolean;
 };
 
-export interface ErrorProps extends ContentCommonProps {
+export type ErrorProps = ContentCommonProps & {
     type: ContentType.Error;
     data: ErrorData;
-}
+};

--- a/src/types/content-props/external-link-props.ts
+++ b/src/types/content-props/external-link-props.ts
@@ -6,7 +6,7 @@ export type ExternalLinkData = {
     permanentRedirect?: boolean;
 };
 
-export interface ExternalLinkProps extends ContentCommonProps {
+export type ExternalLinkProps = ContentCommonProps & {
     type: ContentType.ExternalLink;
     data: ExternalLinkData;
-}
+};

--- a/src/types/content-props/fragment-page-props.ts
+++ b/src/types/content-props/fragment-page-props.ts
@@ -1,7 +1,7 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 import { ComponentProps } from '../component-props/_component-common';
 
-export interface FragmentPageProps extends ContentCommonProps {
+export type FragmentPageProps = ContentCommonProps & {
     type: ContentType.Fragment;
     fragment: ComponentProps;
-}
+};

--- a/src/types/content-props/index-pages-props.ts
+++ b/src/types/content-props/index-pages-props.ts
@@ -18,11 +18,11 @@ export type FrontPageData = {
     areasHeader: string;
 } & CommonData;
 
-export interface FrontPageProps extends ContentCommonProps {
+export type FrontPageProps = ContentCommonProps & {
     type: ContentType.FrontPage;
     data: FrontPageData;
     page: IndexPageProps;
-}
+};
 
 export type AreaPageData = {
     area: Area;
@@ -30,8 +30,8 @@ export type AreaPageData = {
     banner: { link: LinkSelectable; html: ProcessedHtmlProps } & ColorMixin;
 } & CommonData;
 
-export interface AreaPageProps extends ContentCommonProps {
+export type AreaPageProps = ContentCommonProps & {
     type: ContentType.AreaPage;
     data: AreaPageData;
     page: IndexPageProps;
-}
+};

--- a/src/types/content-props/internal-link-props.ts
+++ b/src/types/content-props/internal-link-props.ts
@@ -9,7 +9,7 @@ export type InternalLinkData = {
     anchorId?: string;
 };
 
-export interface InternalLinkProps extends ContentCommonProps {
+export type InternalLinkProps = ContentCommonProps & {
     type: ContentType.InternalLink;
     data: InternalLinkData;
-}
+};

--- a/src/types/content-props/large-table-props.ts
+++ b/src/types/content-props/large-table-props.ts
@@ -5,7 +5,7 @@ export type LargeTableData = {
     text?: ProcessedHtmlProps;
 };
 
-export interface LargeTableProps extends ContentCommonProps {
+export type LargeTableProps = ContentCommonProps & {
     type: ContentType.LargeTable;
     data: LargeTableData;
-}
+};

--- a/src/types/content-props/main-article-chapter-props.ts
+++ b/src/types/content-props/main-article-chapter-props.ts
@@ -24,8 +24,8 @@ type ParentProps = {
     };
 } & ContentProps;
 
-export interface MainArticleChapterProps extends ContentCommonProps {
+export type MainArticleChapterProps = ContentCommonProps & {
     type: ContentType.MainArticleChapter;
     parent: ParentProps;
     data: MainArticleChapterData;
-}
+};

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -30,7 +30,7 @@ export type MainArticleData = Partial<{
     chapters: MainArticleChapterNavigationData[];
 }>;
 
-export interface MainArticleProps extends ContentCommonProps {
+export type MainArticleProps = ContentCommonProps & {
     type: ContentType.MainArticle;
     data: MainArticleData;
-}
+};

--- a/src/types/content-props/office-information-props.ts
+++ b/src/types/content-props/office-information-props.ts
@@ -65,7 +65,7 @@ export type OfficeInformationData = {
     kontaktinformasjon: ContactInfo;
 };
 
-export interface OfficeInformationProps extends ContentCommonProps {
+export type OfficeInformationProps = ContentCommonProps & {
     type: ContentType.OfficeInformation;
     data: OfficeInformationData;
-}
+};

--- a/src/types/content-props/page-list-props.ts
+++ b/src/types/content-props/page-list-props.ts
@@ -16,7 +16,7 @@ export type PageListData = Partial<{
     menuListItems: MenuListItems;
 }>;
 
-export interface PageListProps extends ContentCommonProps {
+export type PageListProps = ContentCommonProps & {
     type: ContentType.PageList;
     data: PageListData;
-}
+};

--- a/src/types/content-props/payout-dates.ts
+++ b/src/types/content-props/payout-dates.ts
@@ -19,7 +19,7 @@ export type PayoutDatesData = {
     dates: Record<Month, number>;
 };
 
-export interface PayoutDatesProps extends ContentCommonProps {
+export type PayoutDatesProps = ContentCommonProps & {
     type: ContentType.PayoutDates;
     data: PayoutDatesData;
-}
+};

--- a/src/types/content-props/publishing-calendar-props.ts
+++ b/src/types/content-props/publishing-calendar-props.ts
@@ -13,8 +13,8 @@ export type PublishingCalendarData = Partial<{
     ingress: string;
 }>;
 
-export interface PublishingCalendarProps extends ContentCommonProps {
+export type PublishingCalendarProps = ContentCommonProps & {
     type: ContentType.PublishingCalendar;
     children: PublishingCalendarEntryProps[];
     data: PublishingCalendarData;
-}
+};

--- a/src/types/content-props/section-page-props.ts
+++ b/src/types/content-props/section-page-props.ts
@@ -18,7 +18,7 @@ export type SectionPageData = Partial<{
     languages: LanguageProps[];
 }>;
 
-export interface SectionPageProps extends ContentCommonProps {
+export type SectionPageProps = ContentCommonProps & {
     type: ContentType.SectionPage;
     data: SectionPageData;
-}
+};

--- a/src/types/content-props/site-props.ts
+++ b/src/types/content-props/site-props.ts
@@ -1,5 +1,5 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
-export interface SiteProps extends ContentCommonProps {
+export type SiteProps = ContentCommonProps & {
     type: ContentType.Site;
-}
+};

--- a/src/types/content-props/template-props.ts
+++ b/src/types/content-props/template-props.ts
@@ -1,8 +1,8 @@
 import { ContentType, ContentCommonProps } from './_content-common';
 
-export interface TemplateProps extends ContentCommonProps {
+export type TemplateProps = ContentCommonProps & {
     type: ContentType.TemplatePage;
     data: {
         supports?: ContentType[];
     };
-}
+};

--- a/src/types/content-props/transport-page-props.ts
+++ b/src/types/content-props/transport-page-props.ts
@@ -6,7 +6,7 @@ export type TransportPageData = Partial<{
     items: LinkPanel[];
 }>;
 
-export interface TransportPageProps extends ContentCommonProps {
+export type TransportPageProps = ContentCommonProps & {
     type: ContentType.TransportPage;
     data: TransportPageData;
-}
+};

--- a/src/types/content-props/url-props.ts
+++ b/src/types/content-props/url-props.ts
@@ -1,4 +1,3 @@
-import { type } from 'os';
 import { ContentType, ContentCommonProps } from './_content-common';
 
 export type UrlData = {

--- a/src/types/content-props/url-props.ts
+++ b/src/types/content-props/url-props.ts
@@ -1,10 +1,11 @@
+import { type } from 'os';
 import { ContentType, ContentCommonProps } from './_content-common';
 
 export type UrlData = {
     url: string;
 };
 
-export interface UrlProps extends ContentCommonProps {
+export type UrlProps = ContentCommonProps & {
     type: ContentType.Url;
     data: UrlData;
-}
+};


### PR DESCRIPTION
## Testing

-   [x] Har testet selv i dev (evt q6)
-   [ ] Har blitt testet ekstra av noen andre, feks redaktører

## Oppsummering av hva som er gjort
- Oppgraderer til 4.9.5
- Endrer fra interface til type for å kunne gjøre en intersection. Fra ts 4.9.4 har regler for extend blitt enforcet i større grad hvis nøstede objekter ikke matcher. 
