### PR TITLE
Støtte for fragmenter og globale verdier i skjemadetaljer

### DIFF
--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-    ContentProps,
-    ContentType,
-    PreviewContentProps,
-} from 'types/content-props/_content-common';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { ErrorPage } from './pages/error-page/ErrorPage';
 import { DynamicPage } from './pages/dynamic-page/DynamicPage';
 import { FragmentPage } from './pages/fragment-page/FragmentPage';
@@ -30,9 +26,7 @@ import { ContentTypeNotSupportedPage } from 'components/pages/contenttype-not-su
 import { FormDetailsPreviewPage } from 'components/pages/form-details-preview-page/FormDetailsPreviewPage';
 
 const contentToReactComponent: {
-    [key in ContentType]?: React.FunctionComponent<
-        ContentProps | PreviewContentProps
-    >;
+    [key in ContentType]?: React.FunctionComponent<ContentProps>;
 } = {
     [ContentType.Error]: ErrorPage,
     [ContentType.LargeTable]: LargeTablePage,

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { ContentProps, ContentType } from 'types/content-props/_content-common';
+import {
+    ContentProps,
+    ContentType,
+    PreviewContentProps,
+} from 'types/content-props/_content-common';
 import { ErrorPage } from './pages/error-page/ErrorPage';
 import { DynamicPage } from './pages/dynamic-page/DynamicPage';
 import { FragmentPage } from './pages/fragment-page/FragmentPage';
@@ -26,7 +30,9 @@ import { ContentTypeNotSupportedPage } from 'components/pages/contenttype-not-su
 import { FormDetailsPreviewPage } from 'components/pages/form-details-preview-page/FormDetailsPreviewPage';
 
 const contentToReactComponent: {
-    [key in ContentType]?: React.FunctionComponent<ContentProps>;
+    [key in ContentType]?: React.FunctionComponent<
+        ContentProps | PreviewContentProps
+    >;
 } = {
     [ContentType.Error]: ErrorPage,
     [ContentType.LargeTable]: LargeTablePage,

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -23,6 +23,7 @@ import { CurrentTopicPage } from './pages/current-topic-page/CurrentTopicPage';
 import { PressLandingPage } from './pages/press-landing-page/PressLandingPage';
 import { PublishingCalendarEntryPage } from './parts/_legacy/publishing-calendar/PublishingCalendarEntryPage';
 import { ContentTypeNotSupportedPage } from 'components/pages/contenttype-not-supported-page/ContentTypeNotSupportedPage';
+import { FormDetailsPreviewPage } from 'components/pages/form-details-preview-page/FormDetailsPreviewPage';
 
 const contentToReactComponent: {
     [key in ContentType]?: React.FunctionComponent<ContentProps>;
@@ -47,6 +48,7 @@ const contentToReactComponent: {
     [ContentType.OfficeBranchPage]: OfficeBranchPage,
     [ContentType.CurrentTopicPage]: CurrentTopicPage,
     [ContentType.PressLandingPage]: PressLandingPage,
+    [ContentType.FormDetails]: FormDetailsPreviewPage,
 
     [ContentType.AreaPage]: DynamicPage,
     [ContentType.FrontPage]: DynamicPage,

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -16,6 +16,10 @@
     }
 }
 
+.ingressWrapper {
+    margin-bottom: 1.75rem;
+}
+
 .vertical {
     flex-direction: column;
 }

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -4,6 +4,7 @@ import { FormDetailsVariation } from './FormDetailsVariation';
 
 import styles from './FormDetails.module.scss';
 import classNames from 'classnames';
+import { ParsedHtml } from '../parsed-html/ParsedHtml';
 
 type FormDetailsProps = {
     formDetails: FormDetailsData;
@@ -29,7 +30,9 @@ export const FormDetails = ({ formDetails }: FormDetailsProps) => {
             <Heading size="medium" level="3">
                 {formDetails.title}
             </Heading>
-            <BodyLong spacing>{formDetails.ingress}</BodyLong>
+            <BodyLong spacing>
+                <ParsedHtml htmlProps={formDetails.ingress} />
+            </BodyLong>
             <div
                 className={classNames(
                     styles.variationWrapper,

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Heading } from '@navikt/ds-react';
+import { Heading } from '@navikt/ds-react';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { FormDetailsVariation } from './FormDetailsVariation';
 
@@ -30,9 +30,9 @@ export const FormDetails = ({ formDetails }: FormDetailsProps) => {
             <Heading size="medium" level="3">
                 {formDetails.title}
             </Heading>
-            <BodyLong spacing>
+            <div className={styles.ingressWrapper}>
                 <ParsedHtml htmlProps={formDetails.ingress} />
-            </BodyLong>
+            </div>
             <div
                 className={classNames(
                     styles.variationWrapper,

--- a/src/components/_common/form-details/FormDetailsVariation.tsx
+++ b/src/components/_common/form-details/FormDetailsVariation.tsx
@@ -14,6 +14,12 @@ export const FormDetailsVariation = (props: FormsListItemProps) => {
     const { variation, index, direction } = props;
     const { url, label } = variation;
 
+    if (!url || label) {
+        // url or label is not required in CS as some form details are ment to only contain informational text
+        // via the form details title and ingress.
+        return null;
+    }
+
     const variant = index === 0 ? 'primary' : 'secondary';
 
     return (

--- a/src/components/_common/form-details/FormDetailsVariation.tsx
+++ b/src/components/_common/form-details/FormDetailsVariation.tsx
@@ -14,7 +14,7 @@ export const FormDetailsVariation = (props: FormsListItemProps) => {
     const { variation, index, direction } = props;
     const { url, label } = variation;
 
-    if (!url || label) {
+    if (!url || !label) {
         // url or label is not required in CS as some form details are ment to only contain informational text
         // via the form details title and ingress.
         return null;

--- a/src/components/_common/form-details/FormDetailsVariation.tsx
+++ b/src/components/_common/form-details/FormDetailsVariation.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, Heading } from '@navikt/ds-react';
+import { Button } from '@navikt/ds-react';
 import classNames from 'classnames';
 import { Variation } from 'types/content-props/form-details';
 
@@ -12,18 +12,12 @@ type FormsListItemProps = {
 
 export const FormDetailsVariation = (props: FormsListItemProps) => {
     const { variation, index, direction } = props;
-    const { url, label, title, ingress } = variation;
+    const { url, label } = variation;
 
     const variant = index === 0 ? 'primary' : 'secondary';
 
     return (
         <div className={classNames(styles.variation, styles[direction])}>
-            {title && (
-                <Heading level="3" size="small">
-                    {title}
-                </Heading>
-            )}
-            {ingress && <BodyLong spacing>{ingress}</BodyLong>}
             <Button as="a" className={styles.cta} variant={variant} href={url}>
                 {label}
             </Button>

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
@@ -3,13 +3,7 @@
 $margin: 2rem;
 
 .formDetailsPreviewPage {
-    align-self: center;
     background-color: white;
-    display: flex;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    margin-top: 2rem;
     max-width: common.$sectionMaxWidth;
     padding: 2rem;
     width: 100%;

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
@@ -1,7 +1,5 @@
 @use 'src/common' as common;
 
-$margin: 2rem;
-
 .formDetailsPreviewPage {
     background-color: white;
     max-width: common.$sectionMaxWidth;

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.module.scss
@@ -1,0 +1,16 @@
+@use 'src/common' as common;
+
+$margin: 2rem;
+
+.formDetailsPreviewPage {
+    align-self: center;
+    background-color: white;
+    display: flex;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    margin-top: 2rem;
+    max-width: common.$sectionMaxWidth;
+    padding: 2rem;
+    width: 100%;
+}

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -5,13 +5,10 @@ import { FormDetailsPageProps } from 'types/content-props/form-details';
 
 import styles from './FormDetailsPreviewPage.module.scss';
 
-export const FormDetailsPreviewPage = (
-    props: FormDetailsPageProps & ContentCommonProps
-) => {
-    const { data } = props;
-    return (
-        <div className={styles.formDetailsPreviewPage}>
-            <FormDetails formDetails={data} />
-        </div>
-    );
-};
+export const FormDetailsPreviewPage = ({
+    data,
+}: FormDetailsPageProps & ContentCommonProps) => (
+    <div className={styles.formDetailsPreviewPage}>
+        <FormDetails formDetails={data} />
+    </div>
+);

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FormDetails } from 'components/_common/form-details/FormDetails';
+import { ContentCommonProps } from 'types/content-props/_content-common';
+import { FormDetailsPageProps } from 'types/content-props/form-details';
+
+import styles from './FormDetailsPreviewPage.module.scss';
+
+export const FormDetailsPreviewPage = (
+    props: FormDetailsPageProps & ContentCommonProps
+) => {
+    const { data } = props;
+    return (
+        <div className={styles.formDetailsPreviewPage}>
+            <FormDetails formDetails={data} />
+        </div>
+    );
+};

--- a/src/types/component-props/parts/form-details.ts
+++ b/src/types/component-props/parts/form-details.ts
@@ -1,10 +1,10 @@
 import { PartComponentProps } from '../_component-common';
 import { PartType } from '../parts';
-import { FormDetails } from 'types/content-props/form-details';
+import { FormDetailsPageProps } from 'types/content-props/form-details';
 
 export interface FormDetailsProps extends PartComponentProps {
     descriptor: PartType.FormDetails;
     config: {
-        targetFormDetails: FormDetails;
+        targetFormDetails: FormDetailsPageProps;
     };
 }

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -174,7 +174,7 @@ type SpecificContentProps =
     | FrontPageProps
     | AreaPageProps
     | GenericPageProps
-    | PressLandingPageProps;
+    | PressLandingPageProps
+    | FormDetailsPageProps;
 
-export type PreviewContentProps = FormDetailsPageProps;
 export type ContentProps = ContentCommonProps & SpecificContentProps;

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -46,6 +46,7 @@ import { AreaPageProps, FrontPageProps } from './index-pages-props';
 import { Audience } from '../component-props/_mixins';
 import { TemplateProps } from 'types/content-props/template-props';
 import { SiteProps } from 'types/content-props/site-props';
+import { FormDetailsPageProps } from './form-details';
 
 export enum ContentType {
     Error = 'error',
@@ -87,6 +88,7 @@ export enum ContentType {
     FrontPage = 'no.nav.navno:front-page',
     AreaPage = 'no.nav.navno:area-page',
     PressLandingPage = 'no.nav.navno:press-landing-page',
+    FormDetails = 'no.nav.navno:form-details',
 }
 
 export type ContentAndMediaCommonProps = {
@@ -172,6 +174,7 @@ type SpecificContentProps =
     | FrontPageProps
     | AreaPageProps
     | GenericPageProps
-    | PressLandingPageProps;
+    | PressLandingPageProps
+    | FormDetailsPageProps;
 
 export type ContentProps = ContentCommonProps & SpecificContentProps;

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -174,7 +174,7 @@ type SpecificContentProps =
     | FrontPageProps
     | AreaPageProps
     | GenericPageProps
-    | PressLandingPageProps
-    | FormDetailsPageProps;
+    | PressLandingPageProps;
 
+export type PreviewContentProps = FormDetailsPageProps;
 export type ContentProps = ContentCommonProps & SpecificContentProps;

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -1,8 +1,4 @@
-import {
-    ContentType,
-    ContentCommonProps,
-    ContentAndMediaCommonProps,
-} from './_content-common';
+import { ContentType, ContentCommonProps } from './_content-common';
 import { LanguageProps } from '../language';
 import {
     ProductDataMixin,
@@ -14,7 +10,6 @@ import { ThemedArticlePageTaxonomy, ToolsPageTaxonomy } from '../taxonomies';
 import { OfficeDetailsData } from './office-details-props';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { ContentListProps } from './content-list-props';
-import { FormDetailsData } from './form-details';
 
 export type DynamicPageData = Partial<{
     languages: LanguageProps[];

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -1,4 +1,8 @@
-import { ContentType, ContentCommonProps } from './_content-common';
+import {
+    ContentType,
+    ContentCommonProps,
+    ContentAndMediaCommonProps,
+} from './_content-common';
 import { LanguageProps } from '../language';
 import {
     ProductDataMixin,
@@ -10,6 +14,7 @@ import { ThemedArticlePageTaxonomy, ToolsPageTaxonomy } from '../taxonomies';
 import { OfficeDetailsData } from './office-details-props';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { ContentListProps } from './content-list-props';
+import { FormDetailsData } from './form-details';
 
 export type DynamicPageData = Partial<{
     languages: LanguageProps[];

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,10 +1,7 @@
 import { OptionSetSingle } from 'types/util-types';
-import {
-    ContentAndMediaCommonProps,
-    ContentCommonProps,
-    ContentType,
-} from './_content-common';
+import { ContentCommonProps, ContentType } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+import { type } from 'os';
 
 export type FormTypes = 'application' | 'complaint' | 'addendum';
 
@@ -35,7 +32,7 @@ export interface FormDetailsData {
     }>;
 }
 
-export interface FormDetailsPageProps extends Omit<ContentCommonProps, 'data'> {
-    __typename: ContentType.FormDetails;
+export interface FormDetailsPageProps {
+    type: ContentType.FormDetails;
     data: FormDetailsData;
 }

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,7 +1,6 @@
 import { OptionSetSingle } from 'types/util-types';
-import { ContentCommonProps, ContentType } from './_content-common';
+import { ContentType } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
-import { type } from 'os';
 
 export type FormTypes = 'application' | 'complaint' | 'addendum';
 

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,8 +1,6 @@
 import { OptionSetSingle } from 'types/util-types';
-import { ContentType } from './_content-common';
+import { ContentCommonProps, ContentType } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
-
-export type FormTypes = 'application' | 'complaint' | 'addendum';
 
 export type FormApplicationTypes = 'digital' | 'paper';
 export type FormComplaintTypes = 'complaint' | 'appeal';
@@ -31,7 +29,7 @@ export interface FormDetailsData {
     }>;
 }
 
-export interface FormDetailsPageProps {
+export type FormDetailsPageProps = {
     type: ContentType.FormDetails;
     data: FormDetailsData;
-}
+} & ContentCommonProps;

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,5 +1,9 @@
 import { OptionSetSingle } from 'types/util-types';
-import { ContentAndMediaCommonProps, ContentType } from './_content-common';
+import {
+    ContentAndMediaCommonProps,
+    ContentCommonProps,
+    ContentType,
+} from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 
 export type FormTypes = 'application' | 'complaint' | 'addendum';
@@ -31,7 +35,7 @@ export interface FormDetailsData {
     }>;
 }
 
-export interface FormDetailsPageProps extends ContentAndMediaCommonProps {
+export interface FormDetailsPageProps extends Omit<ContentCommonProps, 'data'> {
     __typename: ContentType.FormDetails;
     data: FormDetailsData;
 }

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,5 +1,6 @@
 import { OptionSetSingle } from 'types/util-types';
-import { ContentCommonProps, ContentType } from './_content-common';
+import { ContentAndMediaCommonProps, ContentType } from './_content-common';
+import { ProcessedHtmlProps } from 'types/processed-html-props';
 
 export type FormTypes = 'application' | 'complaint' | 'addendum';
 
@@ -9,16 +10,14 @@ export type FormAddendumTypes = 'addendum_digital' | 'addendum_paper';
 
 export interface Variation<T = string> {
     type: T;
-    url: string;
-    label: string;
-    title?: string;
-    ingress?: string;
+    url?: string;
+    label?: string;
 }
 
 export interface FormDetailsData {
     formNumbers: string[];
     title: string;
-    ingress: string;
+    ingress: ProcessedHtmlProps;
     formType: OptionSetSingle<{
         application: {
             variations: Variation<FormApplicationTypes>[];
@@ -32,7 +31,7 @@ export interface FormDetailsData {
     }>;
 }
 
-export interface FormDetails extends ContentCommonProps {
-    __typename: ContentType.CurrentTopicPage;
+export interface FormDetailsPageProps extends ContentAndMediaCommonProps {
+    __typename: ContentType.FormDetails;
     data: FormDetailsData;
 }


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Støtter fragmenter og globale vedier
- Støtter forhåndsvisning av skjemadetaljer til redaktørene
- Legger til en egen PreviewContentProps for sider som kun brukes for redaktørene. Beste løsningen jeg kom på pga konflikter med vanlige ContentProps.

## Testing
Testes av Janne i dev
