### PR TITLE
Fikser feil når filtermenyen er tom.

### DIFF
--- a/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/src/components/_common/filtered-content/FilteredContent.tsx
@@ -20,6 +20,10 @@ export const FilteredContent = ({ filters, children }: Props) => {
         return <>{children}</>;
     }
 
+    if (filters && availableFilters.length === 0) {
+        return <>{children}</>;
+    }
+
     // If no filters are set for a catetory that this part "belongs to"
     // the part should display as default. To achieve this, we need to find out
     // which categories the part belongs to in the first place.

--- a/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/src/components/_common/filtered-content/FilteredContent.tsx
@@ -20,6 +20,8 @@ export const FilteredContent = ({ filters, children }: Props) => {
         return <>{children}</>;
     }
 
+    // The component has filters set, but no actuals filters are available for the page.
+    // This case is an invalid state, so just show the component.
     if (filters && availableFilters.length === 0) {
         return <>{children}</>;
     }

--- a/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/src/components/_common/filtered-content/FilteredContent.tsx
@@ -22,7 +22,7 @@ export const FilteredContent = ({ filters, children }: Props) => {
 
     // The component has filters set, but no actuals filters are available for the page.
     // This case is an invalid state, so just show the component.
-    if (filters && availableFilters.length === 0) {
+    if (availableFilters.length === 0) {
         return <>{children}</>;
     }
 

--- a/src/components/parts/filters-menu/FiltersMenu.tsx
+++ b/src/components/parts/filters-menu/FiltersMenu.tsx
@@ -78,7 +78,12 @@ export const FiltersMenu = ({ config, path, pageProps }: FilterMenuProps) => {
 
     // Will only show if editor didn't add any actual filters in the FiltersMenu part.
     if (!config?.categories) {
-        return <div>{'Det mangler filtre i denne listen.'}</div>;
+        return (
+            <EditorHelp
+                type="error"
+                text="Det er ikke lagt til noen filtere i denne filtermenyen!"
+            />
+        );
     }
 
     const defaultExpandableTitle = getLabel('customizeContent');

--- a/src/store/hooks/useFilteredContent.ts
+++ b/src/store/hooks/useFilteredContent.ts
@@ -44,11 +44,12 @@ export const useFilterState = (): UseFilterState => {
         selectedFiltersAtPage(state, pageId)
     );
 
-    const setAvailableFilters = (newAvailableFilters: Category[] = []) => {
-        const payload = { pageId, availableFilters: newAvailableFilters };
-        if (newAvailableFilters.length > 0) {
-            dispatch(setAvailableFiltersAction(payload));
+    const setAvailableFilters = (filters: Category[]) => {
+        if (!filters) {
+            return;
         }
+        const payload = { pageId, availableFilters: filters };
+        dispatch(setAvailableFiltersAction(payload));
     };
 
     const toggleFilter = (filterId: string): void => {

--- a/src/store/hooks/useFilteredContent.ts
+++ b/src/store/hooks/useFilteredContent.ts
@@ -44,9 +44,11 @@ export const useFilterState = (): UseFilterState => {
         selectedFiltersAtPage(state, pageId)
     );
 
-    const setAvailableFilters = (availableFilters: Category[]) => {
-        const payload = { pageId, availableFilters };
-        dispatch(setAvailableFiltersAction(payload));
+    const setAvailableFilters = (newAvailableFilters: Category[] = []) => {
+        const payload = { pageId, availableFilters: newAvailableFilters };
+        if (newAvailableFilters.length > 0) {
+            dispatch(setAvailableFiltersAction(payload));
+        }
     };
 
     const toggleFilter = (filterId: string): void => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fikser krasj når man har sletter filtermenyen og lagt inn på nytt. Usikker på hvorfor denne ikke er fanget opp tidligere.

## Testing
Har testet i dev.
