### PR TITLE
Flere fikses for AutoReloadDisableHack

### DIFF
--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
@@ -62,7 +62,7 @@ export const AutoReloadDisableHack = ({ content }: Props) => {
                 <BodyLong>
                     {`OBS! ${
                         externalUserName || 'Noen andre'
-                    } redigerte denne siden nå. Hvis du gjør endringer, vil du overskrive det som allerede er gjort. `}
+                    } redigerte denne siden nå. Hvis du gjør endringer, vil du overskrive det som allerede er gjort. Du bør vente med å redigere siden til den andre har avsluttet. `}
                     <EditorLinkWrapper>
                         <LenkeInline
                             href={'#'}

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
@@ -2,6 +2,7 @@ import {
     editorFetchAdminContent,
     editorFetchAdminUserId,
     editorFetchUserInfo,
+    isContentRepo,
     isCurrentEditorRepo,
 } from 'components/_editor-only/editor-hacks/editor-hacks-utils';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
@@ -121,6 +122,10 @@ export const hookDispatchEventForBatchContentServerEvent = ({
 
         detail.items.forEach((item) => {
             const { id, repo } = item;
+
+            if (!isContentRepo(repo)) {
+                return;
+            }
 
             editorFetchAdminContent(id, repo).then((content) => {
                 // If the content could not be fetched, or if it was modified by the current user, dispatch the event

--- a/src/components/_editor-only/editor-hacks/editor-hacks-utils.ts
+++ b/src/components/_editor-only/editor-hacks/editor-hacks-utils.ts
@@ -5,6 +5,8 @@ import { ContentProps } from 'types/content-props/_content-common';
 const adminAuthUrl = `${adminOrigin}/admin/rest/auth/authenticated`;
 const userInfoUrl = `${adminOrigin}/admin/rest-v2/cs/security/principals/user:`;
 
+const CONTENT_REPO_PREFIX = 'com.enonic.cms.';
+
 // The pathname in the editor view looks like this:
 // /admin/tool/com.enonic.app.contentstudio/main/<project id>/edit/<content id>
 const getProjectIdFromCurrentEditorUrl = () =>
@@ -13,7 +15,7 @@ const getProjectIdFromCurrentEditorUrl = () =>
 
 // Content repo-ids look like this: com.enonic.cms.<project-id>
 const getProjectIdFromRepoId = (repoId: string) =>
-    repoId.split('.').slice(-1)[0];
+    repoId.replace(CONTENT_REPO_PREFIX, '');
 
 const getContentServiceUrl = (projectId: string) =>
     `${adminOrigin}/admin/rest-v2/cs/cms/${projectId}/content/content`;
@@ -59,3 +61,6 @@ export const editorFetchUserInfo = async (userId: string) =>
 
 export const isCurrentEditorRepo = (repoId: string) =>
     getProjectIdFromRepoId(repoId) === getProjectIdFromCurrentEditorUrl();
+
+export const isContentRepo = (repoId?: string) =>
+    repoId?.startsWith(CONTENT_REPO_PREFIX);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Hindrer eventer fra repoer som ikke er content-repoer fra å ha noen effekt
- Hindrer eventer av andre typer enn "Update" fra å interceptes
- Oppdaterer varseltekst til redaktører
