### PR TITLE
Fjerne nosnippet og endre til "telefontid" på kontorsider

### DIFF
--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -39,9 +39,6 @@ const shouldNotIndex = (content: ContentProps) =>
     content.type === ContentType.Error ||
     content.data?.noindex;
 
-const shouldNotSnippet = (content: ContentProps) =>
-    [ContentType.OfficeBranchPage].includes(content.type);
-
 const getCanonicalUrl = (content: ContentProps) => {
     if (hasCanonicalUrl(content)) {
         return content.data.canonicalUrl;
@@ -60,7 +57,6 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
-    const noSnippet = shouldNotSnippet(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 
     return (
@@ -71,7 +67,6 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
             ) : (
                 <link rel={'canonical'} href={url} />
             )}
-            {noSnippet && <meta name={'robots'} content={'nosnippet'} />}
             <meta property={'og:title'} content={title} />
             <meta property={'og:site_name'} content={'nav.no'} />
             <meta property={'og:url'} content={url} />

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -273,7 +273,7 @@ export const translationsBundleNb = {
         officeNumber: 'Kontornummer',
         phoneToNav: 'Telefonnummeret til NAV er',
         phoneInformation:
-            'Åpent hverdager kl. 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
+            'Telefontid hverdager kl. 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
         alternativeContacts: 'Andre kontaktopplysninger:',
     },
     dateTime: {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -154,7 +154,7 @@ export const translationsBundleEn: Translations = {
         officeNumber: 'Office number',
         phoneToNav: 'NAV phone number is',
         phoneInformation:
-            'Open, weekdays at 9-15. NAV call center will assist you or connect you with your NAV office.',
+            'Phone hours, weekdays at 9-15. NAV call center will assist you or connect you with your NAV office.',
         alternativeContacts: 'Other contact options:',
     },
     dateTime: {

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -188,7 +188,7 @@ export const translationsBundleNn: Translations = {
         officeNumber: 'Kontornummer',
         phoneToNav: 'Telefonnummeret til NAV er',
         phoneInformation:
-            'Opent kvardagar kl 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
+            'Telefontid kvardagar kl 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
         alternativeContacts: 'Andre kontaktopplysningar:',
     },
     overview: {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fjernet nosnippet etter enighet i teamet.
- Endrer "Åpent" til "Telefontid" for mer korrekthet på Google snippet ved søk.

## Testing
Testet i dev