### PR TITLE
Setter full høyde på bedriftskort for likhet der lang tekst

### DIFF
--- a/src/components/_common/employer-card/EmployerCard.module.scss
+++ b/src/components/_common/employer-card/EmployerCard.module.scss
@@ -1,5 +1,6 @@
 .employerCard {
     margin-bottom: 0;
+    height: 100%;
 
     :global(.employer-frontpage) {
         padding: 1.5rem;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter full høyde på bedriftskort for å gjøre de like høye der hvor det er lang tekst på enkelte kort. Gjelder bare enkelte brekkpunkt.
