### PR TITLE
Globale varsler for redaksjonelle feil på en side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "@navikt/ds-tokens": "2.8.11",
                 "@navikt/nav-dekoratoren-moduler": "2.0.1",
                 "@reduxjs/toolkit": "^1.9.1",
-                "classnames": "^2.3.2",
                 "cookie-parser": "1.4.6",
                 "csp-header": "^5.1.0",
                 "dayjs": "^1.11.7",
@@ -4236,11 +4235,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
-        },
-        "node_modules/classnames": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-            "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
         },
         "node_modules/clean-stack": {
             "version": "2.2.0",
@@ -16895,11 +16889,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
-        },
-        "classnames": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-            "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
         },
         "clean-stack": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "@navikt/ds-tokens": "2.8.11",
         "@navikt/nav-dekoratoren-moduler": "2.0.1",
         "@reduxjs/toolkit": "^1.9.1",
-        "classnames": "^2.3.2",
         "cookie-parser": "1.4.6",
         "csp-header": "^5.1.0",
         "dayjs": "^1.11.7",

--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -17,7 +17,7 @@ const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
         return (
             <EditorHelp
                 text={'Feil på fragmentet - forsøk å sette det inn på nytt'}
-                globalText={'Feil på fragment'}
+                globalWarningText={'Feil på fragment'}
                 type={'error'}
             />
         );

--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -16,9 +16,8 @@ const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
     if (!componentProps.fragment?.type) {
         return (
             <EditorHelp
-                text={
-                    'Fragmentet kunne ikke lastes - det kan være arkivert, eller referansen kan være ugyldig'
-                }
+                text={'Feil på fragmentet - forsøk å sette det inn på nytt'}
+                globalText={'Feil på fragment'}
                 type={'error'}
             />
         );

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -20,8 +20,8 @@ import { fetchAndSetInnloggingsstatus } from 'utils/fetch/fetch-innloggingsstatu
 import { setAuthStateAction } from 'store/slices/authState';
 import { fetchAndSetMeldekortStatus } from 'utils/fetch/fetch-meldekort-status';
 import { LegacyPageChatbot } from './_common/chatbot/LegacyPageChatbot';
-import classNames from 'classnames';
-import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
+import { EditorGlobalWarnings } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
+import { classNames } from 'utils/classnames';
 
 type Props = {
     content: ContentProps;
@@ -137,7 +137,7 @@ export const PageWrapper = (props: Props) => {
         >
             <div className={classNames('app-container')}>
                 <EditorHacks content={content} />
-                {editorView && <DuplicateIdsWarning key={content._id} />}
+                {editorView && <EditorGlobalWarnings key={content._id} />}
                 <DocumentParameterMetatags content={content} />
                 <HeadWithMetatags content={content} />
                 <TopContainer content={content} />

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Detail, Heading } from '@navikt/ds-react';
-import classNames from 'classnames';
+import { classNames } from 'utils/classnames';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { FormDetailsButton } from './FormDetailsButton';

--- a/src/components/_common/office-details/OfficeDetails.tsx
+++ b/src/components/_common/office-details/OfficeDetails.tsx
@@ -1,14 +1,14 @@
 import { Heading } from '@navikt/ds-react';
-import classNames from 'classnames';
+import { classNames } from 'utils/classnames';
 import { translator } from 'translations';
 import { Reception } from './reception/Reception';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { PhonePoster } from './phonePoster/PhonePoster';
 import { OfficeInformation } from './officeInformation/OfficeInformation';
+import { forceArray } from 'utils/arrays';
 
 import styles from './OfficeDetails.module.scss';
-import { forceArray } from 'utils/arrays';
 
 export interface OfficeDetailsProps {
     officeData: OfficeDetailsData;

--- a/src/components/_common/office-details/reception/SingleReception.tsx
+++ b/src/components/_common/office-details/reception/SingleReception.tsx
@@ -1,6 +1,10 @@
 import { BodyShort, Heading } from '@navikt/ds-react';
-import { ClockFillIcon, InformationSquareFillIcon, HouseFillIcon } from '@navikt/aksel-icons';
-import classNames from 'classnames';
+import {
+    ClockFillIcon,
+    InformationSquareFillIcon,
+    HouseFillIcon,
+} from '@navikt/aksel-icons';
+import { classNames } from 'utils/classnames';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { translator } from 'translations';
 import {

--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -243,6 +243,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
             return (
                 <EditorHelp
                     text={"HTML'en er tom eller inneholder feil."}
+                    globalWarningText={'Feil på riktekst/HTML-komponent'}
                     type={'error'}
                 />
             );

--- a/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.module.scss
+++ b/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.module.scss
@@ -1,31 +1,5 @@
 @use 'src/common' as common;
 
-.bigWarning {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 2rem 0;
-    margin-bottom: 1rem;
-    background-color: common.$a-surface-danger-subtle;
-    border: 2px solid common.$a-border-danger;
-
-    @include common.full-width-mixin();
-
-    & > * {
-        max-width: 600px;
-        width: 100%;
-    }
-
-    ul {
-        @include common.unstyled-list();
-        margin: 1rem 0;
-    }
-
-    a {
-        margin-left: 0.25rem;
-    }
-}
-
 .warning {
     min-width: 400px;
     background-color: common.$a-white;

--- a/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.tsx
+++ b/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.tsx
@@ -48,7 +48,7 @@ export const DuplicateIdsWarning = () => {
     return (
         <>
             {uniqueDupeIds.length > 0 && (
-                <div className={style.bigWarning}>
+                <div>
                     <Header level={'2'}>{`Obs! Denne siden har ${
                         uniqueDupeIds.length
                     } id${

--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -3,10 +3,9 @@ import { usePageConfig } from 'store/hooks/usePageConfig';
 import { StaticImage } from '../../_common/image/StaticImage';
 import { classNames } from 'utils/classnames';
 import { BodyShort } from '@navikt/ds-react';
-import { createPortal } from 'react-dom';
-import { EDITOR_GLOBAL_WARNINGS_CONTAINER_ID } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
+import { renderEditorGlobalWarning } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
 
 import helpIcon from '/public/gfx/help.svg';
 import errorIcon from '/public/gfx/error.svg';
@@ -28,11 +27,15 @@ const imagePath = {
 
 type Props = {
     text: string;
-    globalText?: string;
+    globalWarningText?: string;
     type?: 'info' | 'error' | 'help' | 'arrowUp' | 'arrowDown';
 };
 
-export const EditorHelp = ({ text, globalText, type = 'help' }: Props) => {
+export const EditorHelp = ({
+    text,
+    globalWarningText,
+    type = 'help',
+}: Props) => {
     const { pageConfig } = usePageConfig();
     const { editorView } = pageConfig;
 
@@ -62,18 +65,16 @@ export const EditorHelp = ({ text, globalText, type = 'help' }: Props) => {
             >
                 {text}
             </BodyShort>
-            {globalText &&
-                typeof document !== 'undefined' &&
-                createPortal(
-                    <div>
-                        <span>{globalText}</span>
+            {globalWarningText &&
+                renderEditorGlobalWarning(
+                    <>
+                        <span>{globalWarningText}</span>
                         <EditorLinkWrapper>
                             <LenkeInline href={`#${id}`}>
                                 {'[Til feilen]'}
                             </LenkeInline>
                         </EditorLinkWrapper>
-                    </div>,
-                    document.getElementById(EDITOR_GLOBAL_WARNINGS_CONTAINER_ID)
+                    </>
                 )}
         </div>
     );

--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { StaticImage } from '../../_common/image/StaticImage';
 import { classNames } from 'utils/classnames';
 import { BodyShort } from '@navikt/ds-react';
+import { createPortal } from 'react-dom';
+import { EDITOR_GLOBAL_WARNINGS_CONTAINER_ID } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
+import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
+import { LenkeInline } from 'components/_common/lenke/LenkeInline';
+
 import helpIcon from '/public/gfx/help.svg';
 import errorIcon from '/public/gfx/error.svg';
 import lightBulb from '/public/gfx/lightbulb.svg';
@@ -23,12 +28,15 @@ const imagePath = {
 
 type Props = {
     text: string;
+    globalText?: string;
     type?: 'info' | 'error' | 'help' | 'arrowUp' | 'arrowDown';
 };
 
-export const EditorHelp = ({ text, type = 'help' }: Props) => {
+export const EditorHelp = ({ text, globalText, type = 'help' }: Props) => {
     const { pageConfig } = usePageConfig();
     const { editorView } = pageConfig;
+
+    const id = useId();
 
     if (!editorView) {
         return null;
@@ -41,7 +49,7 @@ export const EditorHelp = ({ text, type = 'help' }: Props) => {
     }
 
     return (
-        <div className={style.editorHelp}>
+        <div className={style.editorHelp} id={id}>
             <StaticImage
                 imageData={imagePath[type]}
                 alt={''}
@@ -49,11 +57,24 @@ export const EditorHelp = ({ text, type = 'help' }: Props) => {
             />
             <BodyShort
                 spacing={false}
-                size="small"
+                size={'small'}
                 className={classNames(style.content, style[type])}
             >
                 {text}
             </BodyShort>
+            {globalText &&
+                typeof document !== 'undefined' &&
+                createPortal(
+                    <div>
+                        <span>{globalText}</span>
+                        <EditorLinkWrapper>
+                            <LenkeInline href={`#${id}`}>
+                                {'[Til feilen]'}
+                            </LenkeInline>
+                        </EditorLinkWrapper>
+                    </div>,
+                    document.getElementById(EDITOR_GLOBAL_WARNINGS_CONTAINER_ID)
+                )}
         </div>
     );
 };

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.module.scss
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.module.scss
@@ -1,0 +1,38 @@
+@use 'src/common' as common;
+
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 0;
+    margin-bottom: 1rem;
+    background-color: common.$a-surface-danger-subtle;
+    border: 2px solid common.$a-border-danger;
+
+    @include common.full-width-mixin();
+
+    & > * {
+        max-width: 600px;
+        width: 100%;
+
+        &:not(:last-child)::after {
+            content: '';
+            display: block;
+            margin: 0.75rem 0;
+            border-bottom: solid 1px var(--a-border-divider);
+        }
+    }
+
+    ul {
+        @include common.unstyled-list();
+        margin: 1rem 0;
+    }
+
+    a {
+        margin-left: 0.25rem;
+    }
+
+    &:empty {
+        display: none;
+    }
+}

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
+
+import style from './EditorGlobalWarnings.module.scss';
+
+export const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
+
+export const EditorGlobalWarnings = () => {
+    return (
+        <div
+            className={style.container}
+            id={EDITOR_GLOBAL_WARNINGS_CONTAINER_ID}
+        >
+            <DuplicateIdsWarning />
+        </div>
+    );
+};

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
 
 import style from './EditorGlobalWarnings.module.scss';
 
-export const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
+const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
+
+export const renderEditorGlobalWarning = (component: React.ReactNode) =>
+    typeof document !== 'undefined' &&
+    createPortal(
+        <div>{component}</div>,
+        document.getElementById(EDITOR_GLOBAL_WARNINGS_CONTAINER_ID)
+    );
 
 export const EditorGlobalWarnings = () => {
     return (

--- a/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
+++ b/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
@@ -3,7 +3,7 @@ import { FrontPageProps } from 'types/content-props/index-pages-props';
 import { Header } from 'components/_common/headers/Header';
 import { AreaCard } from 'components/_common/area-card/AreaCard';
 import { EmployerCard } from 'components/_common/employer-card/EmployerCard';
-import classNames from 'classnames';
+import { classNames } from 'utils/classnames';
 import { getAudience } from 'types/component-props/_mixins';
 
 import style from './FrontPageAreaNavigation.module.scss';

--- a/src/components/macros/form-details/MacroFormDetails.tsx
+++ b/src/components/macros/form-details/MacroFormDetails.tsx
@@ -8,7 +8,11 @@ export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
 
     if (!macroConfig || !formDetailsData) {
         return (
-            <EditorHelp text="Mangler referanse til skjemadetalj, eller referansen er feil." />
+            <EditorHelp
+                text="Mangler referanse til skjemadetalj, eller referansen er feil."
+                globalWarningText={'Feil på skjemadetalj'}
+                type={'error'}
+            />
         );
     }
 

--- a/src/components/macros/global-value/MacroGlobalValue.tsx
+++ b/src/components/macros/global-value/MacroGlobalValue.tsx
@@ -21,6 +21,7 @@ export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
         return (
             <EditorHelp
                 text={'Teknisk feil: verdien er ikke definert'}
+                globalWarningText={'Macro for global verdi mangler verdi'}
                 type={'error'}
             />
         );

--- a/src/components/macros/html-fragment/MacroHtmlFragment.tsx
+++ b/src/components/macros/html-fragment/MacroHtmlFragment.tsx
@@ -16,6 +16,7 @@ export const MacroHtmlFragment = ({ config }: MacroHtmlFragmentProps) => {
             <EditorHelp
                 type={'error'}
                 text={`Fant ikke innhold for fragmentet "${config.html_fragment.fragmentId}" - Sjekk om det er avpublisert eller arkivert`}
+                globalWarningText={'Fragment-macro mangler innhold'}
             />
         );
     }

--- a/src/components/macros/saksbehandlingstid/MacroSaksbehandlingstid.tsx
+++ b/src/components/macros/saksbehandlingstid/MacroSaksbehandlingstid.tsx
@@ -39,6 +39,7 @@ export const MacroSaksbehandlingstid = ({
         return (
             <EditorHelp
                 text={'Teknisk feil: verdien er ikke definert'}
+                globalWarningText={'Macro for saksbehandlingstid mangler verdi'}
                 type={'error'}
             />
         );

--- a/src/components/macros/tall/MacroTall.tsx
+++ b/src/components/macros/tall/MacroTall.tsx
@@ -19,7 +19,8 @@ export const MacroTall = ({ config }: MacroTallProps) => {
     if (verdi === undefined) {
         return (
             <EditorHelp
-                text={'Teknisk feil: verdien er ikke definert'}
+                text={'Verdien er ikke definert'}
+                globalWarningText={'Macro for tall mangler gyldig verdi'}
                 type={'error'}
             />
         );
@@ -30,6 +31,7 @@ export const MacroTall = ({ config }: MacroTallProps) => {
         return (
             <EditorHelp
                 text={'Teknisk feil: verdien er ikke et gyldig tall'}
+                globalWarningText={'Macro for tall mangler gyldig verdi'}
                 type={'error'}
             />
         );

--- a/src/components/pages/current-topic-page/CurrentTopicPage.tsx
+++ b/src/components/pages/current-topic-page/CurrentTopicPage.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { ComponentMapper } from '../../ComponentMapper';
-import { CurrentTopicPageProps } from '../../../types/content-props/dynamic-page-props';
-
-import classNames from 'classnames';
+import { CurrentTopicPageProps } from 'types/content-props/dynamic-page-props';
 import { NewsHeader } from 'components/_common/headers/featured-header/FeaturedHeader';
+
 import styles from './CurrentTopicPage.module.scss';
 
 export const CurrentTopicPage = (props: CurrentTopicPageProps) => {
     return (
-        <div className={classNames(styles.currentTopicPage)}>
+        <div className={styles.currentTopicPage}>
             <NewsHeader contentProps={props} />
             <div className={styles.contentWrapper}>
                 <div className={styles.contentAligner}>

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BodyShort, Heading } from '@navikt/ds-react';
 import { translator } from 'translations';
-import classNames from 'classnames';
+import { classNames } from 'utils/classnames';
 import { ContentType, ContentProps } from 'types/content-props/_content-common';
 import { stripXpPathPrefix } from 'utils/urls';
 import { MainArticleChapterNavigationData } from 'types/content-props/main-article-chapter-props';

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { formatDate, getPublishedDateTime } from 'utils/datetime';
-import classNames from 'classnames';
+import { classNames } from 'utils/classnames';
 import { BodyLong, Detail } from '@navikt/ds-react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 

--- a/src/components/parts/office-editorial-detail/details/SocialHelpLinks.tsx
+++ b/src/components/parts/office-editorial-detail/details/SocialHelpLinks.tsx
@@ -1,9 +1,7 @@
-import classNames from 'classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { forceArray } from 'utils/arrays';
 import { DetailProps } from '../OfficeEditorialDetail';
 
-/* eslint-disable-next-line */
 import styles from './SocialHelpLinks.module.scss';
 
 export const SocialHelpLinks = ({ officeData }: DetailProps) => {
@@ -21,7 +19,7 @@ export const SocialHelpLinks = ({ officeData }: DetailProps) => {
                 <LenkeBase
                     key={link.lenke}
                     href={link.lenke}
-                    className={classNames(styles.singleLink)}
+                    className={styles.singleLink}
                 >
                     {link.lenketekst}
                 </LenkeBase>

--- a/src/components/parts/product-details/ProductDetailsPart.tsx
+++ b/src/components/parts/product-details/ProductDetailsPart.tsx
@@ -36,6 +36,9 @@ export const ProductDetailsPart = ({
                     config.detailType === ProductDetailType.PROCESSING_TIMES &&
                     processingTimeHelptext
                 }`}
+                globalWarningText={
+                    'Komponent for produktdetaljer mangler innhold'
+                }
                 type={'error'}
             />
         );

--- a/src/store/hooks/useAuthState.ts
+++ b/src/store/hooks/useAuthState.ts
@@ -1,8 +1,5 @@
-import { TypedUseSelectorHook, useSelector } from 'react-redux';
-import { RootState } from '../store';
+import { useAppSelector } from '../store';
 import { AuthState } from '../slices/authState';
-
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export const useAuthState = (): AuthState => {
     return useAppSelector((state) => state.authState);

--- a/src/store/hooks/useGvEditorState.ts
+++ b/src/store/hooks/useGvEditorState.ts
@@ -1,5 +1,4 @@
-import { TypedUseSelectorHook, useSelector, useDispatch } from 'react-redux';
-import { RootState, AppDispatch } from '../store';
+import { useAppDispatch, useAppSelector } from '../store';
 import {
     GvEditorState,
     setItemEditStateAction,
@@ -8,9 +7,6 @@ import {
 } from '../slices/gvEditorState';
 import { GlobalValueItem } from 'types/content-props/global-values-props';
 import { GVMessageProps } from 'components/pages/global-values-page/components/messages/GVMessages';
-
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export const useGvEditorState = () => {
     const dispatch = useAppDispatch();

--- a/src/store/hooks/usePageConfig.ts
+++ b/src/store/hooks/usePageConfig.ts
@@ -1,5 +1,4 @@
-import { TypedUseSelectorHook, useSelector, useDispatch } from 'react-redux';
-import { RootState, AppDispatch } from '../store';
+import { useAppDispatch, useAppSelector } from '../store';
 import {
     setPageConfigAction,
     currentPageId,
@@ -12,9 +11,6 @@ import {
 import { Language } from 'translations';
 import { ContentProps } from 'types/content-props/_content-common';
 import { Audience } from 'types/component-props/_mixins';
-
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 type PageConfig = {
     pageId: string;


### PR DESCRIPTION
Legger til mulighet for å vise et ekstra varsel på toppen av siden for redaksjonelle feilmeldinger (vises kun i CS). Motivasjonen her er å gjøre det enklere for redaktørene å oppdage når innhold mangler på siden pga feil referanser ol.

Andre endringer:
- Fjerner duplikate dispatch og selector funksjoner for redux
- Fjerner "classnames"-pakka, og erstatter med tilsvarende egen implementasjon der denne fortsatt ble benyttet

![global-warnings](https://github.com/navikt/nav-enonicxp-frontend/assets/18137669/26c25579-e342-4e7d-bdab-9efc00e74bf5)