### PR TITLE
Fikser feil hvor varsel om tomt element vises til redaktørene

### DIFF
--- a/src/components/macros/video/MacroVideo.tsx
+++ b/src/components/macros/video/MacroVideo.tsx
@@ -69,7 +69,9 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
     }
 
     if (scriptState !== 'ready') {
-        return null;
+        // Must return empty div rather than null, otherwise the editor will report error and
+        // "empty element warning". Only an issue in editor mode.
+        return <div />;
     }
 
     const durationAsString = getTimestampFromDuration(duration);

--- a/src/components/macros/video/videoHelpers.ts
+++ b/src/components/macros/video/videoHelpers.ts
@@ -17,7 +17,7 @@ export const buildVideoMeta = (
     // For now, support legacy video with only the URL to go after.
     if (!video.targetContent) {
         const query = parse(video?.video?.split('?')[1]);
-        console.log(video);
+
         return {
             accountId: query?.accountId as string,
             title: video.title,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fikser feil hvor returnert null utløser feilmelding til redaktørene om at elementet er tomt redaktørmodus.

