### PR TITLE
Uxsignal refresh fix

### DIFF
--- a/src/components/_common/uxsignals-widget/UxSignalsWidget.tsx
+++ b/src/components/_common/uxsignals-widget/UxSignalsWidget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import Script from 'next/script';
 
@@ -10,7 +10,7 @@ type Props = {
 
 export const UxSignalsWidget = ({ embedCode }: Props) => {
     return (
-        <>
+        <Fragment key={embedCode}>
             <Script
                 type={'module'}
                 src={
@@ -26,6 +26,6 @@ export const UxSignalsWidget = ({ embedCode }: Props) => {
                 text={'UX Signals rekrutterings-widget'}
                 type={'info'}
             />
-        </>
+        </Fragment>
     );
 };

--- a/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
+++ b/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
@@ -53,10 +53,7 @@ export const FormsOverviewPage = (props: FormsOverviewProps) => {
 
     return (
         <>
-            <AlertBox
-                variant={'info'}
-                style={{ marginBottom: '3rem', marginTop: '-2.5rem' }}
-            >
+            <AlertBox variant={'warning'} style={{ marginBottom: '2.5rem' }}>
                 <>
                     {
                         'Hei! Denne siden er under utvikling og er ikke helt klar til bruk ennå. Innholdet på siden kan være uferdig. '


### PR DESCRIPTION
Tvinger re-render av UXSignals widget når embed-code endres. Fikser en bug der widget'en henger igjen fra forrige side ved navigering mellom sider som widgets som har forskjellige embed-koder.