### PR TITLE
Fikser visuell feil i sidemeny på legacy artikkelsider

### DIFF
--- a/src/components/parts/_legacy/menu-list/MenuList.module.scss
+++ b/src/components/parts/_legacy/menu-list/MenuList.module.scss
@@ -5,6 +5,10 @@
     flex-direction: column;
     width: 100%;
 
+    :global(.navds-accordion) {
+        --__ac-accordion-header-shadow-color: none;
+    }
+
     .panel {
         margin-bottom: 0.5rem;
         background-color: common.$a-white;
@@ -12,6 +16,14 @@
 
         :global(.navds-accordion__header) {
             border-radius: common.$border-radius-base;
+
+            &:not(:focus-visible) {
+                box-shadow: 0 0 0;
+            }
+
+            &:hover {
+                background-color: common.$a-white;
+            }
         }
 
         &:global(.navds-accordion__item--open) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner box-shadow på accordions i legacy artikkelsider i sidemenyen. De er uansett avgrenset med padding og grå bakgrunnsfarge mellom seg.

<img width="466" alt="Screenshot 2023-12-08 at 07 39 11" src="https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/7155b172-52d7-4ce4-81db-34680d21844b">


## Testing
Testes i dev