### PR TITLE
Justeringer på statiske piktogrammer og skjemaoversikt

### DIFF
--- a/src/common.scss
+++ b/src/common.scss
@@ -26,6 +26,7 @@ $mobileMaxWidth: 48rem; // 768px
 $tabletMinWidth: $mobileMaxWidth;
 $tabletMaxWidth: 64rem; // 1024px
 $desktopMinWidth: $tabletMaxWidth;
+$desktopSmallMinWidth: 75rem; // 1200px
 $desktopMaxWidth: 90rem; // 1440px
 
 $mq-screen-mobile: 'only screen and (max-width: #{$mobileMaxWidth})';
@@ -33,6 +34,7 @@ $mq-screen-tablet: 'only screen and (min-width: #{$tabletMinWidth}) and (max-wid
 $mq-screen-tablet-and-desktop: 'only screen and (min-width: #{$tabletMinWidth}) ';
 $mq-screen-tablet-and-mobile: 'only screen and (max-width: #{$tabletMaxWidth}) ';
 $mq-screen-desktop: 'only screen and (min-width: #{$desktopMinWidth}) ';
+$mq-screen-desktop-small-up: 'only screen and (min-width: #{$desktopSmallMinWidth}) ';
 $mq-screen-desktop-large: 'only screen and (min-width: #{$desktopMaxWidth}) ';
 
 // Index page breakpoints

--- a/src/components/_common/card/LargeCard.tsx
+++ b/src/components/_common/card/LargeCard.tsx
@@ -1,13 +1,11 @@
+import React from 'react';
 import { classNames } from 'utils/classnames';
-
-import { AnimatedIconsProps } from '../../../types/content-props/animated-icons';
+import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { CardSize, CardType } from 'types/card';
 import { Heading, BodyLong, BodyShort } from '@navikt/ds-react';
 import { Illustration } from '../illustration/Illustration';
-import { IllustrationPlacements } from 'types/illustrationPlacements';
 import { LenkeBase } from '../lenke/LenkeBase';
 import { LinkProps } from 'types/link-props';
-
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { useCard } from './useCard';
 

--- a/src/components/_common/card/LargeCard.tsx
+++ b/src/components/_common/card/LargeCard.tsx
@@ -63,7 +63,6 @@ export const LargeCard = (props: StortKortProps) => {
                     {hasIllustration && (
                         <Illustration
                             illustration={illustration}
-                            placement={IllustrationPlacements.LARGE_CARD}
                             className={style.illustration}
                             isHovering={isHovering}
                             preferStaticIllustration={

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -4,10 +4,8 @@ import { classNames } from 'utils/classnames';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { CardSize, CardType } from 'types/card';
 import { Illustration } from '../illustration/Illustration';
-import { IllustrationPlacements } from 'types/illustrationPlacements';
 import { LenkeBase } from '../lenke/LenkeBase';
 import { LinkProps } from 'types/link-props';
-
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { useCard } from './useCard';
 

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -49,7 +49,6 @@ export const MiniCard = (props: MiniKortProps) => {
                         className={style.illustration}
                         illustration={illustration}
                         isHovering={isHovering}
-                        placement={IllustrationPlacements.SMALL_CARD}
                         preferStaticIllustration={
                             pageConfig.editorView === 'edit'
                         }

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -166,7 +166,6 @@ export const ThemedPageHeader = ({
         >
             <Illustration
                 illustration={illustration}
-                placement={IllustrationPlacements.PRODUCT_PAGE_HEADER}
                 className={style.illustration}
             />
             <div className={style.text}>

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -7,7 +7,6 @@ import { BodyShort, Detail } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { Illustration } from 'components/_common/illustration/Illustration';
-import { IllustrationPlacements } from 'types/illustrationPlacements';
 import {
     ProductPageProps,
     SituationPageProps,

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -1,36 +1,24 @@
+import React from 'react';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { IllustrationStatic } from './IllustrationStatic';
 import { IllustrationAnimated } from './IllustrationAnimated';
 
-interface IllustrationProps {
-    illustration: AnimatedIconsProps;
-    placement: string;
-    className: string;
+type Props = {
+    illustration?: AnimatedIconsProps;
     isHovering?: boolean;
     preferStaticIllustration?: boolean;
-}
+    className?: string;
+};
 
 export const Illustration = ({
-    className,
     illustration,
     isHovering,
     preferStaticIllustration,
-}: IllustrationProps) => {
+    className,
+}: Props) => {
     if (!illustration) {
         return null;
     }
-
-    const hasStaticIllustration = () => {
-        const { icons } = illustration.data;
-        if (!icons) {
-            return false;
-        }
-
-        const icon1 = icons[0]?.icon;
-        const icon2 = icons[1]?.icon;
-
-        return !!(icon1 || icon2);
-    };
 
     if (!preferStaticIllustration) {
         const animationDataUrl = illustration.data.lottieHover?.mediaUrl;
@@ -45,14 +33,7 @@ export const Illustration = ({
         }
     }
 
-    if (hasStaticIllustration()) {
-        return (
-            <IllustrationStatic
-                illustration={illustration}
-                className={className}
-            />
-        );
-    }
-
-    return null;
+    return (
+        <IllustrationStatic illustration={illustration} className={className} />
+    );
 };

--- a/src/components/_common/illustration/IllustrationAnimated.tsx
+++ b/src/components/_common/illustration/IllustrationAnimated.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import useSWRImmutable from 'swr/immutable';
-import { classNames } from '../../../utils/classnames';
-import { fetchJson } from '../../../utils/fetch/fetch-utils';
+import { classNames } from 'utils/classnames';
+import { fetchJson } from 'utils/fetch/fetch-utils';
 
 import styleCommon from './Illustration.module.scss';
 import styleAnimated from './IllustrationAnimated.module.scss';

--- a/src/components/_common/illustration/IllustrationStatic.module.scss
+++ b/src/components/_common/illustration/IllustrationStatic.module.scss
@@ -2,6 +2,8 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
 
     svg {
         width: 100%;

--- a/src/components/_common/illustration/IllustrationStatic.module.scss
+++ b/src/components/_common/illustration/IllustrationStatic.module.scss
@@ -5,7 +5,7 @@
     width: 100%;
     height: 100%;
 
-    svg {
+    & > * {
         width: 100%;
         height: 100%;
     }

--- a/src/components/_common/illustration/IllustrationStatic.module.scss
+++ b/src/components/_common/illustration/IllustrationStatic.module.scss
@@ -1,10 +1,10 @@
 .icon {
-    background-position: center;
-    background-repeat: no-repeat;
     position: absolute;
-    background-size: contain;
-    width: 100%;
-    height: 100%;
     top: 0;
     left: 0;
+
+    svg {
+        width: 100%;
+        height: 100%;
+    }
 }

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -32,7 +32,7 @@ const StaticIcon = ({
 }) => {
     const ref = useRef<HTMLSpanElement>();
 
-    // Insert svg data into the html to allow us to easily style it with CSS
+    // We inline svg data into the html to allow us to easily style it with CSS
     // Other formats are treated as a regular img
     const isSvg = icon.icon.mediaUrl.endsWith('svg');
 

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -42,7 +42,9 @@ const StaticIcon = ({
     );
 
     useEffect(() => {
-        ref.current.innerHTML = data;
+        if (data) {
+            ref.current.innerHTML = data;
+        }
     }, [data]);
 
     return <span className={styleStatic.icon} ref={ref} />;

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -36,7 +36,6 @@ const StaticIcon = ({
                 src: getMediaUrl(icon.icon.mediaUrl),
                 isEditorView,
             })})`,
-            transform: icon.transformStart || 'none',
         }}
     />
 );

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -7,6 +7,7 @@ import { getMediaUrl } from 'utils/urls';
 import { classNames } from 'utils/classnames';
 import { buildImageCacheUrl, NextImageProps } from '../image/NextImage';
 import { usePageConfig } from 'store/hooks/usePageConfig';
+import useSWRImmutable from 'swr/immutable';
 
 import styleCommon from './Illustration.module.scss';
 import styleStatic from './IllustrationStatic.module.scss';
@@ -30,21 +31,19 @@ const StaticIcon = ({
 }) => {
     const ref = useRef<HTMLSpanElement>();
 
-    useEffect(() => {
-        const url = buildImageCacheUrl({
-            ...nextImageProps,
-            src: getMediaUrl(icon.icon.mediaUrl),
-            isEditorView,
-        });
+    const url = buildImageCacheUrl({
+        ...nextImageProps,
+        src: getMediaUrl(icon.icon.mediaUrl),
+        isEditorView,
+    });
 
-        fetch(url)
-            .then((res) => {
-                if (res.ok) {
-                    return res.text();
-                }
-            })
-            .then((text) => (ref.current.innerHTML = text));
-    }, [icon, isEditorView]);
+    const { data } = useSWRImmutable(url, () =>
+        fetch(url).then((res) => res.text())
+    );
+
+    useEffect(() => {
+        ref.current.innerHTML = data;
+    }, [data]);
 
     return <span className={styleStatic.icon} ref={ref} />;
 };

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
     AnimatedIcon,
     AnimatedIconsProps,
@@ -27,18 +27,27 @@ const StaticIcon = ({
 }: {
     icon: AnimatedIcon;
     isEditorView: boolean;
-}) => (
-    <span
-        className={styleStatic.icon}
-        style={{
-            backgroundImage: `url(${buildImageCacheUrl({
-                ...nextImageProps,
-                src: getMediaUrl(icon.icon.mediaUrl),
-                isEditorView,
-            })})`,
-        }}
-    />
-);
+}) => {
+    const ref = useRef<HTMLSpanElement>();
+
+    useEffect(() => {
+        const url = buildImageCacheUrl({
+            ...nextImageProps,
+            src: getMediaUrl(icon.icon.mediaUrl),
+            isEditorView,
+        });
+
+        fetch(url)
+            .then((res) => {
+                if (res.ok) {
+                    return res.text();
+                }
+            })
+            .then((text) => (ref.current.innerHTML = text));
+    }, [icon, isEditorView]);
+
+    return <span className={styleStatic.icon} ref={ref} />;
+};
 
 export const IllustrationStatic = ({
     illustration,
@@ -69,7 +78,7 @@ export const IllustrationStatic = ({
     return (
         <span
             className={classNames(styleCommon.image, className)}
-            aria-hidden="true"
+            aria-hidden={'true'}
         >
             {hasIcon1 && (
                 <StaticIcon icon={icon1} isEditorView={isEditorView} />

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.module.scss
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.module.scss
@@ -3,7 +3,6 @@
 .overviewFilter {
     display: flex;
     flex-direction: column;
-    max-width: common.$sectionMaxWidth;
 }
 
 .filterWrapper {
@@ -15,24 +14,21 @@
     padding: 0;
 }
 
-.tag {
-    background-color: white;
-    border: 1px solid var(--a-gray-600);
-    cursor: pointer;
-    white-space: nowrap;
-}
-
 .filterButton {
-    background-color: transparent;
-    border: 0;
-    margin: 0 0.5rem 0.5rem 0;
-    padding: 0;
-}
+    background-color: common.$a-deepblue-50;
+    box-shadow: none;
 
-.activeButton {
-    .tag {
-        background-color: common.$a-blue-100;
-        outline: 2px solid common.$a-blue-500;
-        border-color: transparent;
+    padding-left: common.$a-spacing-3;
+
+    &:hover {
+        background-color: common.$a-deepblue-100;
+    }
+
+    &:hover:not(:focus) {
+        box-shadow: none;
+    }
+
+    svg {
+        display: none;
     }
 }

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Chips, Heading, Tag } from '@navikt/ds-react';
+import { Chips, Heading } from '@navikt/ds-react';
 import { Area } from 'types/areas';
 import { Taxonomy } from 'types/taxonomies';
 import { translator } from 'translations';

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
@@ -52,10 +52,7 @@ export const OverviewFilterBase = <Type extends FilterOptions>({
                                 type={'button'}
                                 onClick={() => selectionCallback(option)}
                                 aria-label={`${translations['ariaItemExplanation']} ${optionLabel}`}
-                                className={classNames(
-                                    styles.filterButton,
-                                    isActive && styles.activeButton
-                                )}
+                                className={styles.filterButton}
                                 selected={isActive}
                                 key={option}
                             >

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Heading, Tag } from '@navikt/ds-react';
+import { Chips, Heading, Tag } from '@navikt/ds-react';
 import { Area } from 'types/areas';
 import { Taxonomy } from 'types/taxonomies';
 import { translator } from 'translations';
@@ -42,35 +42,28 @@ export const OverviewFilterBase = <Type extends FilterOptions>({
                 {translations['choose']}
             </Heading>
             <nav aria-label={translations['ariaExplanation']}>
-                <ul className={styles.filterWrapper}>
+                <Chips className={styles.filterWrapper}>
                     {options.map((option) => {
                         const isActive = selected === option;
                         const optionLabel = optionsTranslations(option);
 
                         return (
-                            <li key={option}>
-                                <button
-                                    type={'button'}
-                                    onClick={() => selectionCallback(option)}
-                                    aria-current={isActive}
-                                    aria-label={`${translations['ariaItemExplanation']} ${optionLabel}`}
-                                    className={classNames(
-                                        styles.filterButton,
-                                        isActive && styles.activeButton
-                                    )}
-                                >
-                                    <Tag
-                                        variant={'info'}
-                                        className={styles.tag}
-                                        size={'small'}
-                                    >
-                                        {optionLabel}
-                                    </Tag>
-                                </button>
-                            </li>
+                            <Chips.Toggle
+                                type={'button'}
+                                onClick={() => selectionCallback(option)}
+                                aria-label={`${translations['ariaItemExplanation']} ${optionLabel}`}
+                                className={classNames(
+                                    styles.filterButton,
+                                    isActive && styles.activeButton
+                                )}
+                                selected={isActive}
+                                key={option}
+                            >
+                                {optionLabel}
+                            </Chips.Toggle>
                         );
                     })}
-                </ul>
+                </Chips>
             </nav>
         </div>
     );

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 import { Chips, Heading, Tag } from '@navikt/ds-react';
 import { Area } from 'types/areas';
 import { Taxonomy } from 'types/taxonomies';
@@ -44,7 +43,6 @@ export const OverviewFilterBase = <Type extends FilterOptions>({
             <nav aria-label={translations['ariaExplanation']}>
                 <Chips className={styles.filterWrapper}>
                     {options.map((option) => {
-                        const isActive = selected === option;
                         const optionLabel = optionsTranslations(option);
 
                         return (
@@ -53,7 +51,7 @@ export const OverviewFilterBase = <Type extends FilterOptions>({
                                 onClick={() => selectionCallback(option)}
                                 aria-label={`${translations['ariaItemExplanation']} ${optionLabel}`}
                                 className={styles.filterButton}
-                                selected={isActive}
+                                selected={selected === option}
                                 key={option}
                             >
                                 {optionLabel}

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -1,8 +1,17 @@
 @use 'src/common' as common;
 
-.accordionItem {
-    border-bottom: 1px common.$a-deepblue-100 solid;
+$color: common.$a-deepblue-100;
+$separator-attribs: 1px $color solid;
 
+.accordion {
+    border-bottom: $separator-attribs;
+}
+
+:not(.accordion) + .accordion {
+    border-top: $separator-attribs;
+}
+
+.accordionItem {
     :global(.navds-accordion__header),
     :global(.navds-accordion__content) {
         border-bottom: 0;
@@ -22,7 +31,7 @@
 
         &:hover,
         &:focus {
-            background-color: common.$a-deepblue-100;
+            background-color: $color;
             color: common.$a-text-default;
 
             .illustration {
@@ -66,7 +75,7 @@
     flex-shrink: 0;
 
     & > :first-child:not(:last-child) * {
-        fill: common.$a-deepblue-100;
+        fill: $color;
     }
 }
 

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -9,15 +9,28 @@
     }
 
     :global(.navds-accordion__header) {
+        @include common.expandable-panel-mixin();
+
         align-items: center;
         background-color: white;
         margin-bottom: 3px;
         padding-top: var(--a-spacing-4);
         padding-bottom: var(--a-spacing-4);
 
-        @include common.expandable-panel-mixin();
         &:focus {
             @include common.panel-focus-mixin(true);
+        }
+
+        &:hover,
+        &:focus {
+            background-color: common.$a-deepblue-100;
+            color: common.$a-text-default;
+
+            .illustration {
+                & > :first-child:not(:last-child) * {
+                    fill: common.$a-white;
+                }
+            }
         }
 
         :global(.navds-accordion__header-content) {
@@ -52,6 +65,10 @@
     width: 56px;
     height: 56px;
     flex-shrink: 0;
+
+    & > :first-child:not(:last-child) * {
+        fill: common.$a-deepblue-100;
+    }
 }
 
 .copyLink {

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -1,7 +1,7 @@
 @use 'src/common' as common;
 
 .accordionItem {
-    border-bottom: 1px common.$a-border-divider solid;
+    border-bottom: 1px common.$a-deepblue-100 solid;
 
     :global(.navds-accordion__header),
     :global(.navds-accordion__content) {
@@ -10,12 +10,11 @@
 
     :global(.navds-accordion__header) {
         @include common.expandable-panel-mixin();
+        border-radius: common.$border-radius-xlarge;
 
         align-items: center;
-        background-color: white;
-        margin-bottom: 3px;
-        padding-top: var(--a-spacing-4);
-        padding-bottom: var(--a-spacing-4);
+        background-color: common.$a-white;
+        padding: var(--a-spacing-5);
 
         &:focus {
             @include common.panel-focus-mixin(true);

--- a/src/components/_common/product-panel/ProductPanelExpandable.tsx
+++ b/src/components/_common/product-panel/ProductPanelExpandable.tsx
@@ -72,6 +72,7 @@ export const ProductPanelExpandable = ({
                     <Accordion.Header
                         onClick={handleClick}
                         onMouseOver={contentLoaderCallback}
+                        onFocus={contentLoaderCallback}
                     >
                         <IllustrationStatic
                             className={style.illustration}

--- a/src/components/_common/product-panel/ProductPanelExpandable.tsx
+++ b/src/components/_common/product-panel/ProductPanelExpandable.tsx
@@ -65,47 +65,43 @@ export const ProductPanelExpandable = ({
     };
 
     return (
-        <>
-            <div id={anchorId} />
-            <Accordion className={classNames(!visible && style.hidden)}>
-                <Accordion.Item open={isOpen} className={style.accordionItem}>
-                    <Accordion.Header
-                        onClick={handleClick}
-                        onMouseOver={contentLoaderCallback}
-                        onFocus={contentLoaderCallback}
-                    >
-                        <IllustrationStatic
-                            className={style.illustration}
-                            illustration={illustration}
-                        />
-                        <div className={style.panelHeader}>
-                            <span>{header}</span>
-                            {subHeader && (
-                                <span className={style.subHeader}>
-                                    {subHeader}
-                                </span>
-                            )}
+        <Accordion
+            className={classNames(style.accordion, !visible && style.hidden)}
+            id={anchorId}
+        >
+            <Accordion.Item open={isOpen} className={style.accordionItem}>
+                <Accordion.Header
+                    onClick={handleClick}
+                    onMouseOver={contentLoaderCallback}
+                    onFocus={contentLoaderCallback}
+                >
+                    <IllustrationStatic
+                        className={style.illustration}
+                        illustration={illustration}
+                    />
+                    <div className={style.panelHeader}>
+                        <span>{header}</span>
+                        {subHeader && (
+                            <span className={style.subHeader}>{subHeader}</span>
+                        )}
+                    </div>
+                </Accordion.Header>
+                <Accordion.Content>
+                    <CopyLink
+                        anchor={anchorIdWithHash}
+                        className={style.copyLink}
+                    />
+                    {error && <AlertBox variant={'error'}>{error}</AlertBox>}
+                    {isLoading ? (
+                        <div className={style.loader}>
+                            <Loader size={'2xlarge'} />
+                            <BodyShort>{loadingText}</BodyShort>
                         </div>
-                    </Accordion.Header>
-                    <Accordion.Content>
-                        <CopyLink
-                            anchor={anchorIdWithHash}
-                            className={style.copyLink}
-                        />
-                        {error && (
-                            <AlertBox variant={'error'}>{error}</AlertBox>
-                        )}
-                        {isLoading ? (
-                            <div className={style.loader}>
-                                <Loader size={'2xlarge'} />
-                                <BodyShort>{loadingText}</BodyShort>
-                            </div>
-                        ) : (
-                            children
-                        )}
-                    </Accordion.Content>
-                </Accordion.Item>
-            </Accordion>
-        </>
+                    ) : (
+                        children
+                    )}
+                </Accordion.Content>
+            </Accordion.Item>
+        </Accordion>
     );
 };

--- a/src/components/pages/forms-overview-page/FormsOverviewPage.module.scss
+++ b/src/components/pages/forms-overview-page/FormsOverviewPage.module.scss
@@ -10,7 +10,7 @@
       "main"
       "side";
 
-    @media #{common.$mq-screen-tablet} {
+    @media #{common.$mq-screen-tablet-and-desktop} {
       grid-template-columns: 6rem 2fr 6rem;
       grid-template-areas: 
         "pictogram main ."
@@ -18,7 +18,7 @@
       }
 
     &.withSideCol {
-        @media #{common.$mq-screen-desktop} {
+        @media #{common.$mq-screen-desktop-small-up} {
           grid-template-areas: "pictogram main side";
           grid-template-columns: 6rem 2fr 1fr;
         }
@@ -45,5 +45,15 @@
         width: 6rem;
         height: 6rem;
         display: block;
+    }
+}
+
+
+
+/* Innrykk i ekspanderende paneler */
+
+.main :global(.navds-accordion__content) {
+  @media #{common.$mq-screen-desktop} {
+      padding-left: 84px;
     }
 }

--- a/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
+++ b/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
@@ -26,8 +26,8 @@ const getLinksIfTransportPage = (audience: FormsOverviewAudienceOptions) => {
     }
 
     return pageType.links?.links.map((link) => ({
-        url: link.link._path,
-        text: link.text || link.link.data.title,
+        url: link.link?._path,
+        text: link.text || link.link?.data.title,
     }));
 };
 

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.module.scss
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.module.scss
@@ -3,6 +3,5 @@
 .filterSummary {
     display: flex;
     justify-content: space-between;
-    border-bottom: 1px common.$a-gray-300 solid;
     padding: 0.4rem 0;
 }

--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from 'components/_common/form-details/FormDetails';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
 import { ProductPanelExpandable } from 'components/_common/product-panel/ProductPanelExpandable';
-import { Ingress } from '@navikt/ds-react';
+import { BodyLong } from '@navikt/ds-react';
 import { FormsOverviewProductLink } from 'components/pages/forms-overview-page/forms-list/panel/product-link/FormsOverviewProductLink';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { Language, translator } from 'translations';
@@ -62,6 +62,7 @@ export const FormsOverviewListPanel = ({
         illustration,
         formDetailsPaths,
         title,
+        sortTitle,
         url,
         ingress,
         type,
@@ -109,7 +110,7 @@ export const FormsOverviewListPanel = ({
 
     return (
         <ProductPanelExpandable
-            header={title}
+            header={sortTitle}
             subHeader={buildSubHeader(taxonomy, area, language)}
             illustration={illustration}
             visible={visible}
@@ -122,7 +123,7 @@ export const FormsOverviewListPanel = ({
             }}
         >
             {!isAddendumPage && (
-                <Ingress className={style.ingress}>{ingress}</Ingress>
+                <BodyLong className={style.ingress}>{ingress}</BodyLong>
             )}
             {formDetailsPages?.map((formDetail) => (
                 <FormDetails

--- a/src/components/pages/overview-page/OverviewPage.module.scss
+++ b/src/components/pages/overview-page/OverviewPage.module.scss
@@ -36,6 +36,7 @@
 .filters {
     padding: common.$sectionPaddingDesktop / 2;
     max-width: common.$sectionMaxWidth;
+    background-color: white;
 
     @media #{common.$mq-screen-mobile} {
         padding: common.$sectionPaddingMobile;
@@ -43,7 +44,6 @@
 }
 
 .filters {
-    background-color: white;
     margin-bottom: 1rem;
     padding-bottom: 0;
 }

--- a/src/components/pages/overview-page/OverviewPage.module.scss
+++ b/src/components/pages/overview-page/OverviewPage.module.scss
@@ -34,7 +34,6 @@
 
 .productListWrapper,
 .filters {
-    background-color: white;
     padding: common.$sectionPaddingDesktop / 2;
     max-width: common.$sectionMaxWidth;
 
@@ -44,6 +43,7 @@
 }
 
 .filters {
-    margin-bottom: 1.5rem;
+    background-color: white;
+    margin-bottom: 1rem;
     padding-bottom: 0;
 }

--- a/src/components/pages/overview-page/OverviewPage.module.scss
+++ b/src/components/pages/overview-page/OverviewPage.module.scss
@@ -27,7 +27,13 @@
     }
 }
 
-.productListWrapper {
+.transparent {
+    background-color: transparent;
+    padding: 0;
+}
+
+.productListWrapper,
+.filters {
     background-color: white;
     padding: common.$sectionPaddingDesktop / 2;
     max-width: common.$sectionMaxWidth;
@@ -37,7 +43,7 @@
     }
 }
 
-.transparent {
-    background-color: transparent;
-    padding: 0;
+.filters {
+    margin-bottom: 1.5rem;
+    padding-bottom: 0;
 }

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -38,12 +38,14 @@ export const OverviewPage = (props: OverviewPageProps) => {
                 />
             </div>
             <div className={style.content}>
-                <OverviewFilters
-                    filterableItems={productList}
-                    showAreaFilter={true}
-                    showTaxonomyFilter={overviewType === 'all_products'}
-                    showTextInputFilter={overviewType === 'all_products'}
-                />
+                <div className={style.filters}>
+                    <OverviewFilters
+                        filterableItems={productList}
+                        showAreaFilter={true}
+                        showTaxonomyFilter={overviewType === 'all_products'}
+                        showTextInputFilter={overviewType === 'all_products'}
+                    />
+                </div>
                 <div
                     className={classNames(
                         style.productListWrapper,

--- a/src/types/content-props/animated-icons.ts
+++ b/src/types/content-props/animated-icons.ts
@@ -3,9 +3,6 @@ import { XpImageProps } from '../media';
 
 export type AnimatedIcon = {
     icon?: XpImageProps;
-    transformStart?: string;
-    transformEnd?: string;
-    transformOrigin?: string;
 };
 
 export type AnimatedIconsData = {

--- a/src/types/content-props/forms-overview.ts
+++ b/src/types/content-props/forms-overview.ts
@@ -10,6 +10,7 @@ import { ProductTaxonomy } from 'types/taxonomies';
 
 export type FormDetailsListItemProps = {
     title: string;
+    sortTitle: string;
     ingress: string;
     url: string;
     type: ContentType;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Skriver om StaticIllustration til å benytte inline svg'er.
- Styler om temafarge for StaticIllustration til en uniform farge for oversiktssider
- Diverse justeringer på styling for skjemaoversiktskomponenter
- Fjerner ubrukt `placement`-prop
- Fjerner ubrukte `transform*`-felter