### PR TITLE
article på sidemaler for å sikre at header-tag kommer i egen kontekst

### DIFF
--- a/src/components/pages/generic-page/GenericPage.tsx
+++ b/src/components/pages/generic-page/GenericPage.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { ComponentMapper } from '../../ComponentMapper';
-import {
-    GenericPageProps,
-    ProductPageProps,
-} from '../../../types/content-props/dynamic-page-props';
-import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { GenericPageProps} from 'types/content-props/dynamic-page-props';
+import { ComponentMapper } from 'components/ComponentMapper';
+import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 export const GenericPage = (props: GenericPageProps) => {
     return (
-        <div className={'genericPage'}>
+        <article className={'genericPage'}>
             <ThemedPageHeader contentProps={props} />
             <div className={'content'}>
                 <ComponentMapper
@@ -16,6 +13,6 @@ export const GenericPage = (props: GenericPageProps) => {
                     pageProps={props}
                 />
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/pages/guide-page/GuidePage.tsx
+++ b/src/components/pages/guide-page/GuidePage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { ComponentMapper } from '../../ComponentMapper';
-import { GuidePageProps } from '../../../types/content-props/dynamic-page-props';
-import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { GuidePageProps } from 'types/content-props/dynamic-page-props';
+import { ComponentMapper } from 'components/ComponentMapper';
+import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 import style from './GuidePage.module.scss';
 
 export const GuidePage = (props: GuidePageProps) => {
     return (
-        <div className={style.guidePage}>
+        <article className={style.guidePage}>
             <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
                 <ComponentMapper
@@ -15,6 +15,6 @@ export const GuidePage = (props: GuidePageProps) => {
                     pageProps={props}
                 />
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -38,7 +38,7 @@ export const OverviewPage = (props: OverviewPageProps) => {
     }, [getFilteredList, productList]);
 
     return (
-        <div className={style.overviewPage}>
+        <article className={style.overviewPage}>
             <ThemedPageHeader contentProps={props} showTimeStamp={false} />
             <div className={style.content}>
                 <ComponentMapper
@@ -81,6 +81,6 @@ export const OverviewPage = (props: OverviewPageProps) => {
                     ))}
                 </ul>
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/pages/product-page/ProductPage.tsx
+++ b/src/components/pages/product-page/ProductPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ComponentMapper } from '../../ComponentMapper';
 import { ProductPageProps } from 'types/content-props/dynamic-page-props';
-import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { ComponentMapper } from 'components/ComponentMapper';
+import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 export const ProductPage = (props: ProductPageProps) => {
     return (
-        <div className={'productPage'}>
+        <article className={'productPage'}>
             <ThemedPageHeader contentProps={props} />
             <div className={'content'}>
                 <ComponentMapper
@@ -13,6 +13,6 @@ export const ProductPage = (props: ProductPageProps) => {
                     pageProps={props}
                 />
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/pages/situation-page/SituationPage.tsx
+++ b/src/components/pages/situation-page/SituationPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ComponentMapper } from '../../ComponentMapper';
-import { SituationPageProps } from '../../../types/content-props/dynamic-page-props';
-import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { SituationPageProps } from 'types/content-props/dynamic-page-props';
+import { ComponentMapper } from 'components/ComponentMapper';
+import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 export const SituationPage = (props: SituationPageProps) => {
     return (
-        <div className={'situationPage'}>
+        <article className={'situationPage'}>
             <ThemedPageHeader contentProps={props} />
             <div className={'content'}>
                 <ComponentMapper
@@ -13,6 +13,6 @@ export const SituationPage = (props: SituationPageProps) => {
                     pageProps={props}
                 />
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/pages/themed-article-page/ThemedArticlePage.tsx
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { ComponentMapper } from '../../ComponentMapper';
-import { ThemedArticlePageProps } from '../../../types/content-props/dynamic-page-props';
-import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
+import { ThemedArticlePageProps } from 'types/content-props/dynamic-page-props';
+import { ComponentMapper } from 'components/ComponentMapper';
+import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 import style from './ThemedArticlePage.module.scss';
 
 export const ThemedArticlePage = (props: ThemedArticlePageProps) => {
     return (
-        <div className={style.themedArticlePage}>
+        <article className={style.themedArticlePage}>
             <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
                 <ComponentMapper
@@ -15,6 +15,6 @@ export const ThemedArticlePage = (props: ThemedArticlePageProps) => {
                     pageProps={props}
                 />
             </div>
-        </div>
+        </article>
     );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

`article` som wrapper for sidemaler som bruker ThemedPageHader. 
Denne inneholder `header` som sematisk må komme i en egen kontekst for å skilles fra `header` i dekoratøren.

## Testing

Har testet selv i lokalt og i dev2

