### PR TITLE
Legger til feature-toggles for AutoReloadDisableHack

### DIFF
--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
@@ -2,12 +2,14 @@ import { AlertBox } from '../../../_common/alert-box/AlertBox';
 import { EditorLinkWrapper } from '../../editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from '../../../_common/lenke/LenkeInline';
 import { BodyLong } from '@navikt/ds-react';
-import { ContentProps } from '../../../../types/content-props/_content-common';
+import { ContentProps } from 'types/content-props/_content-common';
 import { useEffect, useState } from 'react';
 import {
     hookDispatchEventForBatchContentServerEvent,
     unhookDispatchEventForBatchContentServerEvent,
 } from './dispatch-event-hook';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
+import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 import style from './AutoRefreshDisableHack.module.scss';
 
@@ -47,7 +49,8 @@ export const AutoReloadDisableHack = ({ content }: Props) => {
         return unhookDispatchEventForBatchContentServerEvent;
     }, [content]);
 
-    return externalContentChange ? (
+    return isEditorFeatureEnabled(EditorFeature.ContentModifiedWarning) &&
+        externalContentChange ? (
         <div className={style.warningWrapper}>
             <AlertBox variant={'warning'} size={'small'}>
                 <BodyLong>

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
@@ -3,11 +3,10 @@ import {
     editorFetchAdminUserId,
     editorFetchUserInfo,
 } from '../editor-fetch-utils';
-import {
-    ContentProps,
-    ContentType,
-} from '../../../../types/content-props/_content-common';
-import { Branch } from '../../../../types/branch';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
+import { Branch } from 'types/branch';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
+import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 // From lib-admin-ui
 export enum NodeServerChangeType {
@@ -110,6 +109,12 @@ export const hookDispatchEventForBatchContentServerEvent = ({
                 'Skipping this event as current content was not updated'
             );
             return false;
+        }
+
+        // If the feature is disabled, we always dispatch the event when the current content was updated
+        // (we still want to bypass the event for other content, see above!)
+        if (!isEditorFeatureEnabled(EditorFeature.EditorReloadBlocker)) {
+            return dispatchEvent(event);
         }
 
         // Publish and unpublish events must always be dispatched in order to keep the editor UI consistent

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -8,6 +8,8 @@ import { SiteInfoSubHeader } from '../_common/sub-header/SiteInfoSubHeader';
 
 export enum EditorFeature {
     HideLeftPanel = 'hide-left-panel',
+    EditorReloadBlocker = 'editor-reload-blocker',
+    ContentModifiedWarning = 'content-modified-warning',
 }
 
 export type EditorFeatureProps = {
@@ -21,6 +23,18 @@ export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
         key: EditorFeature.HideLeftPanel,
         description:
             'Skjuler venstre-panelet i editoren som standard på komponent-baserte sider',
+        defaultValue: false,
+    },
+    [EditorFeature.EditorReloadBlocker]: {
+        key: EditorFeature.EditorReloadBlocker,
+        description:
+            'Hindrer editoren fra å reloades når andre gjør endringer på innholdet du jobber med',
+        defaultValue: true,
+    },
+    [EditorFeature.ContentModifiedWarning]: {
+        key: EditorFeature.ContentModifiedWarning,
+        description:
+            'Viser advarsel når noen andre gjør endringer på innholdet du jobber med. Obs: Denne krever at funksjonaliteten over også er slått på!',
         defaultValue: false,
     },
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Funksjonaliteten er fortsatt enabled som default, men uten å vise varselet. Se [linked issue for](https://github.com/navikt/nav-enonicxp-frontend/issues/1568) for bakgrunn.