### PR TITLE
Viser åpningstider for chat med veileder kun dersom de er definert

### DIFF
--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -69,11 +69,15 @@ export const ChatOption = (props: ChatData) => {
                 prefix={'Chatbot:'}
                 isActive={true}
             />
-            <OpeningInfo
-                regularOpeningHours={regularOpeningHours}
-                specialOpeningHours={specialOpeningHours}
-                textPrefix={`${getTranslations('chat').chatWithCounsellor}:`}
-            />
+            {regularOpeningHours && specialOpeningHours && (
+                <OpeningInfo
+                    regularOpeningHours={regularOpeningHours}
+                    specialOpeningHours={specialOpeningHours}
+                    textPrefix={`${
+                        getTranslations('chat').chatWithCounsellor
+                    }:`}
+                />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Eks:

-   Endrer type i foobar-objektet.
-   Oppdaterer diverse destruct etter typeendringer.

## Testing

Eks: Har testet selv i dev / q6

## Dette trenger jeg å få et ekstra blikk på

Eks: Sjekk om du er enig i hvordan objektet destructes med default-verdi.

## Skjermbilde hvis relevant
