### PR TITLE
Disable pointer-events på områdekort på mobil

### DIFF
--- a/src/components/_common/area-card/graphics/AreaCardGraphics.module.scss
+++ b/src/components/_common/area-card/graphics/AreaCardGraphics.module.scss
@@ -7,6 +7,7 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
+    pointer-events: none;
 
     & > * {
         @include areaCard.transitionMixin;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ved klikk på selve grafikken på områdekort på mobil oppstod det en firkant rundt elementet før brukeren ble sendt til neste side. Denne PR'en disabler pointer-events for grafikken og lar heller det omliggende a-elementet håndtere klikkhendelser.

## Testing
Testes i dev.
