### PR TITLE
Fjerner /utkast restriksjon for office-branch

### DIFF
--- a/src/components/_common/office-details/OfficeDetails.tsx
+++ b/src/components/_common/office-details/OfficeDetails.tsx
@@ -19,7 +19,7 @@ export const OfficeDetails = ({ officeData }: OfficeDetailsProps) => {
     const { brukerkontakt } = officeData;
     const getOfficeTranslations = translator('office', language);
 
-    const publikumsmottak = forceArray(brukerkontakt.publikumsmottak);
+    const publikumsmottak = forceArray(brukerkontakt?.publikumsmottak);
 
     return (
         <div className={styles.wide}>

--- a/src/components/_common/office-details/phonePoster/PhonePoster.tsx
+++ b/src/components/_common/office-details/phonePoster/PhonePoster.tsx
@@ -17,7 +17,7 @@ const humanReadablePhoneNumber = parsePhoneNumber(phoneNumber);
 export const PhonePoster = ({ officeData }: OfficeDetailsProps) => {
     const { language } = usePageConfig();
     const publikumskanaler = forceArray(
-        officeData.brukerkontakt.publikumskanaler
+        officeData.brukerkontakt?.publikumskanaler
     );
     const getOfficeTranslations = translator('office', language);
 

--- a/src/components/pages/office-branch-page/OfficeBranchPage.tsx
+++ b/src/components/pages/office-branch-page/OfficeBranchPage.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { ComponentMapper } from '../../ComponentMapper';
-import { OfficeBranchPageProps } from '../../../types/content-props/dynamic-page-props';
+import { OfficeBranchPageProps } from 'types/content-props/dynamic-page-props';
 import { OfficePageHeader } from '../../_common/headers/office-page-header/OfficePageHeader';
 import { OfficeDetails } from 'components/_common/office-details/OfficeDetails';
-import { useRouter } from 'next/router';
-import ErrorPage404 from 'pages/404';
+import { classNames } from 'utils/classnames';
 
 import styles from './OfficeBranchPage.module.scss';
-import classNames from 'classnames';
 
 export const OfficeBranchPage = (props: OfficeBranchPageProps) => {
     const editorialPage = props.editorial;
@@ -15,14 +13,6 @@ export const OfficeBranchPage = (props: OfficeBranchPageProps) => {
     if (!editorialPage) {
         console.error(`No editorial page found for ${props.displayName}`);
     }
-
-    /* This to be removed before pilot starts after easter */
-    const router = useRouter();
-
-    if (!router.route.includes('utkast')) {
-        return <ErrorPage404 />;
-    }
-    /* End */
 
     return (
         <div className={styles.officeBranchPage}>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Dette håndteres nå isteden i XP, se https://github.com/navikt/nav-enonicxp/pull/1682 (fikser det slik at de nye kontorsidene også kan vises i CS)
- Et par null-sjekker på office-branch data