### PR TITLE
Viser skjemanummer på skjemaoversikter

### DIFF
--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -62,6 +62,7 @@
     & > * {
         padding: 0.25rem;
         white-space: nowrap;
+        color: var(--a-gray-600);
 
         &:first-child:not(.highlight) {
             padding-left: 0;
@@ -71,6 +72,7 @@
 
 .highlight {
     background-color: var(--a-deepblue-100);
+    color: var(--a-gray-800);
 }
 
 .separator {

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -31,7 +31,7 @@
     }
 }
 
-.variationWrapper {
+.variation {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -42,7 +42,7 @@
     }
 }
 
-.ingressWrapper {
+.ingress {
     & > :last-child {
         margin-bottom: 0;
     }

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -60,7 +60,7 @@
     margin-bottom: 0.75rem;
 
     & > * {
-        padding: 0.125rem 0.3125rem;
+        padding: 0.0625rem 0.3125rem;
         white-space: nowrap;
         color: var(--a-gray-600);
 
@@ -73,7 +73,7 @@
 .highlight {
     background-color: var(--a-lightblue-200);
     color: var(--a-gray-800);
-    border-radius: var(--a-border-radius-small);
+    border-radius: var(--a-border-radius-medium);
 }
 
 .separator {

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -52,7 +52,7 @@
     }
 }
 
-.formNumberContainer {
+.formNumbers {
     display: flex;
     flex-wrap: wrap;
     align-items: center;

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -21,7 +21,7 @@
     }
 
     h3 {
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.375rem;
     }
 
     // pull lists upward to text above if any.
@@ -60,7 +60,7 @@
     margin-bottom: 0.75rem;
 
     & > * {
-        padding: 0.25rem;
+        padding: 0.125rem 0.3125rem;
         white-space: nowrap;
         color: var(--a-gray-600);
 
@@ -71,11 +71,14 @@
 }
 
 .highlight {
-    background-color: var(--a-deepblue-100);
+    background-color: var(--a-lightblue-200);
     color: var(--a-gray-800);
+    border-radius: var(--a-border-radius-small);
 }
 
 .separator {
+    color: var(--a-border-default);
+
     @media #{common.$mq-screen-mobile} {
         display: none;
     }

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -57,7 +57,7 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 0.125rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 1rem;
 
     & > * {
         padding: 0.0625rem 0.3125rem;

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -72,3 +72,9 @@
 .highlight {
     background-color: var(--a-deepblue-100);
 }
+
+.separator {
+    @media #{common.$mq-screen-mobile} {
+        display: none;
+    }
+}

--- a/src/components/_common/form-details/FormDetails.module.scss
+++ b/src/components/_common/form-details/FormDetails.module.scss
@@ -21,7 +21,7 @@
     }
 
     h3 {
-        margin-bottom: 1rem;
+        margin-bottom: 0.25rem;
     }
 
     // pull lists upward to text above if any.
@@ -50,4 +50,25 @@
     &:not(:last-child) {
         margin-bottom: 1.75rem;
     }
+}
+
+.formNumberContainer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.125rem;
+    margin-bottom: 0.75rem;
+
+    & > * {
+        padding: 0.25rem;
+        white-space: nowrap;
+
+        &:first-child:not(.highlight) {
+            padding-left: 0;
+        }
+    }
+}
+
+.highlight {
+    background-color: var(--a-deepblue-100);
 }

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -107,7 +107,7 @@ export const FormDetails = ({
                 </div>
             )}
             {variations.length > 0 && (
-                <div className={classNames(style.variation)}>
+                <div className={style.variation}>
                     {variations.map((variation, index) => (
                         <FormDetailsButton
                             key={variation.label}

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -56,7 +56,7 @@ export const FormDetails = ({
 
     const formNumberToHighlight =
         formNumberSelected &&
-        formNumbers.find((formNumber) =>
+        formNumbers?.find((formNumber) =>
             formNumber.toLowerCase().endsWith(formNumberSelected)
         );
 

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -12,6 +12,7 @@ export type FormDetailsComponentProps = {
     displayConfig: {
         showTitle: boolean;
         showIngress: boolean;
+        showFormNumbers?: boolean;
         showAddendums?: boolean;
         showApplications?: boolean;
         showComplaints?: boolean;
@@ -32,42 +33,49 @@ export const FormDetails = ({
         showComplaints = true,
         showIngress,
         showTitle,
+        showFormNumbers,
     } = displayConfig;
 
     const { formNumbers, formType, ingress, title } = formDetails;
 
     const variations = formType.reduce((acc, cur) => {
+        const { _selected } = cur;
+
         if (
-            (cur._selected === 'addendum' && !showAddendums) ||
-            (cur._selected === 'application' && !showApplications) ||
-            (cur._selected === 'complaint' && !showComplaints)
+            (_selected === 'addendum' && !showAddendums) ||
+            (_selected === 'application' && !showApplications) ||
+            (_selected === 'complaint' && !showComplaints)
         ) {
             return acc;
         }
 
-        const variations = cur[cur._selected]?.variations;
+        const variations = cur[_selected]?.variations;
 
         return variations ? [...acc, ...variations] : acc;
     }, []) as Variation[];
 
-    const formNumberToShow =
+    const formNumberToHighlight =
         formNumberSelected &&
         formNumbers.find((formNumber) =>
             formNumber.toLowerCase().endsWith(formNumberSelected)
         );
 
+    const hasVisibleTitle = showTitle && title;
+    const hasVisibleIngress = showIngress && ingress;
+    const hasVisibleFormNumbers = formNumbers && showFormNumbers;
+
     return (
         <div className={classNames(style.formDetails, className)}>
-            {showTitle && title && (
+            {hasVisibleTitle && (
                 <Heading
                     size="medium"
                     level="3"
-                    spacing={(!showIngress || !ingress) && !formNumbers}
+                    spacing={!hasVisibleIngress && !hasVisibleFormNumbers}
                 >
                     {title}
                 </Heading>
             )}
-            {formNumbers && (
+            {hasVisibleFormNumbers && (
                 <Detail className={style.formNumbers}>
                     {formNumbers.map((formNumber, index) => (
                         <Fragment key={formNumber}>
@@ -81,7 +89,7 @@ export const FormDetails = ({
                             )}
                             <span
                                 className={
-                                    formNumber === formNumberToShow
+                                    formNumber === formNumberToHighlight
                                         ? style.highlight
                                         : undefined
                                 }
@@ -93,14 +101,14 @@ export const FormDetails = ({
                     ))}
                 </Detail>
             )}
-            {showIngress && ingress && (
-                <div className={style.ingressWrapper}>
+            {hasVisibleIngress && (
+                <div className={style.ingress}>
                     <ParsedHtml htmlProps={ingress} />
                 </div>
             )}
             {variations.length > 0 && (
-                <div className={classNames(style.variationWrapper)}>
-                    {variations.map((variation, index: number) => (
+                <div className={classNames(style.variation)}>
+                    {variations.map((variation, index) => (
                         <FormDetailsButton
                             key={variation.label}
                             variation={variation}

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,11 +1,11 @@
-import { Heading } from '@navikt/ds-react';
+import React, { Fragment } from 'react';
+import { Detail, Heading } from '@navikt/ds-react';
 import classNames from 'classnames';
-
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { FormDetailsButton } from './FormDetailsButton';
 
-import styles from './FormDetails.module.scss';
+import style from './FormDetails.module.scss';
 
 export type FormDetailsComponentProps = {
     formDetails: FormDetailsData;
@@ -17,22 +17,26 @@ export type FormDetailsComponentProps = {
         showComplaints?: boolean;
     };
     className?: string;
+    formNumberSelected?: string;
 };
 
 export const FormDetails = ({
     formDetails,
     displayConfig,
     className,
+    formNumberSelected,
 }: FormDetailsComponentProps) => {
     const {
         showAddendums = true,
         showApplications = true,
         showComplaints = true,
-        showTitle,
         showIngress,
+        showTitle,
     } = displayConfig;
 
-    const variations = formDetails.formType.reduce((acc, cur) => {
+    const { formNumbers, formType, ingress, title } = formDetails;
+
+    const variations = formType.reduce((acc, cur) => {
         if (
             (cur._selected === 'addendum' && !showAddendums) ||
             (cur._selected === 'application' && !showApplications) ||
@@ -46,20 +50,45 @@ export const FormDetails = ({
         return variations ? [...acc, ...variations] : acc;
     }, []) as Variation[];
 
+    const formNumberToShow =
+        formNumberSelected &&
+        formNumbers.find((formNumber) =>
+            formNumber.toLowerCase().endsWith(formNumberSelected)
+        );
+
     return (
-        <div className={classNames(styles.formDetails, className)}>
-            {(showTitle && formDetails.title) && (
+        <div className={classNames(style.formDetails, className)}>
+            {showTitle && title && (
                 <Heading size="medium" level="3" spacing={!showIngress}>
-                    {formDetails.title}
+                    {title}
                 </Heading>
             )}
-            {(showIngress && formDetails.ingress) && (
-                <div className={styles.ingressWrapper}>
-                    <ParsedHtml htmlProps={formDetails.ingress} />
+            {formNumbers && (
+                <Detail className={style.formNumberContainer}>
+                    {formNumbers.map((formNumber, index) => (
+                        <Fragment key={formNumber}>
+                            {index > 0 && '|'}
+                            <span
+                                className={
+                                    formNumber === formNumberToShow
+                                        ? style.highlight
+                                        : undefined
+                                }
+                                key={formNumber}
+                            >
+                                {formNumber}
+                            </span>
+                        </Fragment>
+                    ))}
+                </Detail>
+            )}
+            {showIngress && ingress && (
+                <div className={style.ingressWrapper}>
+                    <ParsedHtml htmlProps={ingress} />
                 </div>
             )}
             {variations.length > 0 && (
-                <div className={classNames(styles.variationWrapper)}>
+                <div className={classNames(style.variationWrapper)}>
                     {variations.map((variation, index: number) => (
                         <FormDetailsButton
                             key={variation.label}

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -28,12 +28,12 @@ export const FormDetails = ({
     formNumberSelected,
 }: FormDetailsComponentProps) => {
     const {
+        showTitle,
+        showIngress,
+        showFormNumbers,
         showAddendums = true,
         showApplications = true,
         showComplaints = true,
-        showIngress,
-        showTitle,
-        showFormNumbers,
     } = displayConfig;
 
     const { formNumbers, formType, ingress, title } = formDetails;

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -59,7 +59,11 @@ export const FormDetails = ({
     return (
         <div className={classNames(style.formDetails, className)}>
             {showTitle && title && (
-                <Heading size="medium" level="3" spacing={!showIngress}>
+                <Heading
+                    size="medium"
+                    level="3"
+                    spacing={(!showIngress || !ingress) && !formNumbers}
+                >
                     {title}
                 </Heading>
             )}
@@ -67,7 +71,14 @@ export const FormDetails = ({
                 <Detail className={style.formNumberContainer}>
                     {formNumbers.map((formNumber, index) => (
                         <Fragment key={formNumber}>
-                            {index > 0 && '|'}
+                            {index > 0 && (
+                                <span
+                                    aria-hidden={true}
+                                    className={style.separator}
+                                >
+                                    {'|'}
+                                </span>
+                            )}
                             <span
                                 className={
                                     formNumber === formNumberToShow

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -68,7 +68,7 @@ export const FormDetails = ({
                 </Heading>
             )}
             {formNumbers && (
-                <Detail className={style.formNumberContainer}>
+                <Detail className={style.formNumbers}>
                     {formNumbers.map((formNumber, index) => (
                         <Fragment key={formNumber}>
                             {index > 0 && (

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -62,7 +62,7 @@ export const FormDetails = ({
 
     const hasVisibleTitle = showTitle && title;
     const hasVisibleIngress = showIngress && ingress;
-    const hasVisibleFormNumbers = formNumbers && showFormNumbers;
+    const hasVisibleFormNumbers = showFormNumbers && formNumbers;
 
     return (
         <div className={classNames(style.formDetails, className)}>

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -95,6 +95,11 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
                             formDetails={formDetail}
                             visible={isVisible(formDetail)}
                             overviewType={overviewType}
+                            formNumberSelected={
+                                isFormNumber(textFilter)
+                                    ? textFilter
+                                    : undefined
+                            }
                         />
                     </li>
                 ))}

--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -52,12 +52,14 @@ type Props = {
     formDetails: FormDetailsListItemProps;
     visible: boolean;
     overviewType: OverviewType;
+    formNumberSelected?: string;
 };
 
 export const FormsOverviewListPanel = ({
     formDetails,
     visible,
     overviewType,
+    formNumberSelected,
 }: Props) => {
     const {
         anchorId,
@@ -132,6 +134,7 @@ export const FormsOverviewListPanel = ({
                     formDetails={formDetail.data}
                     displayConfig={getFormDetailsDisplayOptions(overviewType)}
                     className={style.formDetails}
+                    formNumberSelected={formNumberSelected}
                     key={formDetail._id}
                 />
             ))}

--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -29,6 +29,7 @@ const getFormDetailsDisplayOptions = (
         showAddendums: true,
         showApplications: overviewType === 'application',
         showComplaints: overviewType === 'complaint',
+        showFormNumbers: true,
     };
 };
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Viser skjemanumre på skjemaoversikter, med highlighting for søketreff. Mulig det blir noen justeringer på designet.

![form-numbers-2](https://github.com/navikt/nav-enonicxp-frontend/assets/18137669/5f200db4-2f6a-4e28-bab0-e7c543133333)

