### PR TITLE
Oppdaterer script for bygg av failover image til dev-miljøer

### DIFF
--- a/failover/.env-dev1
+++ b/failover/.env-dev1
@@ -3,7 +3,7 @@ NODE_ENV=production
 ADMIN_ORIGIN=https://portal-admin-dev.oera.no
 APP_ORIGIN=https://www.ekstern.dev.nav.no
 DECORATOR_URL=https://dekoratoren.ekstern.dev.nav.no
-XP_ORIGIN=https://portal-admin-dev.oera.no
+XP_ORIGIN=https://www.dev.nav.no
 TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect
 REVALIDATOR_PROXY_ORIGIN=http://nav-enonicxp-frontend-revalidator-proxy-dev1
 FAILOVER_ORIGIN=https://www-failover.intern.dev.nav.no

--- a/failover/.env-dev2
+++ b/failover/.env-dev2
@@ -1,9 +1,9 @@
 ENV=dev2
 NODE_ENV=production
-ADMIN_ORIGIN=https://portal-admin-dev.oera.no
+ADMIN_ORIGIN=https://portal-admin-q6.oera.no
 APP_ORIGIN=https://www-2.ekstern.dev.nav.no
 DECORATOR_URL=https://dekoratoren.ekstern.dev.nav.no
-XP_ORIGIN=https://portal-admin-q6.oera.no
+XP_ORIGIN=https://www-q6.nav.no
 TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect
 REVALIDATOR_PROXY_ORIGIN=http://nav-enonicxp-frontend-revalidator-proxy-dev2
 FAILOVER_ORIGIN=https://www-2-failover.intern.dev.nav.no

--- a/failover/Dockerfile
+++ b/failover/Dockerfile
@@ -10,7 +10,7 @@ ARG SERVICE_SECRET
 ARG ENV_FILE
 
 COPY package*.json /failover/.npmrc /app/
-RUN npm ci --force
+RUN npm ci
 RUN rm -f .npmrc
 
 COPY public /app/public/

--- a/failover/build-dev-failover-image.sh
+++ b/failover/build-dev-failover-image.sh
@@ -6,6 +6,9 @@
 # You also need a Github PAT with repo and packages write access in the .github-token
 # file at the root of the project
 # Take care not to expose secrets!
+#
+# Once the image is built, use the relevant deploy action on Github with the chosen
+# image name to deploy
 
 APP_ENV=$1
 IMAGE_NAME=$2
@@ -39,5 +42,3 @@ IMAGE_NAME_FULL="ghcr.io/navikt/nav-enonicxp-frontend:$IMAGE_NAME"
 
 docker build -f Dockerfile -t "$IMAGE_NAME_FULL" --no-cache --build-arg ENV_FILE="$ENV_FILE" --build-arg SERVICE_SECRET="$SERVICE_SECRET" --build-arg GITHUB_PAT="$GITHUB_PAT" ../.
 docker push $IMAGE_NAME_FULL
-
-npx run-func ../trigger-workflow.js triggerWorkflow deploy-failover.dev.yml "" "{\"image_name\":\"$IMAGE_NAME\", \"app_env\":\"$APP_ENV\"}"


### PR DESCRIPTION
- Fikser url'er i .env-filene
- Fjerner --force fra npm ci i dockerfila (skal ikke være nødvendig lengre)
- Fjerner referanse til deploy-script som ikke eksisterer lengre. Imagene kan deployes via workflow_dispatch på GHA.