### PR TITLE
Hack for å reversere default-valg for publisering av avhengigheter

### DIFF
--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -3,7 +3,7 @@ import { AutoReloadDisableHack } from './auto-refresh-disable/AutoReloadDisableH
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
 import { TogglePublishDependencies } from 'components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies';
-import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/utils';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
 import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users

--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -1,13 +1,10 @@
 import { ContentProps } from 'types/content-props/_content-common';
 import { AutoReloadDisableHack } from './auto-refresh-disable/AutoReloadDisableHack';
-import {
-    EditorFeature,
-    isEditorFeatureEnabled,
-} from '../site-info/feature-toggles/utils';
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
-import { editorFeatures } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 import { TogglePublishDependencies } from 'components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/utils';
+import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users
 
@@ -28,14 +25,14 @@ export const EditorHacks = ({ content }: Props) => {
                 <>
                     <AutoReloadDisableHack content={content} />
                     <CustomSelectorLinkTargetHack />
-                    {isEditorFeatureEnabled(
-                        editorFeatures[EditorFeature.HideLeftPanel]
-                    ) && <SetSidepanelToggleHack contentId={_id} />}
+                    {isEditorFeatureEnabled(EditorFeature.HideLeftPanel) && (
+                        <SetSidepanelToggleHack contentId={_id} />
+                    )}
                 </>
             )}
             {(editorView === 'edit' || editorView === 'inline') &&
                 isEditorFeatureEnabled(
-                    editorFeatures[EditorFeature.UncheckDependenciesPublish]
+                    EditorFeature.UncheckDependenciesPublish
                 ) && <TogglePublishDependencies />}
         </>
     );

--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -1,11 +1,13 @@
-import { ContentProps } from '../../../types/content-props/_content-common';
+import { ContentProps } from 'types/content-props/_content-common';
 import { AutoReloadDisableHack } from './auto-refresh-disable/AutoReloadDisableHack';
 import {
-    EditorFeatureCookie,
+    EditorFeature,
     isEditorFeatureEnabled,
 } from '../site-info/feature-toggles/utils';
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
+import { editorFeatures } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
+import { TogglePublishDependencies } from 'components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users
 
@@ -27,10 +29,14 @@ export const EditorHacks = ({ content }: Props) => {
                     <AutoReloadDisableHack content={content} />
                     <CustomSelectorLinkTargetHack />
                     {isEditorFeatureEnabled(
-                        EditorFeatureCookie.HideLeftPanel
+                        editorFeatures[EditorFeature.HideLeftPanel]
                     ) && <SetSidepanelToggleHack contentId={_id} />}
                 </>
             )}
+            {(editorView === 'edit' || editorView === 'inline') &&
+                isEditorFeatureEnabled(
+                    editorFeatures[EditorFeature.UncheckDependenciesPublish]
+                ) && <TogglePublishDependencies />}
         </>
     );
 };

--- a/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
+++ b/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
@@ -8,10 +8,11 @@ const DIALOG_CONTAINER_CLASS = 'dialog-container';
 const PUBLISH_DIALOG_ID = 'ContentPublishDialog';
 const DEPENDANTS_CONTROLS_CLASS = 'dependants-controls';
 
-const DID_TOGGLE_FLAG = 'did-toggle';
 const ALL_DEPENDANTS_CHECKBOX_SELECTOR = `#${PUBLISH_DIALOG_ID} .${DEPENDANTS_CONTROLS_CLASS} input[type="checkbox"]`;
 
-const uncheckPublishAll = () => {
+const TOGGLE_FLAG = 'did-toggle-all';
+
+const uncheckPublishAllDependants = () => {
     const dialogContainer = parent.window.document.getElementsByClassName(
         DIALOG_CONTAINER_CLASS
     )[0];
@@ -32,35 +33,40 @@ const uncheckPublishAll = () => {
 
     if (
         allDependantsCheckbox.checked &&
-        !dialogContainer.classList.contains(DID_TOGGLE_FLAG)
+        !dialogContainer.classList.contains(TOGGLE_FLAG)
     ) {
-        dialogContainer.classList.add(DID_TOGGLE_FLAG);
+        dialogContainer.classList.add(TOGGLE_FLAG);
         allDependantsCheckbox.click();
         console.log('Dependants checkbox clicked!');
     }
 };
 
+const isPublishDialogStateResolved = (element: HTMLElement) =>
+    element?.id === 'DialogStateBar' && !element.classList.contains('checking');
+
+const removeToggleFlag = (mutation: MutationRecord) =>
+    mutation.addedNodes.forEach((node: HTMLElement) => {
+        if (node.classList?.contains(DIALOG_CONTAINER_CLASS)) {
+            // Ensure our toggle flag is removed from new dialog containers
+            // Content studio caches dom-elements, so this will persist even when the dialog is closed
+            node.classList.remove(TOGGLE_FLAG);
+        }
+    });
+
+const mutationCallback: MutationCallback = (mutations) => {
+    mutations.forEach((mutation) => {
+        if (isPublishDialogStateResolved(mutation.target as HTMLElement)) {
+            uncheckPublishAllDependants();
+        }
+
+        removeToggleFlag(mutation);
+    });
+};
+
 export const TogglePublishDependencies = () => {
     useEffect(() => {
-        const callback = (mutations) => {
-            mutations.forEach((mutation) => {
-                if (
-                    mutation.target?.id === 'DialogStateBar' &&
-                    !mutation.target.classList.contains('checking')
-                ) {
-                    uncheckPublishAll();
-                }
-                mutation.addedNodes.forEach((node) => {
-                    if (node.classList?.contains(DIALOG_CONTAINER_CLASS)) {
-                        // We set this classname as a flag and use it to ensure we only toggle off the publishing
-                        // dependants once for every new dialog
-                        node.classList.remove(DID_TOGGLE_FLAG);
-                    }
-                });
-            });
-        };
+        const observer = new MutationObserver(mutationCallback);
 
-        const observer = new MutationObserver(callback);
         observer.observe(parent.window.document.body, {
             childList: true,
             subtree: true,

--- a/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
+++ b/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
@@ -22,9 +22,10 @@ const uncheckPublishAllDependants = () => {
         return;
     }
 
-    const allDependantsCheckbox = parent.window.document.querySelector(
-        ALL_DEPENDANTS_CHECKBOX_SELECTOR
-    ) as HTMLInputElement | null;
+    const allDependantsCheckbox =
+        parent.window.document.querySelector<HTMLInputElement>(
+            ALL_DEPENDANTS_CHECKBOX_SELECTOR
+        );
 
     if (!allDependantsCheckbox) {
         console.log('No dependants checkbox found!');

--- a/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
+++ b/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect } from 'react';
 
+/*
+ * Sets the default option for publishing dependencies to off/unchecked
+ * */
+
 const DIALOG_CONTAINER_CLASS = 'dialog-container';
 const PUBLISH_DIALOG_ID = 'ContentPublishDialog';
 const DEPENDANTS_CONTROLS_CLASS = 'dependants-controls';
@@ -8,9 +12,14 @@ const DID_TOGGLE_FLAG = 'did-toggle';
 const ALL_DEPENDANTS_CHECKBOX_SELECTOR = `#${PUBLISH_DIALOG_ID} .${DEPENDANTS_CONTROLS_CLASS} input[type="checkbox"]`;
 
 const uncheckPublishAll = () => {
-    const dialogContainer = parent.window.document.querySelector(
-        `.${DIALOG_CONTAINER_CLASS}`
-    );
+    const dialogContainer = parent.window.document.getElementsByClassName(
+        DIALOG_CONTAINER_CLASS
+    )[0];
+
+    if (!dialogContainer) {
+        console.log('No dialog container found!');
+        return;
+    }
 
     const allDependantsCheckbox = parent.window.document.querySelector(
         ALL_DEPENDANTS_CHECKBOX_SELECTOR
@@ -39,7 +48,6 @@ export const TogglePublishDependencies = () => {
                     mutation.target?.id === 'DialogStateBar' &&
                     !mutation.target.classList.contains('checking')
                 ) {
-                    console.log(mutation);
                     uncheckPublishAll();
                 }
                 mutation.addedNodes.forEach((node) => {
@@ -58,8 +66,6 @@ export const TogglePublishDependencies = () => {
             subtree: true,
             attributeFilter: ['class'],
         });
-
-        console.log('Added observer');
 
         return () => observer.disconnect();
     }, []);

--- a/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
+++ b/src/components/_editor-only/editor-hacks/toggle-publish-dependencies/TogglePublishDependencies.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react';
+
+const DIALOG_CONTAINER_CLASS = 'dialog-container';
+const PUBLISH_DIALOG_ID = 'ContentPublishDialog';
+const DEPENDANTS_CONTROLS_CLASS = 'dependants-controls';
+
+const DID_TOGGLE_FLAG = 'did-toggle';
+const ALL_DEPENDANTS_CHECKBOX_SELECTOR = `#${PUBLISH_DIALOG_ID} .${DEPENDANTS_CONTROLS_CLASS} input[type="checkbox"]`;
+
+const uncheckPublishAll = () => {
+    const dialogContainer = parent.window.document.querySelector(
+        `.${DIALOG_CONTAINER_CLASS}`
+    );
+
+    const allDependantsCheckbox = parent.window.document.querySelector(
+        ALL_DEPENDANTS_CHECKBOX_SELECTOR
+    ) as HTMLInputElement | null;
+
+    if (!allDependantsCheckbox) {
+        console.log('No dependants checkbox found!');
+        return;
+    }
+
+    if (
+        allDependantsCheckbox.checked &&
+        !dialogContainer.classList.contains(DID_TOGGLE_FLAG)
+    ) {
+        dialogContainer.classList.add(DID_TOGGLE_FLAG);
+        allDependantsCheckbox.click();
+        console.log('Dependants checkbox clicked!');
+    }
+};
+
+export const TogglePublishDependencies = () => {
+    useEffect(() => {
+        const callback = (mutations) => {
+            mutations.forEach((mutation) => {
+                if (
+                    mutation.target?.id === 'DialogStateBar' &&
+                    !mutation.target.classList.contains('checking')
+                ) {
+                    console.log(mutation);
+                    uncheckPublishAll();
+                }
+                mutation.addedNodes.forEach((node) => {
+                    if (node.classList?.contains(DIALOG_CONTAINER_CLASS)) {
+                        // We set this classname as a flag and use it to ensure we only toggle off the publishing
+                        // dependants once for every new dialog
+                        node.classList.remove(DID_TOGGLE_FLAG);
+                    }
+                });
+            });
+        };
+
+        const observer = new MutationObserver(callback);
+        observer.observe(parent.window.document.body, {
+            childList: true,
+            subtree: true,
+            attributeFilter: ['class'],
+        });
+
+        console.log('Added observer');
+
+        return () => observer.disconnect();
+    }, []);
+
+    return null;
+};

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -27,8 +27,8 @@ export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
     [EditorFeature.UncheckDependenciesPublish]: {
         key: EditorFeature.UncheckDependenciesPublish,
         description:
-            'Setter standard-valget for publisering av avhengigheter til av',
-        defaultValue: true,
+            'Reverserer standard-valget for publisering av avhengigheter (ingen avhengigheter publiseres)',
+        defaultValue: process.env.ENV !== 'prod',
     },
 };
 

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {
-    EditorFeature,
-    isEditorFeatureEnabled,
-    setEditorFeatureToggle,
-} from './utils';
+import { isEditorFeatureEnabled, setEditorFeatureToggle } from './utils';
 import { Checkbox } from '@navikt/ds-react';
 import { SiteInfoSubHeader } from '../_common/sub-header/SiteInfoSubHeader';
+
+export enum EditorFeature {
+    HideLeftPanel = 'hide-left-panel',
+    UncheckDependenciesPublish = 'uncheck-dependencies-publish',
+}
 
 export type EditorFeatureProps = {
     cookie: EditorFeature;
@@ -22,7 +23,8 @@ export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
     },
     [EditorFeature.UncheckDependenciesPublish]: {
         cookie: EditorFeature.UncheckDependenciesPublish,
-        description: 'Slår av publisering av referanser som standard-valg',
+        description:
+            'Setter standard-valget for publisering av avhengigheter til av',
         defaultValue: true,
     },
 };
@@ -38,7 +40,7 @@ export const SiteInfoFeatureToggles = () => {
                     <Checkbox
                         size={'small'}
                         key={cookie}
-                        defaultChecked={isEditorFeatureEnabled(feature)}
+                        defaultChecked={isEditorFeatureEnabled(cookie)}
                         onClick={(e) => {
                             setEditorFeatureToggle(
                                 cookie,

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { isEditorFeatureEnabled, setEditorFeatureToggle } from './utils';
+import {
+    isEditorFeatureEnabled,
+    setEditorFeatureToggle,
+} from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
 import { Checkbox } from '@navikt/ds-react';
 import { SiteInfoSubHeader } from '../_common/sub-header/SiteInfoSubHeader';
 
@@ -9,20 +12,20 @@ export enum EditorFeature {
 }
 
 export type EditorFeatureProps = {
-    cookie: EditorFeature;
+    key: EditorFeature;
     description: string;
     defaultValue: boolean;
 };
 
 export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
     [EditorFeature.HideLeftPanel]: {
-        cookie: EditorFeature.HideLeftPanel,
+        key: EditorFeature.HideLeftPanel,
         description:
             'Skjuler venstre-panelet i editoren som standard på komponent-baserte sider',
         defaultValue: false,
     },
     [EditorFeature.UncheckDependenciesPublish]: {
-        cookie: EditorFeature.UncheckDependenciesPublish,
+        key: EditorFeature.UncheckDependenciesPublish,
         description:
             'Setter standard-valget for publisering av avhengigheter til av',
         defaultValue: true,
@@ -34,16 +37,16 @@ export const SiteInfoFeatureToggles = () => {
         <div>
             <SiteInfoSubHeader text={'Eksperimentell funksjonalitet'} />
             {Object.values(editorFeatures).map((feature) => {
-                const { description, cookie } = feature;
+                const { description, key } = feature;
 
                 return (
                     <Checkbox
                         size={'small'}
-                        key={cookie}
-                        defaultChecked={isEditorFeatureEnabled(cookie)}
+                        key={key}
+                        defaultChecked={isEditorFeatureEnabled(key)}
                         onClick={(e) => {
                             setEditorFeatureToggle(
-                                cookie,
+                                key,
                                 e.currentTarget.checked
                             );
                         }}

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -1,30 +1,44 @@
 import React from 'react';
 import {
-    EditorFeatureCookie,
+    EditorFeature,
     isEditorFeatureEnabled,
     setEditorFeatureToggle,
 } from './utils';
 import { Checkbox } from '@navikt/ds-react';
 import { SiteInfoSubHeader } from '../_common/sub-header/SiteInfoSubHeader';
 
-const featureProps = [
-    {
-        cookie: EditorFeatureCookie.HideLeftPanel,
+export type EditorFeatureProps = {
+    cookie: EditorFeature;
+    description: string;
+    defaultValue: boolean;
+};
+
+export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
+    [EditorFeature.HideLeftPanel]: {
+        cookie: EditorFeature.HideLeftPanel,
         description:
             'Skjuler venstre-panelet i editoren som standard på komponent-baserte sider',
+        defaultValue: false,
     },
-];
+    [EditorFeature.UncheckDependenciesPublish]: {
+        cookie: EditorFeature.UncheckDependenciesPublish,
+        description: 'Slår av publisering av referanser som standard-valg',
+        defaultValue: true,
+    },
+};
 
 export const SiteInfoFeatureToggles = () => {
     return (
         <div>
             <SiteInfoSubHeader text={'Eksperimentell funksjonalitet'} />
-            {featureProps.map(({ cookie, description }) => {
+            {Object.values(editorFeatures).map((feature) => {
+                const { description, cookie } = feature;
+
                 return (
                     <Checkbox
                         size={'small'}
                         key={cookie}
-                        defaultChecked={isEditorFeatureEnabled(cookie)}
+                        defaultChecked={isEditorFeatureEnabled(feature)}
                         onClick={(e) => {
                             setEditorFeatureToggle(
                                 cookie,

--- a/src/components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils.ts
+++ b/src/components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils.ts
@@ -5,9 +5,9 @@ import {
 } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 export const isEditorFeatureEnabled = (feature: EditorFeature) => {
-    const { cookie, defaultValue } = editorFeatures[feature];
+    const { key, defaultValue } = editorFeatures[feature];
 
-    const cookieValue = Cookie.get(cookie);
+    const cookieValue = Cookie.get(key);
 
     return cookieValue === undefined ? defaultValue : cookieValue === 'true';
 };

--- a/src/components/_editor-only/site-info/feature-toggles/utils.ts
+++ b/src/components/_editor-only/site-info/feature-toggles/utils.ts
@@ -1,24 +1,18 @@
 import Cookie from 'js-cookie';
-import { EditorFeatureProps } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
+import {
+    EditorFeature,
+    editorFeatures,
+} from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
-export enum EditorFeature {
-    HideLeftPanel = 'hide-left-panel',
-    UncheckDependenciesPublish = 'uncheck-dependencies-publish',
-}
+export const isEditorFeatureEnabled = (feature: EditorFeature) => {
+    const { cookie, defaultValue } = editorFeatures[feature];
 
-export const isEditorFeatureEnabled = ({
-    cookie,
-    defaultValue,
-}: EditorFeatureProps) => {
     const cookieValue = Cookie.get(cookie);
+
     return cookieValue === undefined ? defaultValue : cookieValue === 'true';
 };
 
 export const setEditorFeatureToggle = (
     feature: EditorFeature,
     enable: boolean
-) => {
-    Cookie.set(feature, enable, {
-        expires: 365,
-    });
-};
+) => Cookie.set(feature, enable, { expires: 365 });

--- a/src/components/_editor-only/site-info/feature-toggles/utils.ts
+++ b/src/components/_editor-only/site-info/feature-toggles/utils.ts
@@ -1,14 +1,21 @@
 import Cookie from 'js-cookie';
+import { EditorFeatureProps } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
-export enum EditorFeatureCookie {
+export enum EditorFeature {
     HideLeftPanel = 'hide-left-panel',
+    UncheckDependenciesPublish = 'uncheck-dependencies-publish',
 }
 
-export const isEditorFeatureEnabled = (feature: EditorFeatureCookie) =>
-    Cookie.get(feature) === 'true';
+export const isEditorFeatureEnabled = ({
+    cookie,
+    defaultValue,
+}: EditorFeatureProps) => {
+    const cookieValue = Cookie.get(cookie);
+    return cookieValue === undefined ? defaultValue : cookieValue === 'true';
+};
 
 export const setEditorFeatureToggle = (
-    feature: EditorFeatureCookie,
+    feature: EditorFeature,
     enable: boolean
 ) => {
     Cookie.set(feature, enable, {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Content Studio 4.5 har en ny publiseringsdialog, der en kan velge å krysse av for publisering av alle avhengigheter. Default er at alle avhengigheter publiseres, men redaktørene ønsker at default skal være at ingen publiseres. Ønsket spilles inn til Enonic, men hvis vi ikke får det vi vil ha. så funker denne workaround'en også. 😃 

## Skjermbilde hvis relevant
Før:
![publish-before](https://user-images.githubusercontent.com/18137669/226832740-4b238798-4eff-4813-a0a4-d180b08f1dd7.png)

Etter:
![publish-after](https://user-images.githubusercontent.com/18137669/226832749-a764f009-2ad4-41e2-9895-5f9aedeb8fd4.png)
