### PR TITLE
Legger på ignoreLocation for søket på skjemaoversikt

### DIFF
--- a/src/utils/text-search-utils.ts
+++ b/src/utils/text-search-utils.ts
@@ -4,6 +4,7 @@ const defaultOptions: Fuse.IFuseOptions<unknown> = {
     includeScore: true,
     includeMatches: true,
     findAllMatches: true,
+    ignoreLocation: true,
     distance: 250,
     threshold: 0.15,
 };


### PR DESCRIPTION
Ettersom vi kun søker i relativt korte strenger, så gir det ikke så mye mening å vekte basert på location i string'en