### PR TITLE
Component error boundary

### DIFF
--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -12,6 +12,7 @@ import { FragmentComponent } from './FragmentComponent';
 import { AuthDependantRender } from './_common/auth-dependant-render/AuthDependantRender';
 import { EditorHelp } from './_editor-only/editor-help/EditorHelp';
 import { ErrorBoundary } from 'components/_common/error-boundary/ErrorBoundary';
+import { translator } from 'translations';
 
 type Props = {
     componentProps: ComponentProps;
@@ -74,8 +75,10 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
 };
 
 export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
+    const errorMsg = translator('errors', pageProps.language)('componentError');
+
     return (
-        <ErrorBoundary type={'component'} language={pageProps.language}>
+        <ErrorBoundary errorMsg={errorMsg}>
             <AuthDependantRender
                 renderOn={componentProps?.config?.renderOnAuthState}
             >

--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import {
     ComponentProps,
     ComponentType,
-} from '../types/component-props/_component-common';
+} from 'types/component-props/_component-common';
 import { TextComponentXp } from './parts/_text/TextComponentXp';
 import { ImageComponentXp } from './parts/_image/ImageComponent';
 import { PartsMapper } from './parts/PartsMapper';
-import { ContentProps } from '../types/content-props/_content-common';
+import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutMapper } from './layouts/LayoutMapper';
 import { FragmentComponent } from './FragmentComponent';
 import { AuthDependantRender } from './_common/auth-dependant-render/AuthDependantRender';
 import { EditorHelp } from './_editor-only/editor-help/EditorHelp';
+import { ErrorBoundary } from 'components/_common/error-boundary/ErrorBoundary';
 
 type Props = {
     componentProps: ComponentProps;
@@ -74,13 +75,15 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
 
 export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
     return (
-        <AuthDependantRender
-            renderOn={componentProps?.config?.renderOnAuthState}
-        >
-            <ComponentToRender
-                componentProps={componentProps}
-                pageProps={pageProps}
-            />
-        </AuthDependantRender>
+        <ErrorBoundary type={'component'} language={pageProps.language}>
+            <AuthDependantRender
+                renderOn={componentProps?.config?.renderOnAuthState}
+            >
+                <ComponentToRender
+                    componentProps={componentProps}
+                    pageProps={pageProps}
+                />
+            </AuthDependantRender>
+        </ErrorBoundary>
     );
 };

--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -13,6 +13,7 @@ import { AuthDependantRender } from './_common/auth-dependant-render/AuthDependa
 import { EditorHelp } from './_editor-only/editor-help/EditorHelp';
 import { ErrorBoundary } from 'components/_common/error-boundary/ErrorBoundary';
 import { translator } from 'translations';
+import { AlertBox } from 'components/_common/alert-box/AlertBox';
 
 type Props = {
     componentProps: ComponentProps;
@@ -74,11 +75,38 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
     }
 };
 
-export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
-    const errorMsg = translator('errors', pageProps.language)('componentError');
+const ErrorFallback = ({ componentProps, pageProps }: Props) => {
+    const { editorView, language } = pageProps;
+    const { type, path } = componentProps;
 
+    const descriptorText =
+        type === 'part' || type === 'layout'
+            ? ` av type "${componentProps.descriptor}"`
+            : '';
+
+    return !!editorView ? (
+        <EditorHelp
+            type={'error'}
+            text={`Komponenten "${path}"${descriptorText} kunne ikke rendres pga teknisk feil. Sjekk om komponenten er riktig konfigurert, eller kontakt brukerstøtte.`}
+            globalWarningText={`Feil på ${type}-komponent${descriptorText}`}
+        />
+    ) : (
+        <AlertBox variant={'error'} inline={true}>
+            {translator('errors', language)('componentError')}
+        </AlertBox>
+    );
+};
+
+export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
     return (
-        <ErrorBoundary errorMsg={errorMsg}>
+        <ErrorBoundary
+            fallback={
+                <ErrorFallback
+                    componentProps={componentProps}
+                    pageProps={pageProps}
+                />
+            }
+        >
             <AuthDependantRender
                 renderOn={componentProps?.config?.renderOnAuthState}
             >

--- a/src/components/_common/alert-box/AlertBox.module.scss
+++ b/src/components/_common/alert-box/AlertBox.module.scss
@@ -1,4 +1,6 @@
 .alertBox {
+    align-items: flex-start;
+
     &:not(:last-child) {
         margin-bottom: 1.5rem;
     }

--- a/src/components/_common/error-boundary/ErrorBoundary.tsx
+++ b/src/components/_common/error-boundary/ErrorBoundary.tsx
@@ -1,12 +1,8 @@
 import React, { Suspense } from 'react';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
-import { Language, translator } from 'translations';
-
-export type ErrorBoundaryType = 'component';
 
 type Props = {
-    type: ErrorBoundaryType;
-    language: Language;
+    errorMsg: string;
     children: React.ReactNode;
 };
 
@@ -29,13 +25,13 @@ export class ErrorBoundary extends React.Component<Props, State> {
     }
 
     render() {
-        const { type, children, language } = this.props;
+        const { children, errorMsg } = this.props;
 
         return (
             <Suspense>
                 {this.state.hasError ? (
                     <AlertBox variant={'error'} inline={true}>
-                        {translator('errors', language)(type)}
+                        {errorMsg}
                     </AlertBox>
                 ) : (
                     children

--- a/src/components/_common/error-boundary/ErrorBoundary.tsx
+++ b/src/components/_common/error-boundary/ErrorBoundary.tsx
@@ -1,1 +1,46 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+import { AlertBox } from 'components/_common/alert-box/AlertBox';
+import { Language, translator } from 'translations';
+
+export type ErrorBoundaryType = 'component';
+
+type Props = {
+    type: ErrorBoundaryType;
+    language: Language;
+    children: React.ReactNode;
+};
+
+type State = {
+    hasError: boolean;
+};
+
+export class ErrorBoundary extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(_: Error) {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+        console.error(`Caught error: ${error} - ${errorInfo.componentStack}`);
+    }
+
+    render() {
+        const { type, children, language } = this.props;
+
+        return (
+            <Suspense>
+                {this.state.hasError ? (
+                    <AlertBox variant={'error'} inline={true}>
+                        {translator('errors', language)(type)}
+                    </AlertBox>
+                ) : (
+                    children
+                )}
+            </Suspense>
+        );
+    }
+}

--- a/src/components/_common/error-boundary/ErrorBoundary.tsx
+++ b/src/components/_common/error-boundary/ErrorBoundary.tsx
@@ -1,8 +1,7 @@
 import React, { Suspense } from 'react';
-import { AlertBox } from 'components/_common/alert-box/AlertBox';
 
 type Props = {
-    errorMsg: string;
+    fallback: React.ReactNode;
     children: React.ReactNode;
 };
 
@@ -25,18 +24,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
     }
 
     render() {
-        const { children, errorMsg } = this.props;
+        const { children, fallback } = this.props;
 
-        return (
-            <Suspense>
-                {this.state.hasError ? (
-                    <AlertBox variant={'error'} inline={true}>
-                        {errorMsg}
-                    </AlertBox>
-                ) : (
-                    children
-                )}
-            </Suspense>
-        );
+        return <Suspense>{this.state.hasError ? fallback : children}</Suspense>;
     }
 }

--- a/src/components/_editor-only/editor-help/EditorHelp.module.scss
+++ b/src/components/_editor-only/editor-help/EditorHelp.module.scss
@@ -28,7 +28,7 @@ $redErrorFilter: invert(22%) sepia(84%) saturate(1767%) hue-rotate(346deg)
     }
 
     .content {
-        align-self: center;
+        align-self: flex-start;
 
         &.error {
             color: common.$a-red-600;

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -8,7 +8,6 @@ import {
 } from 'types/taxonomies';
 import { Area } from 'types/areas';
 import { ProductDetailType } from 'types/content-props/product-details';
-import { ErrorBoundaryType } from 'components/_common/error-boundary/ErrorBoundary';
 
 const relatedContent: { [key in MenuListItemKey]: string } = {
     [MenuListItemKey.AppealRights]: 'Klagerettigheter',
@@ -73,12 +72,11 @@ const productDetailTypes: { [key in ProductDetailType]: string } = {
     [ProductDetailType.ALL_PRODUCTS]: 'alle',
 };
 
-const errorBoundaryMsgs: Record<ErrorBoundaryType, string> = {
-    component: 'Det oppsto en feil ved lasting av dette innholdselementet',
-};
-
 export const translationsBundleNb = {
-    errors: errorBoundaryMsgs,
+    errors: {
+        componentError:
+            'Det oppsto en feil ved lasting av dette innholdselementet',
+    },
     localeNames: {
         no: 'norsk (bokmål)',
         nn: 'nynorsk',

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -8,6 +8,7 @@ import {
 } from 'types/taxonomies';
 import { Area } from 'types/areas';
 import { ProductDetailType } from 'types/content-props/product-details';
+import { ErrorBoundaryType } from 'components/_common/error-boundary/ErrorBoundary';
 
 const relatedContent: { [key in MenuListItemKey]: string } = {
     [MenuListItemKey.AppealRights]: 'Klagerettigheter',
@@ -72,7 +73,12 @@ const productDetailTypes: { [key in ProductDetailType]: string } = {
     [ProductDetailType.ALL_PRODUCTS]: 'alle',
 };
 
+const errorBoundaryMsgs: Record<ErrorBoundaryType, string> = {
+    component: 'Det oppsto en feil ved lasting av dette innholdselementet',
+};
+
 export const translationsBundleNb = {
+    errors: errorBoundaryMsgs,
     localeNames: {
         no: 'norsk (bokmål)',
         nn: 'nynorsk',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -50,6 +50,9 @@ const areas: { [key in Area]?: string } = {
 };
 
 export const translationsBundleEn: PartialTranslations = {
+    errors: {
+        componentError: 'An error occurred while loading this content element',
+    },
     stringParts: {
         conjunction: 'and',
     },


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter en error boundary på hver komponent, slik at feil på en enkelt-komponent ikke krasjer hele appen. Bruker suspense-boundary for å kunne fange errors ved server-side rendering, som faller tilbake til client-side håndtering med en error-boundary for å vise feilmelding og logge feilen.

Vises til publikum:
![public-fallback](https://github.com/navikt/nav-enonicxp-frontend/assets/18137669/1dc767b4-72ce-45ce-b382-449262aa8521)

Vises i editoren:
![editor-fallback](https://github.com/navikt/nav-enonicxp-frontend/assets/18137669/d686ea79-487b-4583-8bc9-04940bf0192c)
