### PR TITLE
Benytter DS shadeOnHover

### DIFF
--- a/src/components/_common/office-details/reception/OpeningHours.module.scss
+++ b/src/components/_common/office-details/reception/OpeningHours.module.scss
@@ -1,9 +1,3 @@
-.openingHours {
-    :global(.navds-table__row):hover {
-        background-color: transparent !important;
-    }
-}
-
 .srOnly {
     height: 0px;
     max-height: 0px;

--- a/src/components/_common/office-details/reception/OpeningHours.tsx
+++ b/src/components/_common/office-details/reception/OpeningHours.tsx
@@ -73,7 +73,7 @@ export const OpeningHours = ({ openingHours }: Props) => {
     };
 
     return (
-        <Table zebraStripes={false} className={styles.openingHours}>
+        <Table zebraStripes={false} shadeOnHover={false}>
             <thead className={styles.srOnly}>
                 <tr>
                     <th role="columnheader">{dayLabel}</th>

--- a/src/components/_common/table/Table.tsx
+++ b/src/components/_common/table/Table.tsx
@@ -4,6 +4,7 @@ import style from './Table.module.scss';
 
 type Props = {
     children: React.ReactNode;
+    shadeOnHover?: boolean;
 } & TableProps;
 
 const getTableComponent = (type: string) => {
@@ -24,7 +25,14 @@ const getTableComponent = (type: string) => {
 };
 
 // Recursively transforms table element children to matching ds-react components
-const TableElement = ({ element }: { element?: React.ReactNode }) => {
+const TableElement = ({
+    element,
+    shadeOnHover,
+}: {
+    element?: React.ReactNode;
+    shadeOnHover: boolean;
+}) => {
+    console.log(shadeOnHover);
     const children = React.Children.map(element, (child) => {
         const { type, props } = child as ReactElement;
 
@@ -32,8 +40,11 @@ const TableElement = ({ element }: { element?: React.ReactNode }) => {
 
         if (TableComponent) {
             return (
-                <TableComponent {...props}>
-                    <TableElement element={props.children} />
+                <TableComponent {...props} shadeOnHover={shadeOnHover}>
+                    <TableElement
+                        element={props.children}
+                        shadeOnHover={shadeOnHover}
+                    />
                 </TableComponent>
             );
         }
@@ -44,11 +55,16 @@ const TableElement = ({ element }: { element?: React.ReactNode }) => {
     return <>{children}</>;
 };
 
-export const Table = ({ children, zebraStripes = true, ...rest }: Props) => {
+export const Table = ({
+    children,
+    zebraStripes = true,
+    shadeOnHover = true,
+    ...rest
+}: Props) => {
     return (
         <div className={style.tableWrapper}>
             <DsTable {...rest} zebraStripes={zebraStripes}>
-                <TableElement element={children} />
+                <TableElement element={children} shadeOnHover={shadeOnHover} />
             </DsTable>
         </div>
     );


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Tar vekk hover-overriden og bruker shadeOnHover som Table-elementene ser ut til å støtte nå.

