### PR TITLE
Tweaker liveness/readiness verdier

### DIFF
--- a/.nais/config-failover.yml
+++ b/.nais/config-failover.yml
@@ -17,10 +17,12 @@ spec:
   port: 3000
   liveness:
     path: /api/internal/isAlive
-    initialDelay: 10
+    initialDelay: 5
+    timeout: 10
   readiness:
     path: /api/internal/isReady
-    initialDelay: 10
+    initialDelay: 20
+    timeout: 10
   prometheus:
     enabled: true
     path: /internal/metrics

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -17,11 +17,12 @@ spec:
   port: 3000
   liveness:
     path: /api/internal/isAlive
-    initialDelay: 10
-    timeout: 5
+    initialDelay: 5
+    timeout: 10
   readiness:
     path: /api/internal/isReady
-    initialDelay: 10
+    initialDelay: 20
+    timeout: 10
   prometheus:
     enabled: true
     path: /internal/metrics


### PR DESCRIPTION
Ser at poddene av og til restartes pga readiness/liveness-timeouts etter deploys rundt peak hours. Poddene får ganske mye trøkk når det er mye trafikk med tom cache, så da blir kanskje respons-tiden på live/ready endepunktene en del tregere.

Øker derfor timeoutene en del, og øker også initialDelay på readiness, slik at nye podder oppskaleres saktere og får forholdsvis mindre trafikk i starten.
