### PR TITLE
Fikser diverse issues med video macro

### DIFF
--- a/src/components/macros/video/MacroVideo.module.scss
+++ b/src/components/macros/video/MacroVideo.module.scss
@@ -2,24 +2,6 @@
     margin-bottom: 2rem;
 }
 
-.widgetId {
-    //styling fra Qbrick doc: https://video.qbrick.com/docs/api/#examples.play2-script-adaptive
-    padding-bottom: 56.25%; /* 16:9 aspect ratio */
-    position: relative !important;
-    height: 100% !important;
-    width: 100% !important;
-
-    & > div:first-of-type {
-        bottom: 0;
-        left: 0;
-        position: absolute !important;
-        right: 0;
-        top: 0;
-        height: 100% !important;
-        width: 100% !important;
-    }
-}
-
 .button {
     width: 100%;
     justify-content: flex-start;
@@ -65,6 +47,24 @@
     :global(.gobrain-poster) {
         //hindrer "flash" av forhåndsvisningsbilde før videoen starter
         display: none;
+    }
+
+    & > div {
+        //styling fra Qbrick doc: https://video.qbrick.com/docs/api/#examples.play2-script-adaptive
+        padding-bottom: 56.25%; /* 16:9 aspect ratio */
+        position: relative !important;
+        height: 100% !important;
+        width: 100% !important;
+
+        & > div:first-of-type {
+            bottom: 0;
+            left: 0;
+            position: absolute !important;
+            right: 0;
+            top: 0;
+            height: 100% !important;
+            width: 100% !important;
+        }
     }
 }
 

--- a/src/components/macros/video/MacroVideo.tsx
+++ b/src/components/macros/video/MacroVideo.tsx
@@ -35,6 +35,8 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
     const translations = translator('macroVideo', language);
     const { accountId, mediaId, title, duration, poster } = videoMeta;
 
+    console.log(accountId, mediaId, isPlayerLoaded);
+
     const getVideoMetaFromQbrick = async () => {
         const metaUrl = `https://video.qbrick.com/api/v1/public/accounts/${accountId}/medias/${mediaId}`;
 
@@ -54,6 +56,7 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
     };
 
     const pollPlayerState = (timeLeft = PLAYER_TIMEOUT_MS) => {
+        // console.log(mediaId, isPlayerLoaded);
         if (isPlayerLoaded) {
             return;
         }
@@ -63,9 +66,9 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
                 config: `//video.qbrick.com/play2/api/v1/accounts/${accountId}/configurations/qbrick-player`,
                 data: `//video.qbrick.com/api/v1/public/accounts/${accountId}/medias/${mediaId}`,
                 language: getValidSubtitleLanguage(language, config.video),
-                widgetId: style.widgetId,
             }).on('ready', () => {
                 setIsPlayerLoaded(true);
+                console.log('Loaded', mediaId);
             });
             return;
         }
@@ -113,7 +116,13 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
                     'https://play2.qbrick.com/qbrick-player/framework/GoBrain.min.js'
                 }
                 async={true}
-                onReady={pollPlayerState}
+                onReady={() => {
+                    console.log('Ready', mediaId);
+                    pollPlayerState();
+                }}
+                onError={(e) => {
+                    console.log('error', mediaId, e);
+                }}
             />
             {!isPlayerLoaded && <Loader />}
             <Button
@@ -160,9 +169,9 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
                     style.macroVideo,
                     (!isPlayerLoaded || !isVideoOpen) && style.hidden
                 )}
-            >
-                <div ref={videoRef} title={title} />
-            </div>
+                ref={videoRef}
+                title={title}
+            />
         </div>
     );
 };

--- a/src/components/macros/video/MacroVideo.tsx
+++ b/src/components/macros/video/MacroVideo.tsx
@@ -123,6 +123,8 @@ export const MacroVideo = ({ config }: MacroVideoProps) => {
                 onReady={() => {
                     pollPlayerState();
                 }}
+                // TODO: The onLoad handler should not be necessary, as onReady should always execute (according to next docs).
+                // However this does not always seem to happen...
                 onLoad={() => {
                     pollPlayerState();
                 }}

--- a/src/nodeenv.d.ts
+++ b/src/nodeenv.d.ts
@@ -23,7 +23,11 @@ declare global {
 
     interface Window {
         GoBrain?: {
-            create: any;
+            create: (
+                element: HTMLElement,
+                config: Record<string, string>
+            ) => any;
+            widgets: (widgetId: string) => any;
         };
     }
 

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -332,6 +332,7 @@ export const translationsBundleNb = {
         playMovie: 'Se video:',
         duration: 'Varighet er',
         minutes: 'min',
+        error: 'Det oppsto en feil under lasting av video',
     },
 };
 

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -310,5 +310,6 @@ export const translationsBundleEn: Translations = {
         playMovie: 'Watch video:',
         duration: 'Duration is',
         minutes: 'min',
+        error: 'An error occurred while loading the video',
     },
 };

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -315,5 +315,6 @@ export const translationsBundleNn: Translations = {
         playMovie: 'Sjå video:',
         duration: 'Varighet er',
         minutes: 'min',
+        error: 'Det oppsto en feil under lasting av video',
     },
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Setter unike widgetId'er for hver GoBrain widget (fikser bug der videoer ikke spilles av på sider med flere videoer)
- Workaround for bug med next/script (onReady kjører ikke alltid, så definerer derfor både onLoad og onReady)
- Viser feilmelding dersom video-script ikke kunne lastes