### PR TITLE
Datoformat kontaktmodul

### DIFF
--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -226,7 +226,7 @@ export const translationsBundleNb = {
         shared: {
             closed: 'Stengt',
             openNow: 'Åpent nå',
-            opensAt: 'Åpner {$date} kl {$time}',
+            opensAt: 'Åpner {$date} kl. {$time}',
             closedNow: 'Stengt nå',
             seeMoreOptions: 'Se flere telefonnummer og tastevalg',
         },


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Skriver ukedag i stedet for dato for neste åpningstid
- Tolvtimersformat med am/pm for engelske åpningstider

## Testing
Har testet selv lokalt

