### PR TITLE
Søker i keywords på oversiktssider + Table props fix

### DIFF
--- a/src/components/_common/table/Table.tsx
+++ b/src/components/_common/table/Table.tsx
@@ -12,44 +12,47 @@ type Props = {
 
 const TableContext = React.createContext<TableContextProps>({});
 
-const getTableComponent = (type: string) => {
-    switch (type) {
-        case 'thead':
-            return DsTable.Header;
-        case 'tbody':
-            return DsTable.Body;
-        case 'th':
-            return DsTable.HeaderCell;
-        case 'tr':
-            return DsTable.Row;
-        case 'td':
-            return DsTable.DataCell;
-        default:
-            return null;
-    }
-};
-
 // Recursively transforms table element children to matching ds-react components
-const TableElement = ({ element }: { element?: React.ReactNode }) => {
+const TableComponent = ({ element }: { element?: React.ReactNode }) => {
     const { shadeOnHover } = useContext(TableContext);
 
-    const children = React.Children.map(element, (child) => {
-        const { type, props } = child as ReactElement;
+    const children = React.Children.map(element, (child: ReactElement) => {
+        const { type, props } = child;
 
-        const TableComponent = getTableComponent(type?.toString());
-
-        if (!TableComponent) {
-            return child;
+        switch (type) {
+            case 'thead':
+                return (
+                    <DsTable.Header {...props}>
+                        <TableComponent element={props.children} />
+                    </DsTable.Header>
+                );
+            case 'tbody':
+                return (
+                    <DsTable.Body {...props}>
+                        <TableComponent element={props.children} />
+                    </DsTable.Body>
+                );
+            case 'th':
+                return (
+                    <DsTable.HeaderCell {...props}>
+                        <TableComponent element={props.children} />
+                    </DsTable.HeaderCell>
+                );
+            case 'tr':
+                return (
+                    <DsTable.Row {...props} shadeOnHover={shadeOnHover}>
+                        <TableComponent element={props.children} />
+                    </DsTable.Row>
+                );
+            case 'td':
+                return (
+                    <DsTable.DataCell {...props}>
+                        <TableComponent element={props.children} />
+                    </DsTable.DataCell>
+                );
+            default:
+                return child;
         }
-
-        return (
-            <TableComponent
-                {...props}
-                shadeOnHover={type === 'tr' ? shadeOnHover : undefined}
-            >
-                <TableElement element={props.children} />
-            </TableComponent>
-        );
     });
 
     return <>{children}</>;
@@ -72,7 +75,7 @@ export const Table = ({
         <div className={style.tableWrapper}>
             <TableContext.Provider value={context}>
                 <DsTable {...rest} zebraStripes={zebraStripes}>
-                    <TableElement element={children} />
+                    <TableComponent element={children} />
                 </DsTable>
             </TableContext.Provider>
         </div>

--- a/src/components/_common/table/Table.tsx
+++ b/src/components/_common/table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import { Table as DsTable, TableProps } from '@navikt/ds-react';
 
 import style from './Table.module.scss';
@@ -61,9 +61,16 @@ export const Table = ({
     shadeOnHover = true,
     ...rest
 }: Props) => {
+    const context = useMemo<TableContextProps>(
+        () => ({
+            shadeOnHover,
+        }),
+        [shadeOnHover]
+    );
+
     return (
         <div className={style.tableWrapper}>
-            <TableContext.Provider value={{ shadeOnHover }}>
+            <TableContext.Provider value={context}>
                 <DsTable {...rest} zebraStripes={zebraStripes}>
                     <TableElement element={children} />
                 </DsTable>

--- a/src/components/_common/table/Table.tsx
+++ b/src/components/_common/table/Table.tsx
@@ -13,41 +13,41 @@ type Props = {
 const TableContext = React.createContext<TableContextProps>({});
 
 // Recursively transforms table element children to matching ds-react components
-const TableComponent = ({ element }: { element?: React.ReactNode }) => {
+const TableComponent = ({ children }: Props) => {
     const { shadeOnHover } = useContext(TableContext);
 
-    const children = React.Children.map(element, (child: ReactElement) => {
+    const elements = React.Children.map(children, (child: ReactElement) => {
         const { type, props } = child;
 
         switch (type) {
             case 'thead':
                 return (
                     <DsTable.Header {...props}>
-                        <TableComponent element={props.children} />
+                        <TableComponent>{props.children}</TableComponent>
                     </DsTable.Header>
                 );
             case 'tbody':
                 return (
                     <DsTable.Body {...props}>
-                        <TableComponent element={props.children} />
+                        <TableComponent>{props.children}</TableComponent>
                     </DsTable.Body>
                 );
             case 'th':
                 return (
                     <DsTable.HeaderCell {...props}>
-                        <TableComponent element={props.children} />
+                        <TableComponent>{props.children}</TableComponent>
                     </DsTable.HeaderCell>
                 );
             case 'tr':
                 return (
                     <DsTable.Row {...props} shadeOnHover={shadeOnHover}>
-                        <TableComponent element={props.children} />
+                        <TableComponent>{props.children}</TableComponent>
                     </DsTable.Row>
                 );
             case 'td':
                 return (
                     <DsTable.DataCell {...props}>
-                        <TableComponent element={props.children} />
+                        <TableComponent>{props.children}</TableComponent>
                     </DsTable.DataCell>
                 );
             default:
@@ -55,7 +55,7 @@ const TableComponent = ({ element }: { element?: React.ReactNode }) => {
         }
     });
 
-    return <>{children}</>;
+    return <>{elements}</>;
 };
 
 export const Table = ({
@@ -75,7 +75,7 @@ export const Table = ({
         <div className={style.tableWrapper}>
             <TableContext.Provider value={context}>
                 <DsTable {...rest} zebraStripes={zebraStripes}>
-                    <TableComponent element={children} />
+                    <TableComponent>{children}</TableComponent>
                 </DsTable>
             </TableContext.Provider>
         </div>

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -30,6 +30,7 @@ export const OverviewPage = (props: OverviewPageProps) => {
                     { name: 'title', weight: 10 },
                     { name: 'ingress', weight: 1 },
                     { name: 'productLinks.title', weight: 1 },
+                    { name: 'keywords', weight: 2 },
                 ],
             },
         }).then((result) => {

--- a/src/types/content-props/overview-props.ts
+++ b/src/types/content-props/overview-props.ts
@@ -26,6 +26,7 @@ export type OverviewPageProductItem = {
     productLinks: OverviewPageProductLink[];
     taxonomy: ProductTaxonomy[];
     title: string;
+    keywords?: string[];
 };
 
 export type OverviewPageData = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Legger til søk i feltet `keywords` i text-filteret på oversiktssider
- Refactor shadeOnHover prop for tables for å hindre invalid props error på elementer som ikke har denne prop'en