### PR TITLE
Fikser feil hvor override av ingress i kontaktkanaler ikke fungerer

### DIFF
--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -61,25 +61,25 @@ export const ContactOptionPart = ({
         case 'write': {
             return (
                 <WriteOption
-                    ingress={ingress}
                     {...sharedContactInformation.data.contactType.write}
+                    ingress={ingress}
                 />
             );
         }
         case 'chat': {
             return (
                 <ChatOption
-                    ingress={ingress}
                     {...sharedContactInformation.data.contactType.chat}
+                    ingress={ingress}
                 />
             );
         }
         case 'call': {
             return (
                 <CallOption
+                    {...sharedContactInformation.data.contactType.telephone}
                     ingress={ingress}
                     audience={audience}
-                    {...sharedContactInformation.data.contactType.telephone}
                 />
             );
         }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Spread av sharedContactInformation etter ingress-props gjorde at sistnevnte ble overstyrt. Denne fiksen flytter ingress-props lenger ned slik at de kan overstyre felles ingress dersom de faktisk er satt på den aktuelle parten.

## Testing
Testet i q6