### PR TITLE
Skriver om implementasjon av useSWRImmutableOnScrollIntoView

### DIFF
--- a/src/components/_common/illustration/IllustrationAnimated.tsx
+++ b/src/components/_common/illustration/IllustrationAnimated.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useId } from 'react';
 import { classNames } from 'utils/classnames';
 import { fetchJson } from 'utils/fetch/fetch-utils';
 import { useSWRImmutableOnScrollIntoView } from 'utils/fetch/useSWRImmutableOnScrollIntoView';
@@ -28,10 +28,12 @@ export const IllustrationAnimated = ({
     const lottieContainer = useRef<HTMLDivElement>(null);
     const lottiePlayer = useRef(null);
 
+    const elementId = useId();
+
     const { data: lottieData } = useSWRImmutableOnScrollIntoView({
         url: dataUrl,
         fetchFunc: fetchJsonData,
-        elementRef: lottieContainer,
+        elementId,
     });
 
     useEffect(() => {
@@ -79,7 +81,8 @@ export const IllustrationAnimated = ({
     return (
         <div
             className={classNames(styleCommon.image, className)}
-            aria-hidden="true"
+            aria-hidden={'true'}
+            id={elementId}
         >
             <div
                 ref={lottieContainer}

--- a/src/components/_common/illustration/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/IllustrationStatic.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import {
     AnimatedIcon,
     AnimatedIconsProps,
@@ -36,6 +36,8 @@ const StaticIcon = ({
     // Other formats are treated as a regular img
     const isSvg = icon.icon.mediaUrl.endsWith('svg');
 
+    const elementId = useId();
+
     const { data: svgData } = useSWRImmutableOnScrollIntoView({
         url: isSvg
             ? buildImageCacheUrl({
@@ -45,7 +47,7 @@ const StaticIcon = ({
               })
             : null,
         fetchFunc: fetchSvgData,
-        elementRef: ref,
+        elementId,
     });
 
     useEffect(() => {
@@ -55,7 +57,7 @@ const StaticIcon = ({
     }, [svgData]);
 
     return (
-        <span className={styleStatic.icon} ref={ref}>
+        <span className={styleStatic.icon} id={elementId} ref={ref}>
             {!isSvg && <XpImage imageProps={icon.icon} alt={''} />}
         </span>
     );

--- a/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
+++ b/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
@@ -5,58 +5,70 @@ import debounce from 'lodash.debounce';
 type Props<FetchResponse, ElementType extends HTMLElement = HTMLElement> = {
     url: string | null;
     fetchFunc: (url: string) => Promise<FetchResponse>;
-    elementRef: React.MutableRefObject<ElementType>;
+    elementId: string;
 };
 
-const VIEWPORT_PREFETCH_DISTANCE = 1;
+// Ensures fetch is performed immediately if the element is within one viewport height
+// of the current viewport
+const isNearOrAboveViewport = (elementId: string) => {
+    if (typeof window === 'undefined') {
+        return false;
+    }
 
-const isNearOrAboveViewport = (element?: HTMLElement) => {
+    const element = document.getElementById(elementId);
     if (!element) {
         return false;
     }
 
-    return (
-        element.getBoundingClientRect().y - window.innerHeight <
-        window.innerHeight * VIEWPORT_PREFETCH_DISTANCE
-    );
+    // If the browser does not support IntersectionObserver, ensure we always perform the fetch on load
+    if (typeof IntersectionObserver === 'undefined') {
+        return true;
+    }
+
+    return element.getBoundingClientRect().y < window.innerHeight * 2;
 };
 
 export const useSWRImmutableOnScrollIntoView = <FetchResponse>({
     url,
     fetchFunc,
-    elementRef,
+    elementId,
 }: Props<FetchResponse>) => {
-    const [isScrolledIntoView, setIsScrolledIntoView] = useState(false);
+    const [isScrolledIntoView, setIsScrolledIntoView] = useState(
+        isNearOrAboveViewport(elementId)
+    );
+
     const result = useSWRImmutable(isScrolledIntoView ? url : null, fetchFunc);
 
     useEffect(() => {
-        if (!url) {
+        if (isScrolledIntoView || !url) {
             return;
         }
 
-        const updateElementScrollStatus = debounce(
-            () => {
-                if (!isNearOrAboveViewport(elementRef.current)) {
-                    return false;
-                }
+        const element = document.getElementById(elementId);
+        if (!element) {
+            return;
+        }
 
-                setIsScrolledIntoView(true);
-                window.removeEventListener('scroll', updateElementScrollStatus);
-                return true;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0]?.isIntersecting) {
+                    setIsScrolledIntoView(true);
+                    observer.disconnect();
+                }
             },
-            50,
-            { maxWait: 100 }
+            {
+                root: null,
+                rootMargin: '100% 0%',
+                threshold: 0,
+            }
         );
 
-        if (updateElementScrollStatus()) {
-            return;
-        }
+        observer.observe(element);
 
-        window.addEventListener('scroll', updateElementScrollStatus);
         return () => {
-            window.removeEventListener('scroll', updateElementScrollStatus);
+            observer.disconnect();
         };
-    }, [elementRef, url]);
+    }, [elementId, url, isScrolledIntoView]);
 
     return result;
 };

--- a/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
+++ b/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
@@ -8,8 +8,7 @@ type Props<FetchResponse, ElementType extends HTMLElement = HTMLElement> = {
     elementRef: React.MutableRefObject<ElementType>;
 };
 
-// Start fetching when the element is less than half a viewport away from being visible
-const VIEWPORT_PREFETCH_DISTANCE = 0.5;
+const VIEWPORT_PREFETCH_DISTANCE = 1;
 
 const isNearOrAboveViewport = (element?: HTMLElement) => {
     if (!element) {
@@ -45,8 +44,8 @@ export const useSWRImmutableOnScrollIntoView = <FetchResponse>({
                 window.removeEventListener('scroll', updateElementScrollStatus);
                 return true;
             },
-            15,
-            { maxWait: 30 }
+            50,
+            { maxWait: 100 }
         );
 
         if (updateElementScrollStatus()) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Erstatter scroll event listeners med IntersectionObserver for å fange opp diverse edge-cases som ikke trigger scroll events. F.eks layout shifting ved dom-mutations. Er muligens også noe bedre for performance.
- Kjører fetch ved første render dersom elementet det sjekkes på er i nærheten av viewport'en, istedenfor å gjøre dette i en useEffect. Skal gi litt snarere innlasting.