### PR TITLE
Hindrer diverse komponent-editor elementer fra å vises ved legacy content-typer

### DIFF
--- a/src/components/PageWrapper.module.scss
+++ b/src/components/PageWrapper.module.scss
@@ -65,9 +65,14 @@
     }
 }
 
+// Prevent accidental page customizations on legacy types which we genereally
+// never want to customize
 .legacyType {
-    :global(.xp-page-editor-item-placeholder),
-    :global(.item-view-context-menu) {
+    //  Prevent drag/drop interaction with components
+    pointer-events: none;
+
+    // Hide region dropzones and component-selectors
+    :global(.xp-page-editor-item-placeholder) {
         display: none !important;
     }
 }

--- a/src/components/PageWrapper.module.scss
+++ b/src/components/PageWrapper.module.scss
@@ -64,3 +64,10 @@
         margin-top: -0.75rem;
     }
 }
+
+.legacyType {
+    :global(.xp-page-editor-item-placeholder),
+    :global(.item-view-context-menu) {
+        display: none !important;
+    }
+}

--- a/src/components/PageWrapper.module.scss
+++ b/src/components/PageWrapper.module.scss
@@ -69,7 +69,9 @@
 // never want to customize
 .legacyType {
     //  Prevent drag/drop interaction with components
-    pointer-events: none;
+    :global(.xp-page-editor-region-view) {
+        pointer-events: none !important;
+    }
 
     // Hide region dropzones and component-selectors
     :global(.xp-page-editor-item-placeholder) {

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -25,6 +25,7 @@ import { fetchAndSetMeldekortStatus } from 'utils/fetch/fetch-meldekort-status';
 import { LegacyPageChatbot } from './_common/chatbot/LegacyPageChatbot';
 import { classNames } from 'utils/classnames';
 import { EditorWidgets } from './_editor-only/EditorWidgets';
+import { isLegacyContentType } from 'utils/content-types';
 
 import styles from './PageWrapper.module.scss';
 
@@ -141,7 +142,12 @@ export const PageWrapper = (props: Props) => {
                     : styles.defaultBackground
             }
         >
-            <div className={classNames(styles.appContainer)}>
+            <div
+                className={classNames(
+                    styles.appContainer,
+                    isLegacyContentType(content.type) && styles.legacyType
+                )}
+            >
                 <DocumentParameterMetatags content={content} />
                 <HeadWithMetatags content={content} />
                 <PageWarnings content={content} />

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -142,12 +142,7 @@ export const PageWrapper = (props: Props) => {
                     : styles.defaultBackground
             }
         >
-            <div
-                className={classNames(
-                    styles.appContainer,
-                    isLegacyContentType(content.type) && styles.legacyType
-                )}
-            >
+            <div className={styles.appContainer}>
                 <DocumentParameterMetatags content={content} />
                 <HeadWithMetatags content={content} />
                 <PageWarnings content={content} />
@@ -156,9 +151,9 @@ export const PageWrapper = (props: Props) => {
                     role={'main'}
                     className={classNames(
                         styles.contentWrapper,
-                        (hasWhitePage(content) || hasWhiteHeader(content)) &&
-                            styles.whiteBackground,
-                        shouldPushUpwards(content) && styles.decoratorOffset
+                        hasWhiteHeader(content) && styles.whiteBackground,
+                        shouldPushUpwards(content) && styles.decoratorOffset,
+                        isLegacyContentType(content.type) && styles.legacyType
                     )}
                     id={'maincontent'}
                     tabIndex={-1}

--- a/src/components/_common/metatags/DocumentParameterMetatags.tsx
+++ b/src/components/_common/metatags/DocumentParameterMetatags.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { ContentProps } from '../../../types/content-props/_content-common';
+import { ContentProps } from 'types/content-props/_content-common';
 import Head from 'next/head';
-import { getDecoratorParams } from '../../../utils/decorator/decorator-utils';
+import { getDecoratorParams } from 'utils/decorator/decorator-utils';
+import { isLegacyContentType } from 'utils/content-types';
 
 type Props = {
     content: ContentProps;
@@ -11,6 +12,7 @@ export enum DocumentParameter {
     DecoratorParams = '_decoratorParams',
     HtmlLang = '_htmlLang',
     DecoratorDisabled = 'decoratorDisabled',
+    LegacyContentType = 'legacy',
 }
 
 const isServerSide = typeof window === 'undefined';
@@ -20,6 +22,8 @@ export const DocumentParameterMetatags = ({ content }: Props) => {
     if (!isServerSide) {
         return null;
     }
+
+    const { type, editorView } = content;
 
     const decoratorParams = JSON.stringify(getDecoratorParams(content));
 
@@ -33,6 +37,12 @@ export const DocumentParameterMetatags = ({ content }: Props) => {
                 name={DocumentParameter.HtmlLang}
                 content={content.language}
             />
+            {editorView === 'edit' && isLegacyContentType(type) && (
+                <meta
+                    name={DocumentParameter.LegacyContentType}
+                    content={true}
+                />
+            )}
         </Head>
     );
 };

--- a/src/components/_common/metatags/DocumentParameterMetatags.tsx
+++ b/src/components/_common/metatags/DocumentParameterMetatags.tsx
@@ -40,7 +40,7 @@ export const DocumentParameterMetatags = ({ content }: Props) => {
             {editorView === 'edit' && isLegacyContentType(type) && (
                 <meta
                     name={DocumentParameter.LegacyContentType}
-                    content={true}
+                    content={'true'}
                 />
             )}
         </Head>

--- a/src/components/_editor-only/EditorWidgets.module.scss
+++ b/src/components/_editor-only/EditorWidgets.module.scss
@@ -1,18 +1,19 @@
 @use 'src/common' as common;
 
-.editorWidgets {
+.outer {
     display: flex;
-    flex-direction: column;
-    align-items: center;
     padding-top: 1rem;
-
     @include common.full-width-mixin();
+}
 
-    &.whiteBackground {
-        background-color: var(--a-bg-default);
-    }
+.inner {
+    width: 100%;
 
     &:empty {
         display: none;
     }
+}
+
+.whiteBackground {
+    background-color: var(--a-bg-default);
 }

--- a/src/components/_editor-only/EditorWidgets.tsx
+++ b/src/components/_editor-only/EditorWidgets.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-
 import { ContentProps } from 'types/content-props/_content-common';
 import { EditorHacks } from 'components/_editor-only/editor-hacks/EditorHacks';
 import { EditorGlobalWarnings } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
 import { ReferencesInfo } from 'components/_editor-only/references-info/ReferencesInfo';
 import { VersionHistory } from 'components/_editor-only/version-history/VersionHistory';
-
-import style from './EditorWidgets.module.scss';
 import { hasWhiteHeader } from 'utils/appearance';
 import { classNames } from 'utils/classnames';
+
+import style from './EditorWidgets.module.scss';
 
 type Props = {
     content: ContentProps;
@@ -17,25 +16,28 @@ type Props = {
 export const EditorWidgets = ({ content }: Props) => {
     const { editorView, liveId } = content;
 
-    const whiteBg = hasWhiteHeader(content);
-
     if (!editorView) {
         return null;
     }
 
+    const whiteBg = hasWhiteHeader(content);
+
     return (
         <div
             className={classNames(
-                style.editorWidgets,
+                style.outer,
                 whiteBg && style.whiteBackground
             )}
         >
-            <EditorHacks content={content} />
-            {!liveId && (editorView === 'inline' || editorView === 'edit') && (
-                <ReferencesInfo content={content} />
-            )}
-            <EditorGlobalWarnings key={content._id} />
-            {editorView !== 'edit' && <VersionHistory content={content} />}
+            <div className={style.inner}>
+                <EditorHacks content={content} />
+                {!liveId &&
+                    (editorView === 'inline' || editorView === 'edit') && (
+                        <ReferencesInfo content={content} />
+                    )}
+                <EditorGlobalWarnings key={content._id} />
+                {editorView !== 'edit' && <VersionHistory content={content} />}
+            </div>
         </div>
     );
 };

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -118,7 +118,7 @@ const partsDeprecated: ReadonlySet<PartType> = new Set([
 
 const bem = BEM(ComponentType.Part);
 
-const buildEditorProps = (componentPath: String) => ({
+const buildEditorProps = (componentPath: string) => ({
     'data-portal-component-type': ComponentType.Part,
     'data-portal-component': componentPath,
 });

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -142,7 +142,7 @@ export const PartsMapper = ({ pageProps, partProps }: Props) => {
 
     const isEditView = pageProps.editorView === 'edit';
     const partName = descriptor.split(':')[1];
-    const renderOnAuthState = (config as any)?.renderOnAuthState;
+    const renderOnAuthState = config?.renderOnAuthState;
 
     const editorProps =
         isEditView && !partsWithPageData[descriptor]

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -51,13 +51,12 @@ import { FrontpageContactPart } from './frontpage-contact/FrontpageContactPart';
 import { FrontpageSurveyPanel } from './frontpage-survey-panel/FrontpageSurveyPanel';
 import { UxSignalsWidgetPart } from 'components/parts/uxsignals-widget/UxSignalsWidgetPart';
 import { FormDetailsPart } from './form-details/FormDetailsPart';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 type Props = {
     partProps: PartComponentProps;
     pageProps: ContentProps;
 };
-
-const bem = BEM(ComponentType.Part);
 
 const partsWithPageData: Record<
     PartLegacyType,
@@ -117,6 +116,13 @@ const partsDeprecated: ReadonlySet<PartType> = new Set([
     PartType.PageCrumbs,
 ]) satisfies ReadonlySet<PartDeprecatedType>;
 
+const bem = BEM(ComponentType.Part);
+
+const buildEditorProps = (componentPath: String) => ({
+    'data-portal-component-type': ComponentType.Part,
+    'data-portal-component': componentPath,
+});
+
 const PartComponent = ({ partProps, pageProps }: Props) => {
     const { descriptor } = partProps;
 
@@ -130,27 +136,30 @@ const PartComponent = ({ partProps, pageProps }: Props) => {
         return <PartWithOwnData {...partProps} pageProps={pageProps} />;
     }
 
-    return <div>{`Unimplemented part: ${descriptor}`}</div>;
+    return (
+        <EditorHelp
+            text={`Part-komponenten er ikke implementert: "${descriptor}"`}
+            type={'info'}
+        />
+    );
 };
 
 export const PartsMapper = ({ pageProps, partProps }: Props) => {
     const { path, descriptor, config } = partProps;
 
-    if (!descriptor || partsDeprecated.has(descriptor)) {
+    if (!descriptor) {
         return null;
     }
 
     const isEditView = pageProps.editorView === 'edit';
+    const editorProps = isEditView ? buildEditorProps(path) : undefined;
+
+    if (partsDeprecated.has(descriptor)) {
+        return isEditView ? <div {...editorProps} /> : null;
+    }
+
     const partName = descriptor.split(':')[1];
     const renderOnAuthState = config?.renderOnAuthState;
-
-    const editorProps =
-        isEditView && !partsWithPageData[descriptor]
-            ? {
-                  'data-portal-component-type': ComponentType.Part,
-                  'data-portal-component': path,
-              }
-            : undefined;
 
     return (
         <div

--- a/src/global.scss
+++ b/src/global.scss
@@ -71,3 +71,12 @@ table {
         margin-bottom: 0;
     }
 }
+
+// Prevent the "Customize page" dialog from appearing in the editor
+// on content types which we never want to have customized
+body.legacyContentType {
+    .item-view-context-menu,
+    .xp-page-editor-shader {
+        display: none !important;
+    }
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -48,10 +48,11 @@ class MyDocument extends Document<DocumentProps> {
             DocumentParameter.DecoratorDisabled
         );
 
-        const isLegacyContentType = !!getDocumentParameter(
-            initialProps,
-            DocumentParameter.LegacyContentType
-        );
+        const isLegacyContentType =
+            getDocumentParameter(
+                initialProps,
+                DocumentParameter.LegacyContentType
+            ) === 'true';
 
         const Decorator =
             !decoratorDisabled &&

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,6 +15,7 @@ import { DecoratorComponents } from '@navikt/nav-dekoratoren-moduler/ssr';
 type DocumentProps = {
     language: Language;
     Decorator: DecoratorComponents;
+    isLegacyContentType: boolean;
 };
 
 // The 'head'-field of the document initialProps contains data from <head> (meta-tags etc)
@@ -47,6 +48,11 @@ class MyDocument extends Document<DocumentProps> {
             DocumentParameter.DecoratorDisabled
         );
 
+        const isLegacyContentType = !!getDocumentParameter(
+            initialProps,
+            DocumentParameter.LegacyContentType
+        );
+
         const Decorator =
             !decoratorDisabled &&
             (await getDecoratorComponents(
@@ -57,16 +63,17 @@ class MyDocument extends Document<DocumentProps> {
             ...initialProps,
             Decorator,
             language,
+            isLegacyContentType,
         };
     }
 
     render() {
-        const { Decorator, language } = this.props;
+        const { Decorator, language, isLegacyContentType } = this.props;
 
         return (
             <Html lang={language || 'no'}>
                 <Head>{Decorator && <Decorator.Styles />}</Head>
-                <body>
+                <body className={isLegacyContentType && 'legacyContentType'}>
                     {Decorator && <Decorator.Header />}
                     <Main />
                     {Decorator && <Decorator.Footer />}

--- a/src/types/component-props/_component-common.ts
+++ b/src/types/component-props/_component-common.ts
@@ -1,6 +1,7 @@
 import { PartType } from './parts';
 import { LayoutProps } from './layouts';
 import { ContentProps } from '../content-props/_content-common';
+import { RenderOnAuthStateMixin } from 'types/component-props/_mixins';
 
 export enum ComponentType {
     Page = 'page',
@@ -14,7 +15,7 @@ export enum ComponentType {
 export type ComponentCommonProps = {
     type: ComponentType;
     path: string;
-    config?: unknown;
+    config?: Record<string, unknown> & RenderOnAuthStateMixin;
 };
 
 export type PartComponentProps = ComponentCommonProps & {

--- a/src/types/component-props/parts.ts
+++ b/src/types/component-props/parts.ts
@@ -1,8 +1,9 @@
 export enum PartType {
+    // Deprecated, should never render to anything, only included for compatibility
     Notifications = 'no.nav.navno:notifications',
     BreakingNews = 'no.nav.navno:breaking-news',
     PageCrumbs = 'no.nav.navno:page-crumbs',
-
+    // Legacy, only used in templates for old content types
     LinkPanels = 'no.nav.navno:link-panels',
     LinkLists = 'no.nav.navno:link-lists',
     PageHeading = 'no.nav.navno:page-heading',
@@ -14,7 +15,7 @@ export enum PartType {
     PageList = 'no.nav.navno:page-list',
     PublishingCalendar = 'no.nav.navno:publishing-calendar',
     PublishingCalendarEntry = 'no.nav.navno:publishing-calendar-entry',
-
+    // Parts currently available for active use
     AreaCard = 'no.nav.navno:area-card',
     AlertPanel = 'no.nav.navno:alert-panel',
     LinkPanel = 'no.nav.navno:dynamic-link-panel',
@@ -46,12 +47,12 @@ export enum PartType {
     UxSignalsWidget = 'no.nav.navno:uxsignals-widget',
 }
 
-export type PartDeprecated =
+export type PartDeprecatedType =
     | PartType.Notifications
     | PartType.BreakingNews
     | PartType.PageCrumbs;
 
-export type PartWithPageData =
+export type PartLegacyType =
     | PartType.LinkPanels
     | PartType.LinkLists
     | PartType.PageHeading
@@ -64,33 +65,7 @@ export type PartWithPageData =
     | PartType.PublishingCalendar
     | PartType.PublishingCalendarEntry;
 
-export type PartWithOwnData =
-    | PartType.LinkPanel
-    | PartType.AlertBox
-    | PartType.Header
-    | PartType.LinkList
-    | PartType.NewsList
-    | PartType.HtmlArea
-    | PartType.OfficeEditorialDetail
-    | PartType.Calculator
-    | PartType.PageHeader
-    | PartType.Button
-    | PartType.ProviderCard
-    | PartType.PageNavigationMenu
-    | PartType.FiltersMenu
-    | PartType.FrontpageCurrentTopics
-    | PartType.FrontpageShortcuts
-    | PartType.ProductCard
-    | PartType.ProductCardMini
-    | PartType.ProductCardMicro
-    | PartType.FormDetails
-    | PartType.ContactOption
-    | PartType.ProductDetails
-    | PartType.AlertPanel
-    | PartType.PayoutDates
-    | PartType.AreaCard
-    | PartType.AreapageSituationCard
-    | PartType.LoggedinCard
-    | PartType.FrontpageContact
-    | PartType.FrontpageSurveyPanel
-    | PartType.UxSignalsWidget;
+export type PartCurrentType = Exclude<
+    PartType,
+    PartLegacyType | PartDeprecatedType
+>;

--- a/src/utils/content-types.ts
+++ b/src/utils/content-types.ts
@@ -1,0 +1,16 @@
+import { ContentType } from 'types/content-props/_content-common';
+
+const legacyContentTypes: ReadonlySet<ContentType> = new Set([
+    ContentType.LargeTable,
+    ContentType.MainArticle,
+    ContentType.MainArticleChapter,
+    ContentType.Melding,
+    ContentType.OfficeInformation,
+    ContentType.PageList,
+    ContentType.PublishingCalendar,
+    ContentType.SectionPage,
+    ContentType.TransportPage,
+]);
+
+export const isLegacyContentType = (type: ContentType) =>
+    legacyContentTypes.has(type);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Skjuler drop-soner for regions og component-selectorer i editoren for legacy content -yper
- Skjuler customize-dialogen i editoren for legacy content-typer

Andre endringer:
- Fikser bredde på EditorWidgets-containeren