### PR TITLE
Fikser 404-feil ved fetch av produkt- og skjemadetaljer på oversiktssider

### DIFF
--- a/src/components/_common/redirect-to-404/RedirectTo404.tsx
+++ b/src/components/_common/redirect-to-404/RedirectTo404.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+
+const NOT_FOUND_URL = `${process.env.APP_ORIGIN}/404`;
+
+export const RedirectTo404 = () => {
+    useEffect(() => {
+        window.location.replace(NOT_FOUND_URL);
+    }, []);
+
+    return null;
+};

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
+import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';
 
 import styles from './FormDetailsPreviewPage.module.scss';
 
@@ -12,7 +13,11 @@ const displayConfig = {
 };
 
 export const FormDetailsPreviewPage = (props: FormDetailsPageProps) => {
-    const { data } = props;
+    const { data, editorView } = props;
+
+    if (!editorView) {
+        return <RedirectTo404 />;
+    }
 
     return (
         <div className={styles.formDetailsPreviewPage}>

--- a/src/components/pages/product-details-page/ProductDetailsPage.tsx
+++ b/src/components/pages/product-details-page/ProductDetailsPage.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { ComponentMapper } from '../../ComponentMapper';
 import { ProductDetailsProps } from 'types/content-props/dynamic-page-props';
 import { ProductDetailsUsageCheck } from './product-details-usage-check/ProductDetailsUsageCheck';
+import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';
 
 export const ProductDetailsPage = (props: ProductDetailsProps) => {
+    if (!props.editorView) {
+        return <RedirectTo404 />;
+    }
+
     return (
         // Samme styling som ProductPage
         <div className={'productPage'}>

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -8,12 +8,10 @@ export const logPageLoadError = (errorId: string, message: string) =>
 
 const isPreviewOnly = new Set<ContentType>([
     ContentType.ContactInformationPage,
-    ContentType.FormDetails,
     ContentType.Fragment,
     ContentType.GlobalNumberValuesSet,
     ContentType.GlobalCaseTimeSet,
     ContentType.PayoutDates,
-    ContentType.ProductDetails,
     ContentType.TemplatePage,
     ContentType.PublishingCalendarEntry,
 ]);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Returnerer ikke lengre notFound response fra serveren for innholdstypene form-details og product-details, ettersom disse benyttes som data for oversiktssider. Erstatter dette med redirect til 404 dersom previewet lastes av publikum.

Vanskelig å løse denne på noen bedre måte med innebygd next.js funksjonalitet. Kunne sette opp noe på custom serveren, men dette er et ganske smalt case. Produkt/skjema-detaljer skal ikke vises som selvstendige sider til publikum, men det er uansett ikke noe vi skal lenke til direkte, så det burde ikke skje ofte.