### PR TITLE
Åpner expandable-paneler dersom den inneholder location.hash

### DIFF
--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -36,12 +36,15 @@ export const Expandable = ({
     };
 
     const checkAndOpenPanel = () => {
-        const { hash } = window.location;
-        if (!hash) {
+        if (isOpen) {
             return;
         }
 
-        const targetId = hash.replace('#', '');
+        const targetId = window.location.hash.replace('#', '');
+        if (!targetId) {
+            return;
+        }
+
         if (targetId === anchorId) {
             setIsOpen(true);
             return;

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Accordion } from '@navikt/ds-react';
-import { AnalyticsEvents, logAmplitudeEvent } from '../../../utils/amplitude';
-import { classNames } from '../../../utils/classnames';
+import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { classNames } from 'utils/classnames';
 
 import style from './Expandable.module.scss';
+import { smoothScrollToTarget } from 'utils/scroll-to';
 
 type Props = {
     title: string;
@@ -21,6 +22,7 @@ export const Expandable = ({
     className,
 }: Props) => {
     const [isOpen, setIsOpen] = useState(false);
+    const accordionRef = useRef<HTMLDivElement | null>(null);
 
     const toggleExpandCollapse = () => {
         logAmplitudeEvent(
@@ -34,8 +36,21 @@ export const Expandable = ({
     };
 
     const checkAndOpenPanel = () => {
-        if (anchorId && window.location.hash === `#${anchorId}`) {
+        const { hash } = window.location;
+        if (!hash) {
+            return;
+        }
+
+        const targetId = hash.replace('#', '');
+        if (targetId === anchorId) {
             setIsOpen(true);
+            return;
+        }
+
+        const elementWithId = document.getElementById(targetId);
+        if (accordionRef.current?.contains(elementWithId)) {
+            setIsOpen(true);
+            setTimeout(() => smoothScrollToTarget(targetId), 500);
         }
     };
 
@@ -70,6 +85,7 @@ export const Expandable = ({
         <Accordion
             id={anchorId}
             className={classNames(className, style.expandableWrapper)}
+            ref={accordionRef}
         >
             <Accordion.Item open={isOpen} className={style.expandable}>
                 <Accordion.Header onClick={toggleExpandCollapse}>

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -81,6 +81,9 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
             <meta name={'twitter:image:src'} content={imageUrl} />
             <meta name={'description'} content={description} />
             <meta name={'contentId'} content={content._id} />
+            {content.contentLayer && (
+                <meta name={'contentLayer'} content={content.contentLayer} />
+            )}
             <meta name={'msapplication-TileColor'} content={'#ffffff'} />
             <meta name={'theme-color'} content={'#ffffff'} />
             <link

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -48,7 +48,7 @@ export const TopContainer = ({ content }: Props) => {
         isPagePreview,
         originalType,
         language,
-        redirectToLocale,
+        redirectToLayer,
     } = content;
     const hasDecoratorWidgets =
         (breadcrumbs && breadcrumbs.length > 0) ||
@@ -87,9 +87,9 @@ export const TopContainer = ({ content }: Props) => {
                     'contentTypeChangedWarningPost'
                 )}`}</PageWarning>
             )}
-            {redirectToLocale && !!content.editorView && (
+            {redirectToLayer && !!content.editorView && (
                 <PageWarning whiteBg={hasWhiteHeader}>
-                    {`Obs! Denne siden er satt som redirect til språkversjonen for "${redirectToLocale}". Husk å velge riktig språkversjon hvis du skal redigere.`}
+                    {`Obs! Denne siden er satt som redirect til språkversjonen for "${redirectToLayer}". Husk å velge riktig språkversjon hvis du skal redigere.`}
                 </PageWarning>
             )}
             <div

--- a/src/components/_top-container/TopContainer.tsx
+++ b/src/components/_top-container/TopContainer.tsx
@@ -42,8 +42,14 @@ export const checkForWhiteHeader = (content: ContentProps) => {
 };
 
 export const TopContainer = ({ content }: Props) => {
-    const { breadcrumbs, isFailover, isPagePreview, originalType, language } =
-        content;
+    const {
+        breadcrumbs,
+        isFailover,
+        isPagePreview,
+        originalType,
+        language,
+        redirectToLocale,
+    } = content;
     const hasDecoratorWidgets =
         (breadcrumbs && breadcrumbs.length > 0) ||
         getContentLanguages(content).length > 0;
@@ -80,6 +86,11 @@ export const TopContainer = ({ content }: Props) => {
                 )}"${originalType}"${warningLabels(
                     'contentTypeChangedWarningPost'
                 )}`}</PageWarning>
+            )}
+            {redirectToLocale && !!content.editorView && (
+                <PageWarning whiteBg={hasWhiteHeader}>
+                    {`Obs! Denne siden er satt som redirect til språkversjonen for "${redirectToLocale}". Husk å velge riktig språkversjon hvis du skal redigere.`}
+                </PageWarning>
             )}
             <div
                 className={classNames(

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -145,6 +145,7 @@ export type ContentCommonProps<Type extends ContentType = ContentType> = {
     breadcrumbs?: DecoratorParams['breadcrumbs'];
     isFailover?: boolean;
     languages?: LanguageProps[];
+    redirectToLocale?: string;
 } & ContentAndMediaCommonProps &
     VersionSelectorProps;
 

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -145,7 +145,8 @@ export type ContentCommonProps<Type extends ContentType = ContentType> = {
     breadcrumbs?: DecoratorParams['breadcrumbs'];
     isFailover?: boolean;
     languages?: LanguageProps[];
-    redirectToLocale?: string;
+    contentLayer?: string;
+    redirectToLayer?: string;
 } & ContentAndMediaCommonProps &
     VersionSelectorProps;
 


### PR DESCRIPTION
Andre endringer:
- Viser advarsel til redaktører dersom siden redirecter til et layer
- Setter metatag for layeret til innholdet, slik at [Content Studio bookmarklet](https://navikt.github.io/team-navno/navno-contentstudio-bookmarklet/) kan endres til å lenke til riktig layer