### PR TITLE
Scroller tilbake til filtervalg dersom innhold ovenfor endrer seg

### DIFF
--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -16,6 +16,7 @@ type FilterBarProps = {
 };
 
 export const FilterBar = ({ layoutProps }: FilterBarProps) => {
+    const filterBarRef = useRef(null);
     const { content, intro } = layoutProps.regions;
     const components = [
         ...(content ? content.components : []),
@@ -23,7 +24,6 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
     ];
     const { language } = usePageConfig();
     const getLabel = translator('filteredContent', language);
-    const filterBarRef = useRef(null);
 
     const { selectedFilters, availableFilters, toggleFilter } =
         useFilterState();
@@ -31,10 +31,6 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
     const { saveScrollPosition, scrollToElement } = useScrollPosition(
         filterBarRef?.current
     );
-
-    useEffect(() => {
-        console.log('Filter changed');
-    }, [selectedFilters]);
 
     // Create a flat array of all ids that any
     // underlying part that has filter ids attached.

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -8,6 +8,8 @@ import { SectionWithHeaderProps } from 'types/component-props/layouts/section-wi
 import { FilterExplanation } from './FilterExplanation';
 
 import style from './FilterBar.module.scss';
+import { useEffect, useRef } from 'react';
+import { useScrollPosition } from 'store/hooks/useStickyScroll';
 
 type FilterBarProps = {
     layoutProps: SectionWithHeaderProps;
@@ -21,9 +23,18 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
     ];
     const { language } = usePageConfig();
     const getLabel = translator('filteredContent', language);
+    const filterBarRef = useRef(null);
 
     const { selectedFilters, availableFilters, toggleFilter } =
         useFilterState();
+
+    const { saveScrollPosition, scrollToElement } = useScrollPosition(
+        filterBarRef?.current
+    );
+
+    useEffect(() => {
+        console.log('Filter changed');
+    }, [selectedFilters]);
 
     // Create a flat array of all ids that any
     // underlying part that has filter ids attached.
@@ -59,7 +70,7 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
             <Heading level="3" size="small" className={style.header}>
                 {getLabel('showingInformationFor')}
             </Heading>
-            <div className={style.container}>
+            <div className={style.container} ref={filterBarRef}>
                 {filtersToDisplay.map((filter) => {
                     const isSelected = selectedFilters.includes(filter.id);
                     return (
@@ -72,7 +83,9 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
                                     filternavn: filter.filterName,
                                     opprinnelse: 'innholdtekst',
                                 });
+                                saveScrollPosition();
                                 toggleFilter(filter.id);
+                                setTimeout(() => scrollToElement(), 0);
                             }}
                             filter={filter}
                         />

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -8,7 +8,7 @@ import { SectionWithHeaderProps } from 'types/component-props/layouts/section-wi
 import { FilterExplanation } from './FilterExplanation';
 
 import style from './FilterBar.module.scss';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { useScrollPosition } from 'store/hooks/useStickyScroll';
 
 type FilterBarProps = {

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -28,7 +28,7 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
     const { selectedFilters, availableFilters, toggleFilter } =
         useFilterState();
 
-    const { saveScrollPosition, scrollToElement } = useScrollPosition(
+    const { saveScrollPosition, scrollBackToElement } = useScrollPosition(
         filterBarRef?.current
     );
 
@@ -81,7 +81,7 @@ export const FilterBar = ({ layoutProps }: FilterBarProps) => {
                                 });
                                 saveScrollPosition();
                                 toggleFilter(filter.id);
-                                setTimeout(() => scrollToElement(), 0);
+                                setTimeout(() => scrollBackToElement(), 0);
                             }}
                             filter={filter}
                         />

--- a/src/components/parts/filters-menu/FilterCheckbox.tsx
+++ b/src/components/parts/filters-menu/FilterCheckbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useId } from 'react';
+import { useId } from 'react';
 import { Filter } from 'types/store/filter-menu';
 import { classNames } from 'utils/classnames';
 import { StaticImage } from 'components/_common/image/StaticImage';

--- a/src/components/parts/filters-menu/FilterCheckbox.tsx
+++ b/src/components/parts/filters-menu/FilterCheckbox.tsx
@@ -1,7 +1,7 @@
-import { useId } from 'react';
+import { ChangeEvent, useId } from 'react';
 import { Filter } from 'types/store/filter-menu';
 import { classNames } from 'utils/classnames';
-import { StaticImage } from "components/_common/image/StaticImage";
+import { StaticImage } from 'components/_common/image/StaticImage';
 
 import checkboxIcon from './checkbox.svg';
 import checkedIcon from './checked.svg';
@@ -10,7 +10,7 @@ import style from './FilterCheckbox.module.scss';
 type FilterCheckboxProps = {
     isSelected: boolean;
     filter: Filter;
-    onToggleFilterHandler: () => void;
+    onToggleFilterHandler: (e?: ChangeEvent) => void;
 };
 
 export const FilterCheckbox = ({
@@ -29,7 +29,7 @@ export const FilterCheckbox = ({
         >
             <input
                 type="checkbox"
-                onChange={onToggleFilterHandler}
+                onChange={(e) => onToggleFilterHandler(e)}
                 checked={isSelected}
                 value={filter.id}
                 id={id}
@@ -43,7 +43,13 @@ export const FilterCheckbox = ({
                 )}
             >
                 {!isSelected && <StaticImage imageData={checkboxIcon} alt="" />}
-                {isSelected && <StaticImage imageData={checkedIcon} alt="" className={style.selected} />}
+                {isSelected && (
+                    <StaticImage
+                        imageData={checkedIcon}
+                        alt=""
+                        className={style.selected}
+                    />
+                )}
                 {filter.filterName}
             </label>
         </div>

--- a/src/components/parts/filters-menu/FilterCheckbox.tsx
+++ b/src/components/parts/filters-menu/FilterCheckbox.tsx
@@ -10,7 +10,7 @@ import style from './FilterCheckbox.module.scss';
 type FilterCheckboxProps = {
     isSelected: boolean;
     filter: Filter;
-    onToggleFilterHandler: (e?: ChangeEvent) => void;
+    onToggleFilterHandler: () => void;
 };
 
 export const FilterCheckbox = ({
@@ -29,7 +29,7 @@ export const FilterCheckbox = ({
         >
             <input
                 type="checkbox"
-                onChange={(e) => onToggleFilterHandler(e)}
+                onChange={onToggleFilterHandler}
                 checked={isSelected}
                 value={filter.id}
                 id={id}

--- a/src/store/hooks/useStickyScroll.ts
+++ b/src/store/hooks/useStickyScroll.ts
@@ -10,7 +10,7 @@ export const useScrollPosition = (element: HTMLElement) => {
         }
     };
 
-    const scrollToElement = () => {
+    const scrollBackToElement = () => {
         if (element) {
             const targetScrollPosition =
                 element.getBoundingClientRect().top +
@@ -25,5 +25,5 @@ export const useScrollPosition = (element: HTMLElement) => {
         }
     };
 
-    return { saveScrollPosition, scrollToElement };
+    return { saveScrollPosition, scrollBackToElement };
 };

--- a/src/store/hooks/useStickyScroll.ts
+++ b/src/store/hooks/useStickyScroll.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export const useScrollPosition = (element: HTMLElement) => {
     const scrollPositionRef = useRef(0);

--- a/src/store/hooks/useStickyScroll.ts
+++ b/src/store/hooks/useStickyScroll.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useScrollPosition = (element: HTMLElement) => {
+    const scrollPositionRef = useRef(0);
+
+    const saveScrollPosition = () => {
+        if (element) {
+            scrollPositionRef.current = element.getBoundingClientRect().top;
+            console.log(scrollPositionRef.current);
+        }
+    };
+
+    const scrollToElement = () => {
+        if (element) {
+            const targetScrollPosition =
+                element.getBoundingClientRect().top +
+                window.scrollY -
+                scrollPositionRef.current;
+
+            const scrollOptions: ScrollToOptions = {
+                top: targetScrollPosition,
+                behavior: 'instant',
+            };
+            window.scroll(scrollOptions);
+        }
+    };
+
+    return { saveScrollPosition, scrollToElement };
+};

--- a/src/store/hooks/useStickyScroll.ts
+++ b/src/store/hooks/useStickyScroll.ts
@@ -6,7 +6,6 @@ export const useScrollPosition = (element: HTMLElement) => {
     const saveScrollPosition = () => {
         if (element) {
             scrollPositionRef.current = element.getBoundingClientRect().top;
-            console.log(scrollPositionRef.current);
         }
     };
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Dersom man filtrerer innhold på en produktside og innholdet som filtreres vekk ligger ovenfor filtervalget, vil siden hoppe og ved enkelte tilfeller vil seksjonen man var på forsvinne opp.

Denne fiksen setter ny sidescroll slik at siden (og FilterBar-komponenten) tilsynelatende blir stående der den var.

## Testing
Testes i dev.
