### PR TITLE
Setter absolute url for CSS-url'er

### DIFF
--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -21,28 +21,28 @@
 
             .icon {
                 &.chat {
-                    background-image: url('/gfx/chat-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/chat-filled.svg');
                 }
 
                 &.write {
-                    background-image: url('/gfx/message-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/message-filled.svg');
                 }
 
                 &.call {
-                    background-image: url('/gfx/phone-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/phone-filled.svg');
                 }
 
                 &.navoffice,
                 &.aidcentral {
-                    background-image: url('/gfx/place-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/place-filled.svg');
                 }
 
                 &.facebook {
-                    background-image: url('/gfx/facebook-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/facebook-filled.svg');
                 }
 
                 &.linkedin {
-                    background-image: url('/gfx/linkedin-filled.svg');
+                    background-image: url('https://www.nav.no/gfx/linkedin-filled.svg');
                 }
             }
         }
@@ -71,40 +71,45 @@
 
         &.chat {
             margin-right: 0.7rem;
-            background-image: url('/gfx/chat.svg');
+            background-image: url('https://www.nav.no/gfx/chat.svg');
         }
 
         &.write {
-            background-image: url('/gfx/message.svg');
+            background-image: url('https://www.nav.no/gfx/message.svg');
         }
 
         &.call {
             margin-right: 0.5rem;
-            background-image: url('/gfx/phone.svg');
+            background-image: url('https://www.nav.no/gfx/phone.svg');
         }
 
         &.facebook {
-            background-image: url('/gfx/facebook.svg');
+            background-image: url('https://www.nav.no/gfx/facebook.svg');
         }
 
         &.navoffice,
         &.aidcentral {
-            background-image: url('/gfx/place.svg');
+            background-image: url('https://www.nav.no/gfx/place.svg');
         }
 
         &.linkedin {
-            background-image: url('/gfx/linkedin.svg');
+            background-image: url('https://www.nav.no/gfx/linkedin.svg');
         }
 
         &:after {
             // preload mouseover icons
             position: absolute;
             z-index: -1;
-            content: url('/gfx/chat-filled.svg') url('/gfx/message-filled.svg')
-                url('/gfx/phone-filled.svg') url('/gfx/facebook-filled.svg')
-                url('/gfx/linkedin-filled.svg') url('/gfx/chat.svg')
-                url('/gfx/message.svg') url('/gfx/phone.svg')
-                url('/gfx/facebook.svg') url('/gfx/linkedin.svg');
+            content: url('https://www.nav.no/gfx/chat-filled.svg')
+                url('https://www.nav.no/gfx/message-filled.svg')
+                url('https://www.nav.no/gfx/phone-filled.svg')
+                url('https://www.nav.no/gfx/facebook-filled.svg')
+                url('https://www.nav.no/gfx/linkedin-filled.svg')
+                url('https://www.nav.no/gfx/chat.svg')
+                url('https://www.nav.no/gfx/message.svg')
+                url('https://www.nav.no/gfx/phone.svg')
+                url('https://www.nav.no/gfx/facebook.svg')
+                url('https://www.nav.no/gfx/linkedin.svg');
         }
     }
 

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
@@ -24,29 +24,29 @@
     }
 
     .twitter {
-        background-image: url('/gfx/twitter-filled.svg');
+        background-image: url('https://www.nav.no/gfx/twitter-filled.svg');
         background-size: 1.1875rem 1rem;
 
         &:hover {
-            background-image: url('/gfx/twitter-inverted.svg');
+            background-image: url('https://www.nav.no/gfx/twitter-inverted.svg');
         }
     }
 
     .facebook {
-        background-image: url('/gfx/facebook-filled.svg');
+        background-image: url('https://www.nav.no/gfx/facebook-filled.svg');
         background-size: 0.5625rem 1.125rem;
 
         &:hover {
-            background-image: url('/gfx/facebook-inverted.svg');
+            background-image: url('https://www.nav.no/gfx/facebook-inverted.svg');
         }
     }
 
     .linkedin {
-        background-image: url('/gfx/linkedin-filled.svg');
+        background-image: url('https://www.nav.no/gfx/linkedin-filled.svg');
         background-size: 1rem 1rem;
 
         &:hover {
-            background-image: url('/gfx/linkedin-inverted.svg');
+            background-image: url('https://www.nav.no/gfx/linkedin-inverted.svg');
         }
     }
 
@@ -69,7 +69,8 @@
         // preload mouseover icons
         position: absolute;
         z-index: -1;
-        content: url('/gfx/twitter-inverted.svg')
-            url('/gfx/facebook-inverted.svg') url('/gfx/linkedin-inverted.svg');
+        content: url('https://www.nav.no/gfx/twitter-inverted.svg')
+            url('https://www.nav.no/gfx/facebook-inverted.svg')
+            url('https://www.nav.no/gfx/linkedin-inverted.svg');
     }
 }

--- a/src/components/parts/filters-menu/FilterCheckbox.module.scss
+++ b/src/components/parts/filters-menu/FilterCheckbox.module.scss
@@ -74,7 +74,7 @@
 
         &.selected {
             &:before {
-                background-image: url('/gfx/success-stroke.svg');
+                background-image: url('https://www.nav.no/gfx/success-stroke.svg');
                 box-shadow: 0 0 0;
             }
         }


### PR DESCRIPTION
Workaround for mulig bug ved bruk av assetPrefix/CDN. Ser ut til at de kun får origin fra assetPrefix'en, f.eks. `https://cdn.nav.no/gfx/chat.svg`