### PR TITLE
Støtter visning av spesifikt antall desimaler i tall-macroer

### DIFF
--- a/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
+++ b/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
@@ -70,7 +70,12 @@ export const evaluateExpression = (
 
         const parsedExpression = jsep(expressionWithDotSeparators);
         const result = evaluateExpressionJSEP(parsedExpression);
-        return formatNumber(result, decimals, language);
+        return formatNumber({
+            num: result,
+            minDecimals: decimals,
+            maxDecimals: decimals,
+            language,
+        });
     } catch (e) {
         if (isEditorView) {
             return `[feil ved evaluering av uttrykk: ${e}]`;

--- a/src/components/macros/global-value/MacroGlobalValue.tsx
+++ b/src/components/macros/global-value/MacroGlobalValue.tsx
@@ -32,13 +32,12 @@ export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
         return <>{value}</>;
     }
 
-    const number = parseFloat(value);
     return (
         <>
             {formatNumber({
-                num: number,
+                num: parseFloat(value),
                 minDecimals: decimals,
-                maxDecimals: 2,
+                maxDecimals: decimals,
                 language,
             })}
         </>

--- a/src/components/macros/global-value/MacroGlobalValue.tsx
+++ b/src/components/macros/global-value/MacroGlobalValue.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { usePageConfig } from 'store/hooks/usePageConfig';
-import { MacroGlobalValueProps } from '../../../types/macro-props/global-value';
-import { formatNumber, isStringOnlyNumber } from '../../../utils/math';
+import { MacroGlobalValueProps } from 'types/macro-props/global-value';
+import { formatNumber, isStringOnlyNumber } from 'utils/math';
 import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 
 export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
@@ -15,7 +15,7 @@ export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
         );
     }
 
-    const { value } = config.global_value;
+    const { value, decimals } = config.global_value;
 
     if (value === undefined) {
         return (
@@ -33,5 +33,14 @@ export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
     }
 
     const number = parseFloat(value);
-    return <>{formatNumber(number, 2, language)}</>;
+    return (
+        <>
+            {formatNumber({
+                num: number,
+                minDecimals: decimals,
+                maxDecimals: 2,
+                language,
+            })}
+        </>
+    );
 };

--- a/src/components/macros/tall/MacroTall.tsx
+++ b/src/components/macros/tall/MacroTall.tsx
@@ -37,5 +37,5 @@ export const MacroTall = ({ config }: MacroTallProps) => {
         );
     }
 
-    return <>{formatNumber(number, 2, language)}</>;
+    return <>{formatNumber({ num: number, maxDecimals: 2, language })}</>;
 };

--- a/src/components/macros/tall/MacroTall.tsx
+++ b/src/components/macros/tall/MacroTall.tsx
@@ -15,7 +15,8 @@ export const MacroTall = ({ config }: MacroTallProps) => {
         );
     }
 
-    const { verdi } = config.tall;
+    const { verdi, decimals } = config.tall;
+
     if (verdi === undefined) {
         return (
             <EditorHelp
@@ -37,5 +38,14 @@ export const MacroTall = ({ config }: MacroTallProps) => {
         );
     }
 
-    return <>{formatNumber({ num: number, maxDecimals: 2, language })}</>;
+    return (
+        <>
+            {formatNumber({
+                num: number,
+                minDecimals: decimals,
+                maxDecimals: decimals,
+                language,
+            })}
+        </>
+    );
 };

--- a/src/types/macro-props/global-value.ts
+++ b/src/types/macro-props/global-value.ts
@@ -5,6 +5,7 @@ export interface MacroGlobalValueProps extends MacroPropsCommon {
     config: {
         global_value: {
             value: string;
+            decimals?: number;
         };
     };
 }

--- a/src/types/macro-props/tall.ts
+++ b/src/types/macro-props/tall.ts
@@ -5,6 +5,7 @@ export interface MacroTallProps extends MacroPropsCommon {
     config: {
         tall: {
             verdi: number;
+            decimals?: number;
         };
     };
 }

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -3,7 +3,7 @@ import { Language } from 'translations';
 export const formatNumber = ({
     num,
     minDecimals,
-    maxDecimals = 2,
+    maxDecimals,
     language = 'no',
 }: {
     num: number;
@@ -16,7 +16,7 @@ export const formatNumber = ({
     return num.toLocaleString(language === 'nn' ? 'no' : language, {
         // Ensure null-values are not used, as this is the equivalent of 0-values
         minimumFractionDigits: minDecimals ?? undefined,
-        maximumFractionDigits: maxDecimals ?? undefined,
+        maximumFractionDigits: maxDecimals ?? 2,
     });
 };
 

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,15 +1,22 @@
 import { Language } from 'translations';
 
-export const formatNumber = (
-    num: number,
-    maxPlaces: number = 0,
-    language: Language = 'no'
-) => {
-    const decimalsOOM = 10 ** maxPlaces;
-    const rounded = Math.floor(num * decimalsOOM + 0.5) / decimalsOOM;
+export const formatNumber = ({
+    num,
+    minDecimals = 0,
+    maxDecimals = 0,
+    language = 'no',
+}: {
+    num: number;
+    minDecimals?: number;
+    maxDecimals?: number;
+    language?: Language;
+}) => {
     // Not all browsers process the "nn" locale correctly. Formatting is identical
     // to "no", so we just use that
-    return rounded.toLocaleString(language === 'nn' ? 'no' : language);
+    return num.toLocaleString(language === 'nn' ? 'no' : language, {
+        minimumFractionDigits: minDecimals,
+        maximumFractionDigits: maxDecimals,
+    });
 };
 
 export const isStringOnlyNumber = (numberAsString: string) => {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -2,8 +2,8 @@ import { Language } from 'translations';
 
 export const formatNumber = ({
     num,
-    minDecimals = 0,
-    maxDecimals = 0,
+    minDecimals,
+    maxDecimals = 2,
     language = 'no',
 }: {
     num: number;
@@ -14,8 +14,9 @@ export const formatNumber = ({
     // Not all browsers process the "nn" locale correctly. Formatting is identical
     // to "no", so we just use that
     return num.toLocaleString(language === 'nn' ? 'no' : language, {
-        minimumFractionDigits: minDecimals,
-        maximumFractionDigits: maxDecimals,
+        // Ensure null-values are not used, as this is the equivalent of 0-values
+        minimumFractionDigits: minDecimals ?? undefined,
+        maximumFractionDigits: maxDecimals ?? undefined,
     });
 };
 


### PR DESCRIPTION
Kan benyttes dersom en alltid ønsker å vise et bestemt antall desimaler i et tall, også etterfølgende 0'er