### PR TITLE
Tillate flere samtidige kategorier i skjemadetaljer

### DIFF
--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -6,20 +6,22 @@
 
 .variationWrapper {
     display: flex;
-}
-
-.horizontal {
     flex-direction: row;
+
+    & > :not(:last-child) {
+        margin-right: 1rem;
+    }
 
     @media #{common.$mq-screen-mobile} {
         flex-direction: column;
+
+        & > :not(:last-child) {
+            margin-right: 0;
+            margin-bottom: 1rem;
+        }
     }
 }
 
 .ingressWrapper {
     margin-bottom: 1.75rem;
-}
-
-.vertical {
-    flex-direction: column;
 }

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,10 +1,10 @@
 import { Heading } from '@navikt/ds-react';
-import { FormDetailsData, Variation } from 'types/content-props/form-details';
-import { FormDetailsVariation } from './FormDetailsVariation';
 import classNames from 'classnames';
 
 import { forceArray } from 'utils/arrays';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
+import { FormDetailsData, Variation } from 'types/content-props/form-details';
+import { FormDetailsVariation } from './FormDetailsVariation';
 
 import styles from './FormDetails.module.scss';
 
@@ -32,12 +32,10 @@ export const FormDetails = ({
         ) {
             return acc;
         }
-        const variations = cur[cur._selected].variations || [];
+        const variations = forceArray(cur[cur._selected].variations);
 
         return [...acc, ...variations];
     }, []) as Variation[];
-
-    const direction = variations.length === 0 ? 'vertical' : 'horizontal';
 
     return (
         <div className={styles.formDetails}>
@@ -51,17 +49,11 @@ export const FormDetails = ({
                     <ParsedHtml htmlProps={formDetails.ingress} />
                 </div>
             )}
-            <div
-                className={classNames(
-                    styles.variationWrapper,
-                    styles[direction]
-                )}
-            >
+            <div className={classNames(styles.variationWrapper)}>
                 {variations.map((variation, index: number) => (
                     <FormDetailsVariation
                         key={variation.label}
                         variation={variation}
-                        direction={direction}
                         index={index}
                     />
                 ))}

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -22,11 +22,16 @@ export const FormDetails = ({
     formDetails,
     displayConfig,
 }: FormDetailsProps) => {
-    const { formType } = formDetails;
     const { showAddendums, showApplications, showTitle, showIngress } =
         displayConfig;
 
     const variations = forceArray(formDetails.formType).reduce((acc, cur) => {
+        if (
+            (cur._selected === 'addendum' && !showAddendums) ||
+            (cur._selected === 'application' && !showApplications)
+        ) {
+            return acc;
+        }
         const variations = cur[cur._selected].variations || [];
 
         return [...acc, ...variations];
@@ -36,12 +41,16 @@ export const FormDetails = ({
 
     return (
         <div className={styles.formDetails}>
-            <Heading size="medium" level="3">
-                {formDetails.title}
-            </Heading>
-            <div className={styles.ingressWrapper}>
-                <ParsedHtml htmlProps={formDetails.ingress} />
-            </div>
+            {showTitle && (
+                <Heading size="medium" level="3" spacing={!showIngress}>
+                    {formDetails.title}
+                </Heading>
+            )}
+            {showIngress && (
+                <div className={styles.ingressWrapper}>
+                    <ParsedHtml htmlProps={formDetails.ingress} />
+                </div>
+            )}
             <div
                 className={classNames(
                     styles.variationWrapper,

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,7 +1,6 @@
 import { Heading } from '@navikt/ds-react';
 import classNames from 'classnames';
 
-import { forceArray } from 'utils/arrays';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { FormDetailsVariation } from './FormDetailsVariation';
@@ -25,14 +24,14 @@ export const FormDetails = ({
     const { showAddendums, showApplications, showTitle, showIngress } =
         displayConfig;
 
-    const variations = forceArray(formDetails.formType).reduce((acc, cur) => {
+    const variations = formDetails.formType.reduce((acc, cur) => {
         if (
             (cur._selected === 'addendum' && !showAddendums) ||
             (cur._selected === 'application' && !showApplications)
         ) {
             return acc;
         }
-        const variations = forceArray(cur[cur._selected].variations);
+        const variations = cur[cur._selected].variations;
 
         return [...acc, ...variations];
     }, []) as Variation[];

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,29 +1,38 @@
 import { Heading } from '@navikt/ds-react';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { FormDetailsVariation } from './FormDetailsVariation';
+import classNames from 'classnames';
+
+import { forceArray } from 'utils/arrays';
+import { ParsedHtml } from '../parsed-html/ParsedHtml';
 
 import styles from './FormDetails.module.scss';
-import classNames from 'classnames';
-import { ParsedHtml } from '../parsed-html/ParsedHtml';
 
 type FormDetailsProps = {
     formDetails: FormDetailsData;
+    displayConfig: {
+        showTitle: boolean;
+        showIngress: boolean;
+        showAddendums: boolean;
+        showApplications: boolean;
+    };
 };
 
-export const FormDetails = ({ formDetails }: FormDetailsProps) => {
+export const FormDetails = ({
+    formDetails,
+    displayConfig,
+}: FormDetailsProps) => {
     const { formType } = formDetails;
+    const { showAddendums, showApplications, showTitle, showIngress } =
+        displayConfig;
 
-    const variations = (formDetails.formType[formType._selected]?.variations ||
-        []) as Variation[];
+    const variations = forceArray(formDetails.formType).reduce((acc, cur) => {
+        const variations = cur[cur._selected].variations || [];
 
-    const direction =
-        formDetails.formType._selected === 'addendum'
-            ? 'vertical'
-            : 'horizontal';
+        return [...acc, ...variations];
+    }, []) as Variation[];
 
-    if (variations.length === 0) {
-        return null;
-    }
+    const direction = variations.length === 0 ? 'vertical' : 'horizontal';
 
     return (
         <div className={styles.formDetails}>

--- a/src/components/_common/form-details/FormDetailsVariation.tsx
+++ b/src/components/_common/form-details/FormDetailsVariation.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@navikt/ds-react';
-import classNames from 'classnames';
 import { Variation } from 'types/content-props/form-details';
 
 import styles from './FormDetailsVariation.module.scss';
@@ -7,11 +6,10 @@ import styles from './FormDetailsVariation.module.scss';
 type FormsListItemProps = {
     variation: Variation;
     index: number;
-    direction: 'vertical' | 'horizontal';
 };
 
 export const FormDetailsVariation = (props: FormsListItemProps) => {
-    const { variation, index, direction } = props;
+    const { variation, index } = props;
     const { url, label } = variation;
 
     if (!url || !label) {
@@ -23,7 +21,7 @@ export const FormDetailsVariation = (props: FormsListItemProps) => {
     const variant = index === 0 ? 'primary' : 'secondary';
 
     return (
-        <div className={classNames(styles.variation, styles[direction])}>
+        <div className={styles.variation}>
             <Button as="a" className={styles.cta} variant={variant} href={url}>
                 {label}
             </Button>

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -7,8 +7,16 @@ import styles from './FormDetailsPreviewPage.module.scss';
 
 export const FormDetailsPreviewPage = ({
     data,
-}: FormDetailsPageProps & ContentCommonProps) => (
-    <div className={styles.formDetailsPreviewPage}>
-        <FormDetails formDetails={data} />
-    </div>
-);
+}: FormDetailsPageProps & ContentCommonProps) => {
+    const displayConfig = {
+        showTitle: true,
+        showIngress: true,
+        showAddendums: true,
+        showApplications: true,
+    };
+    return (
+        <div className={styles.formDetailsPreviewPage}>
+            <FormDetails formDetails={data} displayConfig={displayConfig} />
+        </div>
+    );
+};

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -4,25 +4,12 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 
 export const FormDetailsPart = ({ config }: FormDetailsProps) => {
-    const {
-        targetFormDetails,
-        showTitle,
-        showIngress,
-        showAddendums,
-        showApplications,
-    } = config;
+    const { targetFormDetails, ...displayConfig } = config;
 
     if (!targetFormDetails) {
         return <EditorHelp text={'Velg hvilken skjemadetalj som skal vises'} />;
     }
     const formDetails = targetFormDetails.data;
-
-    const displayConfig = {
-        showTitle: showTitle === 'true',
-        showIngress: showIngress === 'true',
-        showAddendums: showAddendums === 'true',
-        showApplications: showApplications === 'true',
-    };
 
     console.log(displayConfig);
 

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -4,12 +4,29 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 
 export const FormDetailsPart = ({ config }: FormDetailsProps) => {
-    const { targetFormDetails } = config;
+    const {
+        targetFormDetails,
+        showTitle,
+        showIngress,
+        showAddendums,
+        showApplications,
+    } = config;
 
     if (!targetFormDetails) {
         return <EditorHelp text={'Velg hvilken skjemadetalj som skal vises'} />;
     }
     const formDetails = targetFormDetails.data;
 
-    return <FormDetails formDetails={formDetails} />;
+    const displayConfig = {
+        showTitle: showTitle === 'true',
+        showIngress: showIngress === 'true',
+        showAddendums: showAddendums === 'true',
+        showApplications: showApplications === 'true',
+    };
+
+    console.log(displayConfig);
+
+    return (
+        <FormDetails formDetails={formDetails} displayConfig={displayConfig} />
+    );
 };

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -11,8 +11,6 @@ export const FormDetailsPart = ({ config }: FormDetailsProps) => {
     }
     const formDetails = targetFormDetails.data;
 
-    console.log(displayConfig);
-
     return (
         <FormDetails formDetails={formDetails} displayConfig={displayConfig} />
     );

--- a/src/types/component-props/parts/form-details.ts
+++ b/src/types/component-props/parts/form-details.ts
@@ -6,9 +6,9 @@ export interface FormDetailsProps extends PartComponentProps {
     descriptor: PartType.FormDetails;
     config: {
         targetFormDetails: FormDetailsPageProps;
-        showTitle: string;
-        showIngress: string;
-        showAddendums: string;
-        showApplications: string;
+        showTitle: boolean;
+        showIngress: boolean;
+        showAddendums: boolean;
+        showApplications: boolean;
     };
 }

--- a/src/types/component-props/parts/form-details.ts
+++ b/src/types/component-props/parts/form-details.ts
@@ -6,5 +6,9 @@ export interface FormDetailsProps extends PartComponentProps {
     descriptor: PartType.FormDetails;
     config: {
         targetFormDetails: FormDetailsPageProps;
+        showTitle: string;
+        showIngress: string;
+        showAddendums: string;
+        showApplications: string;
     };
 }

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -2,12 +2,11 @@ import { OptionSetSingle } from 'types/util-types';
 import { ContentCommonProps, ContentType } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 
-export type FormApplicationTypes = 'digital' | 'paper';
 export type FormComplaintTypes = 'complaint' | 'appeal';
 export type FormAddendumTypes = 'addendum_digital' | 'addendum_paper';
 
 export interface Variation<T = string> {
-    type: T;
+    type?: T;
     url?: string;
     label?: string;
 }
@@ -18,13 +17,13 @@ export interface FormDetailsData {
     ingress: ProcessedHtmlProps;
     formType: OptionSetSingle<{
         application: {
-            variations: Variation<FormApplicationTypes>[];
+            variations: Variation[];
         };
         complaint: {
             variations: Variation<FormComplaintTypes>[];
         };
         addendum: {
-            variations: Variation<FormAddendumTypes>[];
+            variations: Variation[];
         };
     }>;
 }

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -25,7 +25,7 @@ export interface FormDetailsData {
         addendum: {
             variations: Variation[];
         };
-    }>;
+    }>[];
 }
 
 export type FormDetailsPageProps = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Åpner opp for å legge til flere kategorier samtidig (Søknad, klage/anke og ettersendelse) i samme skjemdetalj.
- Kan styre hvilke detaljer som skal vises når man setter inn en part for skjemadetaljen.
- Fjerner type (digltalt / papir) siden dette ikke er behov for når vi får mellomsteg på plass.

## Testing
Testes i q6 av Janne og Terje