### PR TITLE
Fikser bug som krasjer globale warnings i editor-viewet

### DIFF
--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -5,7 +5,7 @@ import { classNames } from 'utils/classnames';
 import { BodyShort } from '@navikt/ds-react';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { RenderAsGlobalWarning } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
+import { RenderToEditorGlobalWarnings } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
 
 import helpIcon from '/public/gfx/help.svg';
 import errorIcon from '/public/gfx/error.svg';
@@ -66,14 +66,14 @@ export const EditorHelp = ({
                 {text}
             </BodyShort>
             {globalWarningText && (
-                <RenderAsGlobalWarning>
+                <RenderToEditorGlobalWarnings>
                     <span>{globalWarningText}</span>
                     <EditorLinkWrapper>
                         <LenkeInline href={`#${id}`}>
                             {'[Til feilen]'}
                         </LenkeInline>
                     </EditorLinkWrapper>
-                </RenderAsGlobalWarning>
+                </RenderToEditorGlobalWarnings>
             )}
         </div>
     );

--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -5,7 +5,7 @@ import { classNames } from 'utils/classnames';
 import { BodyShort } from '@navikt/ds-react';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { renderEditorGlobalWarning } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
+import { RenderAsGlobalWarning } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
 
 import helpIcon from '/public/gfx/help.svg';
 import errorIcon from '/public/gfx/error.svg';
@@ -65,17 +65,16 @@ export const EditorHelp = ({
             >
                 {text}
             </BodyShort>
-            {globalWarningText &&
-                renderEditorGlobalWarning(
-                    <>
-                        <span>{globalWarningText}</span>
-                        <EditorLinkWrapper>
-                            <LenkeInline href={`#${id}`}>
-                                {'[Til feilen]'}
-                            </LenkeInline>
-                        </EditorLinkWrapper>
-                    </>
-                )}
+            {globalWarningText && (
+                <RenderAsGlobalWarning>
+                    <span>{globalWarningText}</span>
+                    <EditorLinkWrapper>
+                        <LenkeInline href={`#${id}`}>
+                            {'[Til feilen]'}
+                        </LenkeInline>
+                    </EditorLinkWrapper>
+                </RenderAsGlobalWarning>
+            )}
         </div>
     );
 };

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -6,7 +6,7 @@ import style from './EditorGlobalWarnings.module.scss';
 
 const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
 
-export const RenderAsGlobalWarning = ({
+export const RenderToEditorGlobalWarnings = ({
     children,
 }: {
     children: React.ReactNode;

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
 
@@ -6,12 +6,30 @@ import style from './EditorGlobalWarnings.module.scss';
 
 const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
 
-export const renderEditorGlobalWarning = (component: React.ReactNode) =>
-    typeof document !== 'undefined' &&
-    createPortal(
-        <div>{component}</div>,
-        document.getElementById(EDITOR_GLOBAL_WARNINGS_CONTAINER_ID)
+export const RenderAsGlobalWarning = ({
+    children,
+}: {
+    children: React.ReactNode;
+}) => {
+    const [isFirstRender, setIsFirstRender] = useState(true);
+
+    useEffect(() => {
+        setIsFirstRender(false);
+    }, []);
+
+    if (isFirstRender) {
+        return null;
+    }
+
+    const element = document.getElementById(
+        EDITOR_GLOBAL_WARNINGS_CONTAINER_ID
     );
+    if (!element) {
+        return null;
+    }
+
+    return createPortal(children, element);
+};
 
 export const EditorGlobalWarnings = () => {
     return (


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Noe ™️ krasjer ved bruk av react portals ved første render i editor-viewet i content studio, legger inn en fiks for dette.