### PR TITLE
Fikser feil nivå på adresseoverskrift

### DIFF
--- a/src/components/_common/office-details/reception/SingleReception.tsx
+++ b/src/components/_common/office-details/reception/SingleReception.tsx
@@ -79,7 +79,7 @@ export const SingleReception = (props: AudienceReception) => {
 
     return (
         <div className={styles.singleReception}>
-            <Heading level="2" size="medium" spacing className={styles.heading}>
+            <Heading level="3" size="medium" spacing className={styles.heading}>
                 <PlaceFilled
                     aria-hidden="true"
                     className={classNames(styles.headingIcon, styles.iconPlace)}


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fikser feil overskriftnivå slik at alle tre i kontaktinfo er på samme nivå.
