### PR TITLE
UU: Opprydding sematikk sideinndelinger og aria for navigasjon

### DIFF
--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, {useId} from 'react';
 import { Heading } from '@navikt/ds-react';
 import { LinkProps } from 'types/link-props';
 import { LenkeStandalone } from '../lenke/LenkeStandalone';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+import { classNames } from 'utils/classnames';
+
 import style from './Lenkeliste.module.scss';
-import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 type Props = {
     lenker: LinkProps[];
@@ -18,34 +20,34 @@ export const Lenkeliste = ({
     withChevron = false,
     className,
 }: Props) => {
+    const headingId = `heading-linklist-${useId()}`;
+
     if (!lenker || lenker.length === 0) {
         return <EditorHelp text={'Tom lenkeliste'} />;
     }
 
     return (
-        <section className={className} aria-label={tittel}>
+        <nav className={classNames(className, style.lenker)}
+             aria-labelledby={headingId}
+        >
             {tittel && (
-                <div className={style.tittel}>
-                    <Heading size="small" level="2">
-                        {tittel}
-                    </Heading>
-                </div>
+                <Heading className={style.tittel} id={headingId} size="small" level="2">
+                    {tittel}
+                </Heading>
             )}
-            <nav className={style.lenker}>
-                {lenker.map((lenke, index) => (
-                    <LenkeStandalone
-                        href={lenke.url}
-                        label={lenke.label}
-                        key={index}
-                        className={style.lenke}
-                        component={'link-list'}
-                        linkGroup={tittel}
-                        withChevron={withChevron}
-                    >
-                        {lenke.text}
-                    </LenkeStandalone>
-                ))}
-            </nav>
-        </section>
+            {lenker.map((lenke, index) => (
+                <LenkeStandalone
+                    href={lenke.url}
+                    label={lenke.label}
+                    key={index}
+                    className={style.lenke}
+                    component={'link-list'}
+                    linkGroup={tittel}
+                    withChevron={withChevron}
+                >
+                    {lenke.text}
+                </LenkeStandalone>
+            ))}
+        </nav>
     );
 };

--- a/src/components/pages/current-topic-page/CurrentTopicPage.tsx
+++ b/src/components/pages/current-topic-page/CurrentTopicPage.tsx
@@ -7,7 +7,7 @@ import styles from './CurrentTopicPage.module.scss';
 
 export const CurrentTopicPage = (props: CurrentTopicPageProps) => {
     return (
-        <div className={styles.currentTopicPage}>
+        <article className={styles.currentTopicPage}>
             <NewsHeader contentProps={props} />
             <div className={styles.contentWrapper}>
                 <div className={styles.contentAligner}>
@@ -19,6 +19,6 @@ export const CurrentTopicPage = (props: CurrentTopicPageProps) => {
                     </div>
                 </div>
             </div>
-        </div>
+        </article>
     );
 };

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -33,22 +33,20 @@ const getChapters = (contentProps: ContentProps) => {
 
 export const MainArticleChapterNavigation = (props: ContentProps) => {
     const { language } = usePageConfig();
-
     const chapters = getChapters(props);
     if (!chapters || chapters.length === 0) {
         return null;
     }
-
     const getLabel = translator('mainArticle', language);
-
     const currentPath = stripXpPathPrefix(props._path);
     const parentPath = stripXpPathPrefix(props.parent?._path || props._path);
     const parentTitle = props.parent?.displayName || props.displayName;
     const parentSelected = parentPath === currentPath;
+    const headingId = `heading-chapter-navigation`;
 
     return (
-        <nav className={style.mainArticleChapterNavigation}>
-            <Heading level="2" size="medium" className={style.title}>
+        <nav className={style.mainArticleChapterNavigation} aria-labelledby={headingId}>
+            <Heading id={headingId} level="2" size="medium" className={style.title}>
                 {getLabel('contents')}
             </Heading>
             <ul>

--- a/src/components/parts/_legacy/main-article/komponenter/NewsPressHeader.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/NewsPressHeader.tsx
@@ -25,7 +25,7 @@ export const NewsPressHeader = ({
     const tagLocaleId = type === 'news' ? 'news' : 'pressRelease';
 
     return (
-        <header className={styles.newsPressHeader}>
+        <section className={styles.newsPressHeader}>
             <div className={styles.tagWrapper}>
                 <StaticImage
                     imageData={icon}
@@ -40,6 +40,6 @@ export const NewsPressHeader = ({
                 {title}
             </Heading>
             <div className={styles.newsPressLine} />
-        </header>
+        </section>
     );
 };

--- a/src/components/parts/_legacy/page-heading/PageHeading.tsx
+++ b/src/components/parts/_legacy/page-heading/PageHeading.tsx
@@ -10,7 +10,7 @@ const PageHeading = (props: ContentProps) => {
         props.type !== ContentType.SectionPage && props.data?.ingress;
 
     return (
-        <header className={style.pageHeading}>
+        <section className={style.pageHeading}>
             <Heading level="1" size="xlarge">
                 {displayName || 'Tittel'}
             </Heading>
@@ -19,7 +19,7 @@ const PageHeading = (props: ContentProps) => {
                     <Ingress>{ingress}</Ingress>
                 </div>
             )}
-        </header>
+        </section>
     );
 };
 

--- a/src/components/parts/_legacy/page-list/PageList.tsx
+++ b/src/components/parts/_legacy/page-list/PageList.tsx
@@ -29,25 +29,23 @@ export const PageList = (props: PageListProps) => {
 
     return (
         <div className={style.pageList}>
-            <header>
-                <Heading level={'1'} size={'xlarge'}>
-                    {props.displayName}
-                </Heading>
-                <div className={style.ingress}>
-                    <Ingress>{data.ingress}</Ingress>
+            <Heading level={'1'} size={'xlarge'}>
+                {props.displayName}
+            </Heading>
+            <div className={style.ingress}>
+                <Ingress>{data.ingress}</Ingress>
+            </div>
+            {!hideDatesOnPage && (
+                <div className={style.date}>
+                    <ArtikkelDato
+                        publish={publish}
+                        createdTime={createdTime}
+                        modifiedTime={modifiedTime}
+                        publishLabel={publishLabel}
+                        modifiedLabel={modifiedLabel}
+                    />
                 </div>
-                {!hideDatesOnPage && (
-                    <div className={style.date}>
-                        <ArtikkelDato
-                            publish={publish}
-                            createdTime={createdTime}
-                            modifiedTime={modifiedTime}
-                            publishLabel={publishLabel}
-                            modifiedLabel={modifiedLabel}
-                        />
-                    </div>
-                )}
-            </header>
+            )}
             <div className={style.list}>
                 {sectionContents.map((section) => {
                     const {

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -15,16 +15,14 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
 
     return (
         <div className={style.publishingCalendar}>
-            <header>
-                <Heading level="1" size="large">
-                    {props.displayName}
-                </Heading>
-                {props.data.ingress && (
-                    <Ingress className={style.ingress}>
-                        {props.data.ingress}
-                    </Ingress>
-                )}
-            </header>
+            <Heading level="1" size="large">
+                {props.displayName}
+            </Heading>
+            {props.data.ingress && (
+                <Ingress className={style.ingress}>
+                    {props.data.ingress}
+                </Ingress>
+            )}
             <Table zebraStripes>
                 <Table.Header>
                     <Table.Row>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- All `nav` har aria-label
- Alle `header` ligger i kontekst `article`, eller erstattes av `section`

## Testing
Har testet selv lokalt og på dev2
