### PR TITLE
Fiks av center alignment for kontor-tags ved mange publikumsmottak

### DIFF
--- a/src/components/_common/headers/office-page-header/OfficePageHeader.module.scss
+++ b/src/components/_common/headers/office-page-header/OfficePageHeader.module.scss
@@ -40,7 +40,6 @@
 }
 
 .taglineWrapper {
-    align-items: center;
     display: flex;
     flex-wrap: nowrap;
     align-items: flex-start;

--- a/src/components/_common/headers/office-page-header/OfficePageHeader.module.scss
+++ b/src/components/_common/headers/office-page-header/OfficePageHeader.module.scss
@@ -42,27 +42,45 @@
 .taglineWrapper {
     align-items: center;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    align-items: flex-start;
 
     @media #{common.$mq-screen-mobile} {
         flex-direction: column;
         align-items: flex-start;
+        flex-wrap: wrap;
     }
 }
 
 .taglineLabel {
     color: var(--a-gray-800);
+    text-align: left;
+    white-space: nowrap;
+    display: flex;
+
     @media #{common.$mq-screen-mobile} {
         margin-bottom: 0.5rem;
-        text-align: left;
     }
 }
 
-.divider {
-    padding: 0 0.75rem;
-
+.branchNamesLabel {
+    color: var(--a-gray-800);
+    text-align: left;
+    display: flex;
     @media #{common.$mq-screen-mobile} {
-        display: none;
+        margin-bottom: 0.5rem;
+    }
+
+    &::before {
+        content: '';
+        border-left: 1px solid black;
+        display: flex;
+        padding: 0 0.75rem 0 0;
+        margin-left: 0.75rem;
+
+        @media #{common.$mq-screen-mobile} {
+            display: none;
+        }
     }
 }
 

--- a/src/components/_common/headers/office-page-header/OfficePageHeader.tsx
+++ b/src/components/_common/headers/office-page-header/OfficePageHeader.tsx
@@ -44,12 +44,9 @@ export const OfficePageHeader = ({ officeDetails }: Props) => {
                     </BodyShort>
                     {subTitle && (
                         <>
-                            <span aria-hidden="true" className={style.divider}>
-                                {'|'}
-                            </span>
                             <BodyShort
                                 size="small"
-                                className={style.taglineLabel}
+                                className={style.branchNamesLabel}
                             >
                                 {subTitle}
                             </BodyShort>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
NAV-kontor med mange publikumsmottak og lange navn på hvert mottak gjør at det ikke ser supersexy ut på kontorsidene. Dette er en fiks som ihvertfall sørger for at tagline blir posisjonert litt penere ved flere linjer av publikumsottak.

![Screenshot 2023-06-15 at 15 12 01](https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/ebe8940c-c4a4-485c-a37b-eeba8034b580)

## Testing
Testes i dev