### PR TITLE
Fikser bugs med failover-instans

### DIFF
--- a/.nais/config-failover.yml
+++ b/.nais/config-failover.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
@@ -41,6 +42,7 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
+        - application: {{dekoratorenApp}}
       external:
         {{#each externalHosts as |host|}}
         - host: {{host}}

--- a/server/custom-cache-handler.ts
+++ b/server/custom-cache-handler.ts
@@ -38,10 +38,15 @@ export default class CustomFileSystemCache extends FileSystemCache {
             console.error('PAGE_CACHE_DIR is not defined!');
         }
 
+        const serverDistDir =
+            process.env.PAGE_CACHE_DIR &&
+            process.env.IS_FAILOVER_INSTANCE !== 'true'
+                ? process.env.PAGE_CACHE_DIR
+                : (ctx.serverDistDir as string);
+
         super({
             ...ctx,
-            serverDistDir:
-                process.env.PAGE_CACHE_DIR || (ctx.serverDistDir as string),
+            serverDistDir,
             fs: ctx.fs || nodeFs,
             dev: ctx.dev ?? process.env.NODE_ENV === 'development',
             _appDir: ctx._appDir ?? false,

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -85,7 +85,7 @@ const hasFileExtensionPattern = /\.[a-zA-Z0-9]+($|\?|#)/;
 // The failover app should not fetch from itself, and we only want to fetch html-documents
 // Ignore requests for json-files, images, etc
 const shouldFetchFromFailoverApp = (path: string) =>
-    !isFailoverInstance && hasFileExtensionPattern.test(path);
+    !isFailoverInstance && !hasFileExtensionPattern.test(path);
 
 const Error = (props: ContentProps) => <PageBase content={props} />;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ const getStaticPropsNormal: GetStaticProps = async () => {
 
     if (isFailover && isPropsWithContent(pageProps.props)) {
         pageProps.props.content.isFailover = true;
+        return pageProps;
     }
 
     return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';
 import Config from 'config';
-import { isPropsWithContent } from 'types/_type-guards';
 
 const isFailover = process.env.IS_FAILOVER_INSTANCE === 'true';
 
@@ -26,8 +25,8 @@ const getStaticPropsNormal: GetStaticProps = async () => {
         routerQuery: '',
     });
 
-    if (isFailover && isPropsWithContent(pageProps.props)) {
-        pageProps.props.content.isFailover = true;
+    if (isFailover) {
+        (pageProps.props as any).content.isFailover = true;
         return pageProps;
     }
 

--- a/src/utils/fetch/fetch-content.ts
+++ b/src/utils/fetch/fetch-content.ts
@@ -71,7 +71,7 @@ const fetchSiteContentStandard = async ({
     console.log(`Fetching content from ${url}`);
 
     return fetchWithTimeout(url, FETCH_TIMEOUT_MS, fetchConfig).catch((e) => {
-        console.log(`Sitecontent fetch error: ${e}`);
+        console.log(`Sitecontent fetch error for ${url}: ${e}`);
         return null;
     });
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sørger for at serverDistDir ikke overstyres for failover-instans. Dette er ikke nødvendig ettersom alle sider genereres build-time, så det påvirker ikke readonly fs på nais-podder. Dessuten er ikke dagens løsning i sync med build-time cache-genereringen, så dette gjør at ingen sider faktisk har vært tilgjengelige fra failover-instansen i det siste... 😅 
- Legger til manglende access policy for dekoratøren
- Fikser reversert logikk ved sjekk på om en request skal trigge fetch fra failover
- Sørger for at revalidate ikke benyttes for index page på failover