### PR TITLE
Fikset padding på heading i mobil-view så den aligner med innhold under

### DIFF
--- a/src/components/layouts/index-page/area-page/AreaPageHeader.module.scss
+++ b/src/components/layouts/index-page/area-page/AreaPageHeader.module.scss
@@ -24,6 +24,12 @@
     }
 }
 
+.heading {
+    @media #{common.$mq-screen-mobile-small} {
+        padding-left: 0.5rem;
+    }
+}
+
 .gfxContainer {
     display: flex;
     flex-shrink: 3;

--- a/src/components/layouts/index-page/area-page/AreaPageHeader.module.scss
+++ b/src/components/layouts/index-page/area-page/AreaPageHeader.module.scss
@@ -25,7 +25,7 @@
 }
 
 .heading {
-    @media #{common.$mq-screen-mobile-small} {
+    @media #{common.$mq-screen-tablet-and-mobile} {
         padding-left: 0.5rem;
     }
 }

--- a/src/components/layouts/index-page/area-page/AreaPageHeader.tsx
+++ b/src/components/layouts/index-page/area-page/AreaPageHeader.tsx
@@ -18,7 +18,7 @@ export const AreaPageHeader = ({ content }: Props) => {
     return (
         <div className={style.panel}>
             <div className={style.headerContainer}>
-                <Heading level={'1'} size={'xlarge'}>
+                <Heading level={'1'} size={'xlarge'} className={style.heading}>
                     {header}
                 </Heading>
                 {banner && (


### PR DESCRIPTION
-   Fikset padding på heading i mobil- og tablet-view så den aligner med innhold under

## Testing

Har testet selv i dev2