### PR TITLE
Legger til nosnippet hvis satt i CS

### DIFF
--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -39,11 +39,11 @@ const shouldNotIndex = (content: ContentProps) =>
     content.type === ContentType.Error ||
     content.data?.noindex;
 
-const shouldNoSnippet = (content: ContentProps) => content.data.nosnippet;
+const shouldNotSnippet = (content: ContentProps) => content.data.nosnippet;
 
 const buildRobotsMeta = (content: ContentProps) => {
     const noIndex = shouldNotIndex(content);
-    const noSnippet = shouldNoSnippet(content);
+    const noSnippet = shouldNotSnippet(content);
 
     if (noIndex) {
         return 'noindex, nofollow';
@@ -74,7 +74,7 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
-    const noSnippet = shouldNoSnippet(content);
+    const noSnippet = shouldNotSnippet(content);
     const robotsMeta = buildRobotsMeta(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -39,6 +39,23 @@ const shouldNotIndex = (content: ContentProps) =>
     content.type === ContentType.Error ||
     content.data?.noindex;
 
+const shouldNoSnippet = (content: ContentProps) => content.data.nosnippet;
+
+const buildRobotsMeta = (content: ContentProps) => {
+    const noIndex = shouldNotIndex(content);
+    const noSnippet = shouldNoSnippet(content);
+
+    if (noIndex) {
+        return 'noindex, nofollow';
+    }
+
+    if (noSnippet) {
+        return 'index, follow, nosnippet';
+    }
+
+    return 'index, follow';
+};
+
 const getCanonicalUrl = (content: ContentProps) => {
     if (hasCanonicalUrl(content)) {
         return content.data.canonicalUrl;
@@ -57,16 +74,15 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
+    const noSnippet = shouldNoSnippet(content);
+    const robotsMeta = buildRobotsMeta(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 
     return (
         <Head>
             <title>{title}</title>
-            {noIndex ? (
-                <meta name={'robots'} content={'noindex, nofollow'} />
-            ) : (
-                <link rel={'canonical'} href={url} />
-            )}
+            <meta name={'robots'} content={robotsMeta} />
+            {!noIndex && <link rel={'canonical'} href={url} />}
             <meta property={'og:title'} content={title} />
             <meta property={'og:site_name'} content={'nav.no'} />
             <meta property={'og:url'} content={url} />

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -128,6 +128,7 @@ type ContentCommonData = Partial<{
     metaDescription: string;
     canonicalUrl: string;
     noindex: boolean;
+    nosnippet: boolean;
     ingress: string;
     title: string;
     description: string;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Enkelte ganger ønsker vi at Google ikke forsøker å hente ut snippets fra et innhold basert på hva brukeren har søkt etter. Feks kan det gi feilaktige svar til brukeren dersom teksten vises ute av kontekst i Google-søk.

Denne funksjonen lar redaktøren sette nosnippet for hele innholdet.

## Testing
Testet i dev
