### PR TITLE
Tekstendringer arbeidslivssenter

### DIFF
--- a/src/components/parts/_legacy/office-information/OfficeInfoEmail.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInfoEmail.tsx
@@ -26,7 +26,7 @@ export const OfficeInfoEmail = ({ email, unitType }: Props) => {
     return (
         <div>
             <Heading level={'2'} size={'medium'}>
-                {'Epost'}
+                {'E-post'}
             </Heading>
             <BodyShort>{email.adresse}</BodyShort>
         </div>

--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -97,6 +97,8 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
         },
     ];
 
+    console.log('publikumsmottak', publikumsmottak);
+
     return (
         <>
             <script
@@ -208,7 +210,7 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                         <BodyShort>{unit.enhetNr}</BodyShort>
                     </div>
                 )}
-                {unit.type !== 'ALS' && (
+                {publikumsmottak.length > 0 && (
                     <Reception
                         receptions={publikumsmottak}
                         language={props.language}

--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -147,14 +147,30 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                     <Heading level="2" size="small">
                         Innsending av skjemaer
                     </Heading>
-                    <BodyLong>
-                        Skal du sende søknader og skjemaer, må du bruke{' '}
-                        <LenkeInline href="https://www.nav.no/soknader/nb/person">
-                            NAVs skjemaveileder.
-                        </LenkeInline>{' '}
-                        Skjemaveilederen gir deg hjelp til å velge rett skjema
-                        og rett adresse det skal sendes til.
-                    </BodyLong>
+                    {unit.type === 'ALS' ? (
+                        <BodyLong>
+                            Du kan skrive til oss hvis du ønsker hjelp til å
+                            rekruttere, inkludere arbeidstakere og forebygge
+                            sykefravær, se{' '}
+                            <LenkeInline href="https://kontaktskjema.arbeidsgiver.nav.no/s/">
+                                kontaktskjema for arbeidsgivere
+                            </LenkeInline>
+                            . Skal du sende søknader eller skjemaer, må du bruke{' '}
+                            <LenkeInline href="https://www.nav.no/arbeidsgiver/soknader">
+                                skjemaoversikten for arbeidsgivere
+                            </LenkeInline>
+                            .
+                        </BodyLong>
+                    ) : (
+                        <BodyLong>
+                            Skal du sende søknader og skjemaer, må du bruke{' '}
+                            <LenkeInline href="https://www.nav.no/soknader/nb/person">
+                                NAVs skjemaveileder.
+                            </LenkeInline>{' '}
+                            Skjemaveilederen gir deg hjelp til å velge rett
+                            skjema og rett adresse det skal sendes til.
+                        </BodyLong>
+                    )}
                 </div>
                 <SpecialInformation info={contact.spesielleOpplysninger} />
                 <div>

--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -97,8 +97,6 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
         },
     ];
 
-    console.log('publikumsmottak', publikumsmottak);
-
     return (
         <>
             <script

--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -192,10 +192,12 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                         <BodyShort>{unit.enhetNr}</BodyShort>
                     </div>
                 )}
-                <Reception
-                    receptions={publikumsmottak}
-                    language={props.language}
-                />
+                {unit.type !== 'ALS' && (
+                    <Reception
+                        receptions={publikumsmottak}
+                        language={props.language}
+                    />
+                )}
             </article>
         </>
     );


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Gjør etterspurte tekstendringer på arbeidslivssentersidene (ALS)
-   Foreslår å fjerne overskriften "Publikumsmottak" på alle sidene hvor det er tomt, og ikke bare ALS. Treffer ihvertfall https://www.nav.no/no/nav-og-samfunn/kontakt-nav/kontorer/nav-okonomi-stonad. (Tommel opp fra Janne)
-   Tenker det kanskje ikke er verdt det å bruke tid mer tid på refaktorering av store komponenter siden disse malene skal bort "snart", og sannsynligvis ikke endres så mye mer før de skal bort.

## Testing

Har testet selv i dev
