### PR TITLE
Feat marginbottom button part

### DIFF
--- a/src/components/_common/button/Button.module.scss
+++ b/src/components/_common/button/Button.module.scss
@@ -3,14 +3,15 @@
 .button {
     white-space: break-spaces;
 
+    &:global(.buttonPart) {
+        margin-bottom: 1rem;
+    }
     &__icon {
         height: 1.5rem;
     }
-
     &--fullWidth {
         width: 100%;
     }
-
     :global(.navds-label) {
         text-align: center;
     }

--- a/src/components/_common/button/Button.module.scss
+++ b/src/components/_common/button/Button.module.scss
@@ -4,7 +4,7 @@
     white-space: break-spaces;
 
     &:global(.buttonPart) {
-        margin-bottom: 1rem;
+        margin-bottom: var(--a-spacing-7);
     }
     &__icon {
         height: 1.5rem;

--- a/src/components/parts/button/ButtonPart.tsx
+++ b/src/components/parts/button/ButtonPart.tsx
@@ -33,6 +33,7 @@ export const ButtonPart = ({ config }: ButtonPartProps) => {
 
     return (
         <Button
+            className="buttonPart"
             href={linkProps.url}
             variant={typePropToVariant[type]}
             xpIcon={icon}


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Legger til margin-bottom som for et avsnitt når en knapp er satt inn som en part.
(Knapp satt inn som makro vil legges i et avsnitt og få margin gjennom det.)

## Testing

Har testet selv lokalt og i dev

## Dette trenger jeg å få et ekstra blikk på
Er dette en grei løsning? Undergraver det komponent-designet vårt?

## Skjermbilde etter justering
![Skjermbilde 2023-06-29 kl  13 36 37](https://github.com/navikt/nav-enonicxp-frontend/assets/35491554/5c2eaa3a-d8f3-4638-8fa4-142702c1fd82)


