### PR TITLE
Fikser inkonsistent content state i CS

### DIFF
--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
@@ -19,6 +19,8 @@ import style from './AutoRefreshDisableHack.module.scss';
  * When external changes are detected, we show an alert-box which notifies of changes having occured, and offer a
  * manual reload option instead.
  *
+ * Note: This is very scary and may break things! :D
+ *
  * */
 
 type Props = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner noe funksjonalitet fra auto-reload-disable hack'en, som førte til inkonsistente data ved bruk av editoren i enkelte edge-cases. Dette kunne skje dersom innhold ble endret programmatisk med `nodeLib.repoConnection.modify` i XP.

XP 7.12.0 reduserer mengden auto-reloads i komponent-editoren slik at denne hack'en uansett vil ha mindre verdi, når vi får oppgradert til denne versjonen.

Beholder funksjonalitet for å hindre auto-reload når andre redaktører gjør endringer. Denne er litt mindre skummel ettersom en da får en eksplisitt beskjed om at state er endret og en reload kreves.

## Testing
Testet lokalt

