### PR TITLE
Kontorsider filtrere spesielle apningstider

### DIFF
--- a/src/components/_common/office-details/reception/SingleReception.tsx
+++ b/src/components/_common/office-details/reception/SingleReception.tsx
@@ -70,12 +70,22 @@ export const SingleReception = (props: AudienceReception) => {
         };
     };
 
-    const {
-        address,
-        adkomstbeskrivelse,
-        openingHours,
-        openingHoursExceptions,
-    } = formatAudienceReception(props);
+    const { address, adkomstbeskrivelse, openingHours } =
+        formatAudienceReception(props);
+
+    let { openingHoursExceptions } = formatAudienceReception(props);
+
+    const todaysDate: Date = new Date();
+    openingHoursExceptions = openingHoursExceptions
+        .filter((exception) => {
+            const openingHoursExceptionDate = new Date(exception.dato);
+            return openingHoursExceptionDate >= todaysDate;
+        })
+        .sort((a, b) => {
+            const dateA = new Date(a.dato).getTime();
+            const dateB = new Date(b.dato).getTime();
+            return dateA - dateB;
+        });
 
     return (
         <div className={styles.singleReception}>
@@ -92,6 +102,7 @@ export const SingleReception = (props: AudienceReception) => {
                     {adkomstbeskrivelse}
                 </BodyShort>
             </section>
+
             {openingHours.length > 0 && (
                 <>
                     <Heading

--- a/src/components/_common/office-details/reception/SingleReception.tsx
+++ b/src/components/_common/office-details/reception/SingleReception.tsx
@@ -75,10 +75,10 @@ export const SingleReception = (props: AudienceReception) => {
 
     let { openingHoursExceptions } = formatAudienceReception(props);
 
-    const todaysDate: Date = new Date();
-    openingHoursExceptions = openingHoursExceptions
+    const todaysDate: string = new Date().toISOString().slice(0, 10);
+    const futureOpeningHoursExceptions = openingHoursExceptions
         .filter((exception) => {
-            const openingHoursExceptionDate = new Date(exception.dato);
+            const openingHoursExceptionDate: string = exception.dato;
             return openingHoursExceptionDate >= todaysDate;
         })
         .sort((a, b) => {
@@ -123,12 +123,12 @@ export const SingleReception = (props: AudienceReception) => {
                     <OpeningHours openingHours={openingHours} />
                 </>
             )}
-            {openingHoursExceptions.length > 0 && (
+            {futureOpeningHoursExceptions.length > 0 && (
                 <>
                     <Heading level="3" size="medium" spacing>
                         {getLabel('specialOpeningHours')}
                     </Heading>
-                    <OpeningHours openingHours={openingHoursExceptions} />
+                    <OpeningHours openingHours={futureOpeningHoursExceptions} />
                 </>
             )}
             <div className={styles.appointmentBookingInfo}>


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Filtrere spesielle åpningstider ved at passerte datoer ikke vises 
-   Sortere etter dato fra lav til høy

## Testing

Har testet lokalt
