### PR TITLE
Setter inn nosnippet på kontorsidene

### DIFF
--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -39,7 +39,7 @@ const shouldNotIndex = (content: ContentProps) =>
     content.type === ContentType.Error ||
     content.data?.noindex;
 
-const sholdNotSnippet = (content: ContentProps) =>
+const shouldNotSnippet = (content: ContentProps) =>
     [ContentType.OfficeBranchPage].includes(content.type);
 
 const getCanonicalUrl = (content: ContentProps) => {
@@ -60,7 +60,7 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
-    const noSnippet = sholdNotSnippet(content);
+    const noSnippet = shouldNotSnippet(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 
     return (

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -39,6 +39,9 @@ const shouldNotIndex = (content: ContentProps) =>
     content.type === ContentType.Error ||
     content.data?.noindex;
 
+const sholdNotSnippet = (content: ContentProps) =>
+    [ContentType.OfficeBranchPage].includes(content.type);
+
 const getCanonicalUrl = (content: ContentProps) => {
     if (hasCanonicalUrl(content)) {
         return content.data.canonicalUrl;
@@ -57,6 +60,7 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
+    const noSnippet = sholdNotSnippet(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 
     return (
@@ -67,6 +71,7 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
             ) : (
                 <link rel={'canonical'} href={url} />
             )}
+            {noSnippet && <meta name={'robots'} content={'nosnippet'} />}
             <meta property={'og:title'} content={title} />
             <meta property={'og:site_name'} content={'nav.no'} />
             <meta property={'og:url'} content={url} />


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ref denne fra Tobias:
https://github.com/navikt/team-navno/issues/313

Snippets hentet fra kontorsidene fremstiller åpningstidene feil (se screenshot nedenfor), så jeg er enig i at vi bør slå de av. Ser ikke ut til at det er noen måte å styre hvilke deler av siden som Google skal hente snippets fra.
<img width="670" alt="Screenshot 2023-06-07 at 19 36 18" src="https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/41158de1-5829-416f-9704-00c1d79b6ba0">

## Testing
Testet i dev
