### PR TITLE
Forbedrer fritekst-filter på oversiktssider

### DIFF
--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -16,5 +16,11 @@
 }
 
 .ingressWrapper {
-    margin-bottom: 1.75rem;
+    & > :last-child {
+        margin-bottom: 0;
+    }
+
+    &:not(:last-child) {
+        margin-bottom: 1.75rem;
+    }
 }

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -58,15 +58,17 @@ export const FormDetails = ({
                     <ParsedHtml htmlProps={formDetails.ingress} />
                 </div>
             )}
-            <div className={classNames(styles.variationWrapper)}>
-                {variations.map((variation, index: number) => (
-                    <FormDetailsButton
-                        key={variation.label}
-                        variation={variation}
-                        index={index}
-                    />
-                ))}
-            </div>
+            {variations.length > 0 && (
+                <div className={classNames(styles.variationWrapper)}>
+                    {variations.map((variation, index: number) => (
+                        <FormDetailsButton
+                            key={variation.label}
+                            variation={variation}
+                            index={index}
+                        />
+                    ))}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/_common/overview-filters/summary/OverviewFiltersSummary.module.scss
+++ b/src/components/_common/overview-filters/summary/OverviewFiltersSummary.module.scss
@@ -3,7 +3,7 @@
 .summary {
     display: inline-flex;
     align-items: center;
-    margin-top: 1rem;
+    margin: 1rem 0;
     border-bottom: 1px common.$a-gray-300 solid;
     width: 100%;
     height: 2.75rem;
@@ -28,7 +28,6 @@
 }
 
 .nohits {
-    margin-top: 0.75rem;
     background-color: common.$a-gray-100;
     padding: 1.5rem;
     border-radius: common.$border-radius-large;

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -35,9 +35,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
             ingress,
             title,
             sortTitle,
-        ]
-            .filter(Boolean)
-            .map((value) => value.toLowerCase());
+        ].map((value) => value?.toLowerCase() || '');
 
         return matchFilters({
             ...formDetail,

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -7,6 +7,8 @@ import { FormsOverviewListPanel } from 'components/pages/forms-overview-page/for
 import { OverviewFilters } from 'components/_common/overview-filters/OverviewFilters';
 import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
 import { OverviewFiltersSummary } from 'components/_common/overview-filters/summary/OverviewFiltersSummary';
+import { translator } from 'translations';
+import { usePageConfig } from 'store/hooks/usePageConfig';
 
 export const FormsOverviewList = (props: FormsOverviewProps) => {
     const {
@@ -17,14 +19,35 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
         overviewType,
     } = props.data;
 
+    const { language } = usePageConfig();
+
     const { matchFilters } = useOverviewFiltersState();
 
-    const isVisible = (formDetail: FormDetailsListItemProps) =>
-        matchFilters({
+    const isVisible = (formDetail: FormDetailsListItemProps) => {
+        const { area, taxonomy, ingress, title, sortTitle } = formDetail;
+
+        const areaTranslations = translator('areas', language);
+        const taxonomyTranslations = translator('taxonomies', language);
+
+        const fieldsToMatch = [
+            ...area.map(areaTranslations),
+            ...taxonomy.map(taxonomyTranslations),
+            ingress,
+            title,
+            sortTitle,
+        ]
+            .filter(Boolean)
+            .map((value) => value.toLowerCase());
+
+        return matchFilters({
             ...formDetail,
-            textMatchFunc: (textFilter) =>
-                formDetail.title.toLowerCase().includes(textFilter),
+            textMatchFunc: (textFilter) => {
+                return fieldsToMatch.some((value) =>
+                    value.includes(textFilter)
+                );
+            },
         });
+    };
 
     const numMatchingFilters = formDetailsList.filter(isVisible).length;
 

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -7,8 +7,6 @@ import { FormsOverviewListPanel } from 'components/pages/forms-overview-page/for
 import { OverviewFilters } from 'components/_common/overview-filters/OverviewFilters';
 import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
 import { OverviewFiltersSummary } from 'components/_common/overview-filters/summary/OverviewFiltersSummary';
-import { translator } from 'translations';
-import { usePageConfig } from 'store/hooks/usePageConfig';
 
 export const FormsOverviewList = (props: FormsOverviewProps) => {
     const {
@@ -19,19 +17,15 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
         overviewType,
     } = props.data;
 
-    const { language } = usePageConfig();
-
     const { matchFilters } = useOverviewFiltersState();
 
     const isVisible = (formDetail: FormDetailsListItemProps) => {
-        const { area, taxonomy, ingress, title, sortTitle } = formDetail;
-
-        const areaTranslations = translator('areas', language);
-        const taxonomyTranslations = translator('taxonomies', language);
+        const { ingress, title, sortTitle, formDetailsTitles, formNumbers } =
+            formDetail;
 
         const fieldsToMatch = [
-            ...area.map(areaTranslations),
-            ...taxonomy.map(taxonomyTranslations),
+            ...formDetailsTitles,
+            ...formNumbers,
             ingress,
             title,
             sortTitle,

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -23,7 +23,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
         matchFilters({
             ...formDetail,
             textMatchFunc: (textFilter) =>
-                textFilter === formDetail.title.toLowerCase(),
+                formDetail.title.toLowerCase().includes(textFilter),
         });
 
     const numMatchingFilters = formDetailsList.filter(isVisible).length;

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -22,7 +22,8 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
     const isVisible = (formDetail: FormDetailsListItemProps) =>
         matchFilters({
             ...formDetail,
-            text: formDetail.title,
+            textMatchFunc: (textFilter) =>
+                textFilter === formDetail.title.toLowerCase(),
         });
 
     const numMatchingFilters = formDetailsList.filter(isVisible).length;

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -22,7 +22,7 @@ export const OverviewPage = (props: OverviewPageProps) => {
         matchFilters({
             ...product,
             textMatchFunc: (textFilter) =>
-                textFilter === product.title.toLowerCase(),
+                product.title.toLowerCase().includes(textFilter),
         });
 
     const numVisibleProducts = productList.filter(isVisiblePredicate).length;

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -19,7 +19,11 @@ export const OverviewPage = (props: OverviewPageProps) => {
     const { matchFilters } = useOverviewFiltersState();
 
     const isVisiblePredicate = (product: SimplifiedProductData) =>
-        matchFilters({ ...product, text: product.title });
+        matchFilters({
+            ...product,
+            textMatchFunc: (textFilter) =>
+                textFilter === product.title.toLowerCase(),
+        });
 
     const numVisibleProducts = productList.filter(isVisiblePredicate).length;
 

--- a/src/components/pages/overview-page/product-elements/ProductLink.module.scss
+++ b/src/components/pages/overview-page/product-elements/ProductLink.module.scss
@@ -1,10 +1,6 @@
 .productLink {
     margin-bottom: 1rem;
 
-    &:first-child {
-        margin-top: 1rem;
-    }
-
     &:last-child {
         margin-bottom: 0;
     }

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -40,12 +40,12 @@ export const useOverviewFiltersState = () => {
             return false;
         }
 
-        const isSearchMatching =
+        const isTextFilterMatching =
             !textFilter ||
             !filterableContent.textMatchFunc ||
             filterableContent.textMatchFunc(textFilter);
 
-        return isSearchMatching;
+        return isTextFilterMatching;
     };
 
     return {

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -7,8 +7,8 @@ import { ContentType } from 'types/content-props/_content-common';
 export type OverviewFilterableItem = {
     area: Area[];
     taxonomy: ProductTaxonomy[];
-    text?: string;
     type?: ContentType;
+    textMatchFunc?: (textFilter: string) => boolean;
 };
 
 export const useOverviewFiltersState = () => {
@@ -42,9 +42,8 @@ export const useOverviewFiltersState = () => {
 
         const isSearchMatching =
             !textFilter ||
-            filterableContent.text
-                .toLowerCase()
-                .includes(textFilter.toLowerCase());
+            !filterableContent.textMatchFunc ||
+            filterableContent.textMatchFunc(textFilter);
 
         return isSearchMatching;
     };

--- a/src/store/slices/overviewFilters.ts
+++ b/src/store/slices/overviewFilters.ts
@@ -32,7 +32,7 @@ const overviewFiltersSlice = createSlice({
         },
         setTextFilter: (state, action: PayloadAction<{ text: string }>) => {
             const { text } = action.payload;
-            return { ...state, textFilter: text.toLowerCase() };
+            return { ...state, textFilter: text.toLowerCase().trim() };
         },
         resetFilters: () => {
             window.dispatchEvent(

--- a/src/store/slices/overviewFilters.ts
+++ b/src/store/slices/overviewFilters.ts
@@ -32,7 +32,7 @@ const overviewFiltersSlice = createSlice({
         },
         setTextFilter: (state, action: PayloadAction<{ text: string }>) => {
             const { text } = action.payload;
-            return { ...state, textFilter: text };
+            return { ...state, textFilter: text.toLowerCase() };
         },
         resetFilters: () => {
             window.dispatchEvent(

--- a/src/types/content-props/forms-overview.ts
+++ b/src/types/content-props/forms-overview.ts
@@ -19,6 +19,8 @@ export type FormDetailsListItemProps = {
     area: Area[];
     taxonomy: ProductTaxonomy[];
     formDetailsPaths: string[];
+    formDetailsTitles: string[];
+    formNumbers: string[];
 };
 
 export type FormsOverviewAudienceOptions = OptionSetSingle<{


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- useOverviewFiltersState tar nå inn en matcher-funksjon for å teste mot fritekst-filteret, istedenfor bare en string. Dermed kan det tilpasses med mer avansert matching.
- Bruker flere felter for å matche mot fritekst-filteret på skjemaoversikt. Sjekker nå produkt-ingress og begge title-varianter, og skjemanummer og tittel fra skjemadetaljer
- Diverse tweaks og bugfixes på styling (margins etc)