### PR TITLE
Press landing page cleanup

### DIFF
--- a/src/components/_common/press-landing/PressNews.tsx
+++ b/src/components/_common/press-landing/PressNews.tsx
@@ -5,7 +5,6 @@ import { Next } from '@navikt/ds-icons';
 import { PressNewsItem } from './PressNewsItem';
 
 import styles from './PressNews.module.scss';
-import { MainArticleProps } from 'types/content-props/main-article-props';
 
 type PressNewsProps = {
     page: PressLandingPageProps;
@@ -13,7 +12,7 @@ type PressNewsProps = {
 
 export const PressNews = (props: PressNewsProps) => {
     const { language } = props.page;
-    const { pressNews, moreNewsUrl, maxNewsCount } = props.page?.data;
+    const { pressNews, moreNewsUrl } = props.page?.data;
 
     const getTranslations = translator('pressLanding', language);
 
@@ -24,16 +23,6 @@ export const PressNews = (props: PressNewsProps) => {
         return null;
     }
 
-    const pressNewsItems = pressNews.data.sectionContents
-        .sort((a: MainArticleProps, b: MainArticleProps) => {
-            if (!a?.publish?.first || !b?.publish?.first) {
-                return 0;
-            }
-
-            return a.publish.first < b.publish.first ? 1 : -1;
-        })
-        .slice(0, parseInt(maxNewsCount, 10) || 5);
-
     return (
         <div className={styles.pressNews}>
             <div className={styles.content}>
@@ -41,7 +30,7 @@ export const PressNews = (props: PressNewsProps) => {
                     {getTranslations('latestPressNews')}
                 </Heading>
                 <ul className={styles.newsList}>
-                    {pressNewsItems.map((newsItem) => (
+                    {pressNews.data.sectionContents.map((newsItem) => (
                         <PressNewsItem
                             newsItem={newsItem}
                             key={newsItem._path}

--- a/src/components/_common/press-landing/PressNewsItem.tsx
+++ b/src/components/_common/press-landing/PressNewsItem.tsx
@@ -6,8 +6,8 @@ import { shortenText } from 'utils/string';
 import { StaticImage } from '../image/StaticImage';
 import { getPublicPathname } from 'utils/urls';
 import { formatDate } from 'utils/datetime';
-
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
+
 import styles from './PressNewsItem.module.scss';
 
 type PressNewsItemProps = {
@@ -50,7 +50,7 @@ export const PressNewsItem = ({ newsItem }: PressNewsItemProps) => {
                 <Detail className={styles.publishDate}>
                     {getTranslations('published')}{' '}
                     {formatDate({
-                        datetime: newsItem.publish.first,
+                        datetime: newsItem.publish.from,
                         language,
                         short: true,
                         year: true,

--- a/src/components/_common/press-landing/PressShortcuts.tsx
+++ b/src/components/_common/press-landing/PressShortcuts.tsx
@@ -1,9 +1,9 @@
 import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
 import { translator } from 'translations';
-
-import styles from './PressShortcuts.module.scss';
 import { Heading, LinkPanel } from '@navikt/ds-react';
 import { getPublicPathname } from 'utils/urls';
+
+import styles from './PressShortcuts.module.scss';
 
 type PressShortcutsProps = {
     page: PressLandingPageProps;
@@ -11,22 +11,16 @@ type PressShortcutsProps = {
 
 export const PressShortcuts = (props: PressShortcutsProps) => {
     const { language } = props.page;
-    const { maxShortcutsCount } = props.page?.data;
     const getTranslations = translator('pressLanding', language);
 
     const shortcuts = props.page.data?.shortcuts;
 
     if (
         !shortcuts?.data?.sectionContents ||
-        shortcuts?.data?.sectionContents?.length === 0
+        shortcuts.data.sectionContents.length === 0
     ) {
         return null;
     }
-
-    const shortcutItems = shortcuts.data.sectionContents.slice(
-        0,
-        parseInt(maxShortcutsCount, 10) || 5
-    );
 
     return (
         <div className={styles.pressShortcuts}>
@@ -35,7 +29,7 @@ export const PressShortcuts = (props: PressShortcutsProps) => {
                     {getTranslations('pressShortcuts')}
                 </Heading>
                 <ul className={styles.shortcutList}>
-                    {shortcutItems.map((shortcut) => {
+                    {shortcuts.data.sectionContents.map((shortcut) => {
                         return (
                             <li key={shortcut._path}>
                                 <LinkPanel

--- a/src/components/pages/press-landing-page/PressLandingPage.tsx
+++ b/src/components/pages/press-landing-page/PressLandingPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PressLandingPageProps } from '../../../types/content-props/dynamic-page-props';
+import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
 import { PressTopSection } from 'components/_common/press-landing/PressTopSection';
 import { PressNews } from 'components/_common/press-landing/PressNews';
 import { PressShortcuts } from 'components/_common/press-landing/PressShortcuts';

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -38,8 +38,6 @@ export type PressLandingPageData = Partial<{
     pressNews: ContentListProps;
     shortcuts: ContentListProps;
     moreNewsUrl: string;
-    maxNewsCount: string;
-    maxShortcutsCount: string;
 }>;
 
 export type DynamicPageProps = ContentCommonProps & {


### PR DESCRIPTION
- Fjerner pruning/sortinger av lister, ettersom dette nå håndteres på backend
- Viser publish.from som publiseringstidspunkt