### PR TITLE
Aktiverer fritekst-filter på alle oversiktssider (+ refactoring)

### DIFF
--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -4,7 +4,7 @@ import { OverviewTaxonomyFilter } from 'components/_common/overview-filters/taxo
 import { OverviewTextFilter } from 'components/_common/overview-filters/text-filter/OverviewTextFilter';
 import {
     OverviewFilterableItem,
-    useOverviewFiltersState,
+    useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
 import { resetOverviewFiltersAction } from 'store/slices/overviewFilters';
 import { classNames } from 'utils/classnames';
@@ -119,7 +119,7 @@ type Props = {
 
 export const OverviewFilters = (props: Props) => {
     const { showTextInputFilter, showAreaFilter, showTaxonomyFilter } = props;
-    const { dispatch } = useOverviewFiltersState();
+    const { dispatch } = useOverviewFilters();
 
     useEffect(() => {
         // Reset filters when the component dismounts

--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -6,7 +6,6 @@ import {
     OverviewFilterableItem,
     useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
-import { resetOverviewFiltersAction } from 'store/slices/overviewFilters';
 import { classNames } from 'utils/classnames';
 import { FunnelIcon } from '@navikt/aksel-icons';
 import { translator } from 'translations';
@@ -119,14 +118,14 @@ type Props = {
 
 export const OverviewFilters = (props: Props) => {
     const { showTextInputFilter, showAreaFilter, showTaxonomyFilter } = props;
-    const { dispatch } = useOverviewFilters();
+    const { resetFilters } = useOverviewFilters();
 
     useEffect(() => {
         // Reset filters when the component dismounts
         return () => {
-            dispatch(resetOverviewFiltersAction());
+            resetFilters();
         };
-    }, [dispatch]);
+    }, [resetFilters]);
 
     if (!showAreaFilter && !showTaxonomyFilter && !showTextInputFilter) {
         return null;

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -6,8 +6,6 @@ import {
     OverviewFilterableItem,
     useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
-import { setAreaFilterAction } from 'store/slices/overviewFilters';
-import { sortLikeArray } from 'utils/arrays';
 
 const orderedAreas: Area[] = [
     Area.WORK,
@@ -27,14 +25,14 @@ type Props = {
 };
 
 export const OverviewAreaFilter = ({ items }: Props) => {
-    const { dispatch, areaFilter } = useOverviewFilters();
+    const { areaFilter, setAreaFilter } = useOverviewFilters();
 
     const handleFilterUpdate = (area: Area) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             omrade: area,
             opprinnelse: 'oversiktsside områder',
         });
-        dispatch(setAreaFilterAction({ area }));
+        setAreaFilter(area);
     };
 
     const areasPresent = orderedAreas.filter((area) =>

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -4,7 +4,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { OverviewFilterBase } from 'components/_common/overview-filters/filter-base/OverviewFilterBase';
 import {
     OverviewFilterableItem,
-    useOverviewFiltersState,
+    useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
 import { setAreaFilterAction } from 'store/slices/overviewFilters';
 import { sortLikeArray } from 'utils/arrays';
@@ -27,7 +27,7 @@ type Props = {
 };
 
 export const OverviewAreaFilter = ({ items }: Props) => {
-    const { dispatch, areaFilter } = useOverviewFiltersState();
+    const { dispatch, areaFilter } = useOverviewFilters();
 
     const handleFilterUpdate = (area: Area) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {

--- a/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
+++ b/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import {
-    resetOverviewFiltersAction,
-    setAreaFilterAction,
-    setTaxonomyFilterAction,
-} from 'store/slices/overviewFilters';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
-import { BodyLong, Heading, Chips } from '@navikt/ds-react';
+import { BodyLong, Chips, Heading } from '@navikt/ds-react';
 import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
 
@@ -26,8 +21,14 @@ export const OverviewFiltersSummary = ({
 }: Props) => {
     const { language } = usePageConfig();
 
-    const { hasDefaultFilters, dispatch, areaFilter, taxonomyFilter } =
-        useOverviewFilters();
+    const {
+        hasDefaultFilters,
+        areaFilter,
+        taxonomyFilter,
+        setAreaFilter,
+        setTaxonomyFilter,
+        resetFilters,
+    } = useOverviewFilters();
 
     const overviewTranslations = translator('overview', language);
     const taxonomyTranslations = translator('taxonomies', language);
@@ -45,13 +46,7 @@ export const OverviewFiltersSummary = ({
                     <Chips className={style.chips}>
                         {areaFilter !== Area.ALL && (
                             <Chips.Removable
-                                onClick={() =>
-                                    dispatch(
-                                        setAreaFilterAction({
-                                            area: Area.ALL,
-                                        })
-                                    )
-                                }
+                                onClick={() => setAreaFilter(Area.ALL)}
                             >
                                 {areaTranslations(areaFilter)}
                             </Chips.Removable>
@@ -59,11 +54,7 @@ export const OverviewFiltersSummary = ({
                         {taxonomyFilter !== ProductTaxonomy.ALL && (
                             <Chips.Removable
                                 onClick={() =>
-                                    dispatch(
-                                        setTaxonomyFilterAction({
-                                            taxonomy: ProductTaxonomy.ALL,
-                                        })
-                                    )
+                                    setTaxonomyFilter(ProductTaxonomy.ALL)
                                 }
                             >
                                 {taxonomyTranslations(taxonomyFilter)}
@@ -71,7 +62,7 @@ export const OverviewFiltersSummary = ({
                         )}
                         <Chips.Removable
                             onClick={() => {
-                                dispatch(resetOverviewFiltersAction());
+                                resetFilters();
                             }}
                         >
                             {overviewTranslations('resetFilters')}

--- a/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
+++ b/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
@@ -4,7 +4,7 @@ import {
     setAreaFilterAction,
     setTaxonomyFilterAction,
 } from 'store/slices/overviewFilters';
-import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
+import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { BodyLong, Heading, Chips } from '@navikt/ds-react';
@@ -27,7 +27,7 @@ export const OverviewFiltersSummary = ({
     const { language } = usePageConfig();
 
     const { hasDefaultFilters, dispatch, areaFilter, taxonomyFilter } =
-        useOverviewFiltersState();
+        useOverviewFilters();
 
     const overviewTranslations = translator('overview', language);
     const taxonomyTranslations = translator('taxonomies', language);

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -4,7 +4,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { OverviewFilterBase } from 'components/_common/overview-filters/filter-base/OverviewFilterBase';
 import {
     OverviewFilterableItem,
-    useOverviewFiltersState,
+    useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
 import { setTaxonomyFilterAction } from 'store/slices/overviewFilters';
 
@@ -25,7 +25,7 @@ type Props = {
 };
 
 export const OverviewTaxonomyFilter = ({ items }: Props) => {
-    const { dispatch, taxonomyFilter } = useOverviewFiltersState();
+    const { dispatch, taxonomyFilter } = useOverviewFilters();
 
     const handleFilterUpdate = (taxonomy: ProductTaxonomy) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -6,7 +6,6 @@ import {
     OverviewFilterableItem,
     useOverviewFilters,
 } from 'store/hooks/useOverviewFilters';
-import { setTaxonomyFilterAction } from 'store/slices/overviewFilters';
 
 const orderedTaxonomies: ProductTaxonomy[] = [
     ProductTaxonomy.BENEFITS,
@@ -25,14 +24,14 @@ type Props = {
 };
 
 export const OverviewTaxonomyFilter = ({ items }: Props) => {
-    const { dispatch, taxonomyFilter } = useOverviewFilters();
+    const { taxonomyFilter, setTaxonomyFilter } = useOverviewFilters();
 
     const handleFilterUpdate = (taxonomy: ProductTaxonomy) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             type: taxonomy,
             opprinnelse: 'oversiktsside typer',
         });
-        dispatch(setTaxonomyFilterAction({ taxonomy }));
+        setTaxonomyFilter(taxonomy);
     };
 
     const taxonomiesPresent = orderedTaxonomies.filter((taxonomy) =>

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -3,7 +3,7 @@ import { Search } from '@navikt/ds-react';
 import debounce from 'lodash.debounce';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
-import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
+import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { setTextFilterAction } from 'store/slices/overviewFilters';
 import * as Sentry from '@sentry/react';
 import { windowScrollTo } from 'utils/scroll-to';
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
-    const { dispatch } = useOverviewFiltersState();
+    const { dispatch } = useOverviewFilters();
     const { language } = usePageConfig();
     const inputId = useId();
 

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -4,7 +4,6 @@ import debounce from 'lodash.debounce';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
-import { setTextFilterAction } from 'store/slices/overviewFilters';
 import * as Sentry from '@sentry/react';
 import { windowScrollTo } from 'utils/scroll-to';
 
@@ -17,7 +16,7 @@ type Props = {
 };
 
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
-    const { dispatch } = useOverviewFilters();
+    const { setTextFilter } = useOverviewFilters();
     const { language } = usePageConfig();
     const inputId = useId();
 
@@ -26,14 +25,14 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const dispatchInput = useCallback(
         debounce((value: string) => {
-            dispatch(setTextFilterAction({ text: value }));
+            setTextFilter(value);
             window.dispatchEvent(
                 new CustomEvent(OVERVIEW_FILTERS_TEXT_INPUT_EVENT, {
                     detail: { value, id: inputId },
                 })
             );
         }, 500),
-        [dispatch]
+        [setTextFilter]
     );
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -64,10 +64,6 @@ $separator-attribs: 1px $color solid;
     }
 }
 
-.hidden {
-    display: none;
-}
-
 .illustration {
     width: 56px;
     height: 56px;

--- a/src/components/_common/product-panel/ProductPanelExpandable.tsx
+++ b/src/components/_common/product-panel/ProductPanelExpandable.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Accordion, BodyShort, Loader } from '@navikt/ds-react';
 import { IllustrationStatic } from 'components/_common/illustration/IllustrationStatic';
-import { classNames } from 'utils/classnames';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
@@ -15,7 +14,6 @@ type Props = {
     header: string;
     subHeader?: string;
     illustration: AnimatedIconsProps;
-    visible: boolean;
     anchorId: string;
     contentLoaderCallback: () => void;
     analyticsData?: Record<string, string>;
@@ -29,7 +27,6 @@ export const ProductPanelExpandable = ({
     subHeader,
     anchorId,
     illustration,
-    visible,
     contentLoaderCallback,
     analyticsData,
     isLoading,
@@ -77,10 +74,7 @@ export const ProductPanelExpandable = ({
     };
 
     return (
-        <Accordion
-            className={classNames(style.accordion, !visible && style.hidden)}
-            id={anchorId}
-        >
+        <Accordion className={style.accordion} id={anchorId}>
             <Accordion.Item open={isOpen} className={style.accordionItem}>
                 <Accordion.Header
                     onClick={handleClick}

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -42,6 +42,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
     useEffect(() => {
         getFilteredList({
             filterableItems: formDetailsList,
+            textFilterOverride: formNumberFromSearch,
             fuseOptions: formNumberFromSearch
                 ? {
                       keys: ['formNumbers'],

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -42,9 +42,9 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
     useEffect(() => {
         getFilteredList({
             filterableItems: formDetailsList,
-            textFilterOverride: formNumberFromSearch,
             // If the text filter input was formatted like a form number
             // we only want to search for this exact form number
+            textFilterOverride: formNumberFromSearch,
             fuseOptions: formNumberFromSearch
                 ? {
                       keys: ['formNumbers'],

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
 import { FormsOverviewListPanel } from 'components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel';
 import { OverviewFilters } from 'components/_common/overview-filters/OverviewFilters';
-import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
+import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { OverviewFiltersSummary } from 'components/_common/overview-filters/summary/OverviewFiltersSummary';
 
 import style from './FormsOverviewList.module.scss';
@@ -29,7 +29,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
 
     const [filteredList, setFilteredList] = useState(formDetailsList);
 
-    const { textFilter, getFilteredList } = useOverviewFiltersState();
+    const { textFilter, getFilteredList } = useOverviewFilters();
 
     const formNumberFromSearch = getExactFormNumberIfFormSearch(textFilter);
 
@@ -61,12 +61,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
         }).then((result) => {
             setFilteredList(result);
         });
-    }, [
-        getFilteredList,
-        formDetailsList,
-        getFilteredList,
-        formNumberFromSearch,
-    ]);
+    }, [getFilteredList, formDetailsList, formNumberFromSearch]);
 
     return (
         <div>

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -43,6 +43,8 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
         getFilteredList({
             filterableItems: formDetailsList,
             textFilterOverride: formNumberFromSearch,
+            // If the text filter input was formatted like a form number
+            // we only want to search for this exact form number
             fuseOptions: formNumberFromSearch
                 ? {
                       keys: ['formNumbers'],

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -83,7 +83,6 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
                     <li key={formDetail.anchorId}>
                         <FormsOverviewListPanel
                             formDetails={formDetail}
-                            visible={true}
                             overviewType={overviewType}
                             formNumberSelected={formNumberFromSearch}
                         />

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -65,7 +65,7 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
     }, [getFilteredList, formDetailsList, formNumberFromSearch]);
 
     return (
-        <div>
+        <>
             <OverviewFilters
                 filterableItems={formDetailsList}
                 showTaxonomyFilter={taxonomyFilterToggle}
@@ -90,6 +90,6 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
                     </li>
                 ))}
             </ul>
-        </div>
+        </>
     );
 };

--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -51,14 +51,12 @@ const buildSubHeader = (
 
 type Props = {
     formDetails: FormDetailsListItemProps;
-    visible: boolean;
     overviewType: OverviewType;
     formNumberSelected?: string;
 };
 
 export const FormsOverviewListPanel = ({
     formDetails,
-    visible,
     overviewType,
     formNumberSelected,
 }: Props) => {
@@ -118,7 +116,6 @@ export const FormsOverviewListPanel = ({
             header={sortTitle}
             subHeader={buildSubHeader(taxonomy, area, language)}
             illustration={illustration}
-            visible={visible}
             anchorId={anchorId}
             contentLoaderCallback={handleFormDetailsFetch}
             isLoading={isLoading}

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -69,12 +69,11 @@ export const OverviewPage = (props: OverviewPageProps) => {
                     {filteredList.map((product) => (
                         <li key={`${product._id}-${language}`}>
                             {isAllProductsOverview ? (
-                                <ProductLink product={product} visible={true} />
+                                <ProductLink product={product} />
                             ) : (
                                 <ProductDetailsPanel
                                     productDetails={product}
                                     pageProps={props}
-                                    visible={true}
                                     detailType={overviewType}
                                 />
                             )}

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -18,8 +18,6 @@ export const OverviewPage = (props: OverviewPageProps) => {
 
     const [filteredList, setFilteredList] = useState(productList);
 
-    console.log('overview render');
-
     const { getFilteredList } = useOverviewFilters();
 
     const isAllProductsOverview = overviewType === 'all_products';

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -8,7 +8,7 @@ import { OverviewFilters } from 'components/_common/overview-filters/OverviewFil
 import { OverviewFiltersSummary } from 'components/_common/overview-filters/summary/OverviewFiltersSummary';
 import { ProductLink } from 'components/pages/overview-page/product-elements/ProductLink';
 import { ProductDetailsPanel } from 'components/pages/overview-page/product-elements/ProductDetailsPanel';
-import { useOverviewFiltersState } from 'store/hooks/useOverviewFilters';
+import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
 import style from './OverviewPage.module.scss';
 
@@ -20,7 +20,7 @@ export const OverviewPage = (props: OverviewPageProps) => {
 
     console.log('overview render');
 
-    const { getFilteredList } = useOverviewFiltersState();
+    const { getFilteredList } = useOverviewFilters();
 
     const isAllProductsOverview = overviewType === 'all_products';
 
@@ -69,25 +69,20 @@ export const OverviewPage = (props: OverviewPageProps) => {
                         isAllProductsOverview && style.allProducts
                     )}
                 >
-                    {filteredList.map((product) => {
-                        return (
-                            <li key={`${product._id}-${language}`}>
-                                {isAllProductsOverview ? (
-                                    <ProductLink
-                                        product={product}
-                                        visible={true}
-                                    />
-                                ) : (
-                                    <ProductDetailsPanel
-                                        productDetails={product}
-                                        pageProps={props}
-                                        visible={true}
-                                        detailType={overviewType}
-                                    />
-                                )}
-                            </li>
-                        );
-                    })}
+                    {filteredList.map((product) => (
+                        <li key={`${product._id}-${language}`}>
+                            {isAllProductsOverview ? (
+                                <ProductLink product={product} visible={true} />
+                            ) : (
+                                <ProductDetailsPanel
+                                    productDetails={product}
+                                    pageProps={props}
+                                    visible={true}
+                                    detailType={overviewType}
+                                />
+                            )}
+                        </li>
+                    ))}
                 </ul>
             </div>
         </div>

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -28,7 +28,6 @@ export const OverviewPage = (props: OverviewPageProps) => {
             fuseOptions: {
                 keys: [
                     { name: 'sortTitle', weight: 10 },
-                    { name: 'keywords', weight: 2 },
                     { name: 'ingress', weight: 1 },
                     { name: 'title', weight: 1 },
                 ],

--- a/src/components/pages/overview-page/product-elements/ProductDetailsPanel.tsx
+++ b/src/components/pages/overview-page/product-elements/ProductDetailsPanel.tsx
@@ -13,14 +13,12 @@ type Props = {
     detailType: ProductDetailType;
     pageProps: ContentProps;
     productDetails: SimplifiedProductData;
-    visible: boolean;
 };
 
 export const ProductDetailsPanel = ({
     detailType,
     pageProps,
     productDetails,
-    visible,
 }: Props) => {
     const { productDetailsPath, anchorId, illustration, sortTitle } =
         productDetails;
@@ -64,7 +62,6 @@ export const ProductDetailsPanel = ({
         <ProductPanelExpandable
             header={sortTitle}
             illustration={illustration}
-            visible={visible}
             anchorId={anchorId}
             contentLoaderCallback={handleProductDetailsFetch}
             error={error}

--- a/src/components/pages/overview-page/product-elements/ProductLink.module.scss
+++ b/src/components/pages/overview-page/product-elements/ProductLink.module.scss
@@ -3,7 +3,3 @@
         background-color: white;
     }
 }
-
-.hidden {
-    display: none;
-}

--- a/src/components/pages/overview-page/product-elements/ProductLink.tsx
+++ b/src/components/pages/overview-page/product-elements/ProductLink.tsx
@@ -2,15 +2,13 @@ import { MiniCard } from 'components/_common/card/MiniCard';
 import { CardType } from 'types/card';
 import { SimplifiedProductData } from 'types/component-props/_mixins';
 import { LinkProps } from 'types/link-props';
-import { classNames } from 'utils/classnames';
 
 import style from './ProductLink.module.scss';
 
 type ProductLinkProps = {
     product: SimplifiedProductData;
-    visible: boolean;
 };
-export const ProductLink = ({ product, visible }: ProductLinkProps) => {
+export const ProductLink = ({ product }: ProductLinkProps) => {
     const link: LinkProps = {
         url: product.path,
         text: product.sortTitle,
@@ -21,7 +19,7 @@ export const ProductLink = ({ product, visible }: ProductLinkProps) => {
             link={link}
             type={CardType.Product}
             illustration={product.illustration}
-            className={classNames(style.productLink, !visible && style.hidden)}
+            className={style.productLink}
         />
     );
 };

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -1,59 +1,84 @@
+import { useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '../store';
 import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
-import { overviewFiltersInitialState } from 'store/slices/overviewFilters';
+import {
+    overviewFiltersInitialState,
+    OverviewFiltersState,
+} from 'store/slices/overviewFilters';
 import { ContentType } from 'types/content-props/_content-common';
+import { getFuseSearchFunc } from 'utils/text-search-utils';
+import type Fuse from 'fuse.js';
 
 export type OverviewFilterableItem = {
     area: Area[];
     taxonomy: ProductTaxonomy[];
     type?: ContentType;
-    textMatchFunc?: (textFilter: string) => boolean;
+};
+
+type FilteredListProps<ItemType extends OverviewFilterableItem> = {
+    filterableItems: ItemType[];
+    fuseOptions?: Fuse.IFuseOptions<ItemType>;
+};
+
+const getFilterListFunc = async <ItemType extends OverviewFilterableItem>({
+    filterableItems,
+    filters,
+    fuseOptions,
+}: FilteredListProps<ItemType> & {
+    filters: OverviewFiltersState;
+}) => {
+    const { textFilter, areaFilter, taxonomyFilter } = filters;
+
+    const isAreaMatching = (item: ItemType) =>
+        areaFilter === Area.ALL || item.area.includes(areaFilter);
+
+    const isTaxonomyMatching = (item: ItemType) =>
+        taxonomyFilter === ProductTaxonomy.ALL ||
+        item.taxonomy.includes(taxonomyFilter) ||
+        (taxonomyFilter === ProductTaxonomy.OTHER &&
+            item.type === 'no.nav.navno:guide-page');
+
+    const matchFilters = (item: ItemType) =>
+        isAreaMatching(item) && isTaxonomyMatching(item);
+
+    if (!textFilter || !fuseOptions) {
+        return filterableItems.filter(matchFilters);
+    }
+
+    return getFuseSearchFunc(filterableItems, fuseOptions).then(
+        (fuseSearchFunc) => {
+            const result = fuseSearchFunc(textFilter);
+            return result.filter(matchFilters);
+        }
+    );
 };
 
 export const useOverviewFiltersState = () => {
     const dispatch = useAppDispatch();
 
-    const { textFilter, areaFilter, taxonomyFilter } = useAppSelector(
-        (state) => state.overviewFilters
-    );
+    const filtersState = useAppSelector((state) => state.overviewFilters);
+
+    const { textFilter, areaFilter, taxonomyFilter } = filtersState;
 
     const hasDefaultFilters =
         textFilter === overviewFiltersInitialState.textFilter &&
         areaFilter === overviewFiltersInitialState.areaFilter &&
         taxonomyFilter === overviewFiltersInitialState.taxonomyFilter;
 
-    const matchFilters = (filterableContent: OverviewFilterableItem) => {
-        const isAreaMatching =
-            areaFilter === Area.ALL ||
-            filterableContent.area.includes(areaFilter);
-        if (!isAreaMatching) {
-            return false;
-        }
-
-        const isTaxonomyMatching =
-            taxonomyFilter === ProductTaxonomy.ALL ||
-            filterableContent.taxonomy.includes(taxonomyFilter) ||
-            (taxonomyFilter === ProductTaxonomy.OTHER &&
-                filterableContent.type === 'no.nav.navno:guide-page');
-        if (!isTaxonomyMatching) {
-            return false;
-        }
-
-        const isTextFilterMatching =
-            !textFilter ||
-            !filterableContent.textMatchFunc ||
-            filterableContent.textMatchFunc(textFilter);
-
-        return isTextFilterMatching;
-    };
+    const getFilteredList = useCallback(
+        (props: FilteredListProps<any>) => {
+            return getFilterListFunc({ ...props, filters: filtersState });
+        },
+        [filtersState]
+    );
 
     return {
         hasDefaultFilters,
-        matchFilters,
         dispatch,
         areaFilter,
         taxonomyFilter,
         textFilter,
+        getFilteredList,
     };
 };

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -43,15 +43,15 @@ const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
         (taxonomyFilter === ProductTaxonomy.OTHER &&
             item.type === 'no.nav.navno:guide-page');
 
-    const itemsMatchingTagFilters = filterableItems.filter(
+    const itemsMatchingToggleFilters = filterableItems.filter(
         (item: ItemType) => isAreaMatching(item) && isTaxonomyMatching(item)
     );
 
     if (!textFilter || !fuseOptions) {
-        return itemsMatchingTagFilters;
+        return itemsMatchingToggleFilters;
     }
 
-    return getFuseSearchFunc(itemsMatchingTagFilters, fuseOptions).then(
+    return getFuseSearchFunc(itemsMatchingToggleFilters, fuseOptions).then(
         (fuseSearchFunc) => {
             return fuseSearchFunc(textFilter);
         }

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -39,17 +39,17 @@ const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
         (taxonomyFilter === ProductTaxonomy.OTHER &&
             item.type === 'no.nav.navno:guide-page');
 
-    const matchFilters = (item: ItemType) =>
-        isAreaMatching(item) && isTaxonomyMatching(item);
+    const itemsMatchingTagFilters = filterableItems.filter(
+        (item: ItemType) => isAreaMatching(item) && isTaxonomyMatching(item)
+    );
 
     if (!textFilter || !fuseOptions) {
-        return filterableItems.filter(matchFilters);
+        return itemsMatchingTagFilters;
     }
 
-    return getFuseSearchFunc(filterableItems, fuseOptions).then(
+    return getFuseSearchFunc(itemsMatchingTagFilters, fuseOptions).then(
         (fuseSearchFunc) => {
-            const result = fuseSearchFunc(textFilter);
-            return result.filter(matchFilters);
+            return fuseSearchFunc(textFilter);
         }
     );
 };

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -21,7 +21,7 @@ type FilteredListProps<ItemType extends OverviewFilterableItem> = {
     fuseOptions?: Fuse.IFuseOptions<ItemType>;
 };
 
-const getFilterListFunc = async <ItemType extends OverviewFilterableItem>({
+const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
     filterableItems,
     filters,
     fuseOptions,
@@ -54,7 +54,7 @@ const getFilterListFunc = async <ItemType extends OverviewFilterableItem>({
     );
 };
 
-export const useOverviewFiltersState = () => {
+export const useOverviewFilters = () => {
     const dispatch = useAppDispatch();
 
     const filtersState = useAppSelector((state) => state.overviewFilters);
@@ -67,8 +67,10 @@ export const useOverviewFiltersState = () => {
         taxonomyFilter === overviewFiltersInitialState.taxonomyFilter;
 
     const getFilteredList = useCallback(
-        (props: FilteredListProps<any>) => {
-            return getFilterListFunc({ ...props, filters: filtersState });
+        <ItemType extends OverviewFilterableItem>(
+            props: FilteredListProps<ItemType>
+        ) => {
+            return _getFilteredList({ ...props, filters: filtersState });
         },
         [filtersState]
     );

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -5,6 +5,10 @@ import { ProductTaxonomy } from 'types/taxonomies';
 import {
     overviewFiltersInitialState,
     OverviewFiltersState,
+    resetOverviewFiltersAction,
+    setAreaFilterAction,
+    setTaxonomyFilterAction,
+    setTextFilterAction,
 } from 'store/slices/overviewFilters';
 import { ContentType } from 'types/content-props/_content-common';
 import { getFuseSearchFunc } from 'utils/text-search-utils';
@@ -75,12 +79,36 @@ export const useOverviewFilters = () => {
         [filtersState]
     );
 
+    const setAreaFilter = useCallback(
+        (area: Area) => dispatch(setAreaFilterAction({ area })),
+        [dispatch]
+    );
+
+    const setTaxonomyFilter = useCallback(
+        (taxonomy: ProductTaxonomy) =>
+            dispatch(setTaxonomyFilterAction({ taxonomy })),
+        [dispatch]
+    );
+
+    const setTextFilter = useCallback(
+        (value: string) => dispatch(setTextFilterAction({ text: value })),
+        [dispatch]
+    );
+
+    const resetFilters = useCallback(
+        () => dispatch(resetOverviewFiltersAction()),
+        [dispatch]
+    );
+
     return {
         hasDefaultFilters,
-        dispatch,
         areaFilter,
         taxonomyFilter,
         textFilter,
         getFilteredList,
+        setAreaFilter,
+        setTaxonomyFilter,
+        setTextFilter,
+        resetFilters,
     };
 };

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -22,17 +22,21 @@ export type OverviewFilterableItem = {
 
 type FilteredListProps<ItemType extends OverviewFilterableItem> = {
     filterableItems: ItemType[];
+    textFilterOverride?: string;
     fuseOptions?: Fuse.IFuseOptions<ItemType>;
 };
 
 const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
     filterableItems,
-    filters,
+    textFilterOverride,
     fuseOptions,
+    filters,
 }: FilteredListProps<ItemType> & {
     filters: OverviewFiltersState;
 }) => {
     const { textFilter, areaFilter, taxonomyFilter } = filters;
+
+    const textFilterActual = textFilterOverride || textFilter;
 
     const isAreaMatching = (item: ItemType) =>
         areaFilter === Area.ALL || item.area.includes(areaFilter);
@@ -47,13 +51,13 @@ const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
         (item: ItemType) => isAreaMatching(item) && isTaxonomyMatching(item)
     );
 
-    if (!textFilter || !fuseOptions) {
+    if (!textFilterActual || !fuseOptions) {
         return itemsMatchingToggleFilters;
     }
 
     return getFuseSearchFunc(itemsMatchingToggleFilters, fuseOptions).then(
         (fuseSearchFunc) => {
-            return fuseSearchFunc(textFilter);
+            return fuseSearchFunc(textFilterActual);
         }
     );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Alle typer oversiktssider skal nå ha fritekst-filter
- Re-rendrer listen fremfor å skjule med CSS ved bruk av filter. Med den nåværende implementasjonen av filter (hvor listen sorteres på beste treff) vil listen uansett re-rendres ved filtrering, så CSS-løsningen gir ingen verdi lengre.
- Diverse refactor av filter-koden