### PR TITLE
Viser 404 dersom man forsøker å se skjemadetalj isolert og utenfor CS

### DIFF
--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -3,6 +3,7 @@ import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
 
 import styles from './FormDetailsPreviewPage.module.scss';
+import ErrorPage404 from 'pages/404';
 
 const displayConfig = {
     showTitle: true,
@@ -11,7 +12,11 @@ const displayConfig = {
     showApplications: true,
 };
 
-export const FormDetailsPreviewPage = ({ data }: FormDetailsPageProps) => {
+export const FormDetailsPreviewPage = (props: FormDetailsPageProps) => {
+    const { data, editorView } = props;
+    if (!editorView) {
+        return <ErrorPage404 />;
+    }
     return (
         <div className={styles.formDetailsPreviewPage}>
             <FormDetails formDetails={data} displayConfig={displayConfig} />


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Hindrer at skjemadetaljer vises isolert i preview-siden offentlig uten å ha kontekst (feks produktsider) rundt seg.

## Testing
Testet i dev
