### PR TITLE
U: Headings skjemadetaljer

### DIFF
--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.module.scss
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.module.scss
@@ -45,6 +45,18 @@ $padding: 2rem;
     margin-bottom: 1rem;
     width: 100%;
     cursor: pointer;
+    &:global(.navds-link-panel) {
+        border: 1px solid common.$a-text-action;
+    }
+    & :global {
+        .navds-link-panel__title,
+        .navds-link-panel__chevron {
+            color: common.$a-text-action;
+        }
+    }
+    @media #{common.$mq-screen-mobile} {
+        padding: 0.75rem 1rem;
+    }
 }
 
 .buttonGroup {

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.module.scss
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.module.scss
@@ -42,20 +42,17 @@ $padding: 2rem;
 }
 
 .stepAction {
-    margin-bottom: 1rem;
-    width: 100%;
-    cursor: pointer;
     &:global(.navds-link-panel) {
-        border: 1px solid common.$a-text-action;
+        border-color: var(--a-text-action);
     }
     & :global {
         .navds-link-panel__title,
         .navds-link-panel__chevron {
-            color: common.$a-text-action;
+            color: var(--a-text-action);
         }
     }
     @media #{common.$mq-screen-mobile} {
-        padding: 0.75rem 1rem;
+        padding: 0.75rem;
     }
 }
 

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Heading } from '@navikt/ds-react';
+import { BodyLong, Button, Heading, LinkPanel } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
 import { FormIntermediateStepPageProps } from 'types/content-props/form-intermediate-step';
@@ -7,7 +7,6 @@ import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { useRouter } from 'next/compat/router';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import LenkepanelNavNo from 'components/_common/lenkepanel-legacy/LenkepanelNavNo';
 import { InfoBox } from 'components/_common/info-box/InfoBox';
 
 import styles from './FormIntermediateStepPage.module.scss';
@@ -122,17 +121,37 @@ export const FormIntermediateStepPage = (
                                                 {step.languageDisclaimer}
                                             </InfoBox>
                                         )}
-                                        <LenkepanelNavNo
+                                        <LinkPanel
                                             href={getHrefFromStep(step)}
                                             onClick={getOnClickFromStep(
                                                 step,
                                                 index
                                             )}
                                             className={styles.stepAction}
-                                            tittel={step.label}
+                                            as={(props) => (
+                                                <LenkeBase
+                                                    analyticsComponent="mellomsteg"
+                                                    analyticsLinkGroup={currentStepData.stepsHeadline}
+                                                    analyticsLabel={step.label}
+                                                    {...props}
+                                                >
+                                                    <div className={styles.innhold}>
+                                                        <Heading
+                                                            as = "span"
+                                                            level="2"
+                                                            size="small"
+                                                            className="navds-link-panel__title"
+                                                        >
+                                                            {step.label}
+                                                        </Heading>
+                                                        <BodyLong>
+                                                            {step.explanation}
+                                                        </BodyLong>
+                                                    </div>
+                                                </LenkeBase>
+                                            )}
                                         >
-                                            {step.explanation}
-                                        </LenkepanelNavNo>
+                                        </LinkPanel>
                                     </li>
                                 );
                             }
@@ -157,7 +176,7 @@ export const FormIntermediateStepPage = (
                             as={LenkeBase}
                             href={router.asPath}
                             analyticsComponent={'mellomsteg'}
-                            analyticsLinkGroup={'steg-1'}
+                            analyticsLinkGroup={currentStepData.stepsHeadline}
                             analyticsLabel={'Tilbake'}
                         >
                             {getTranslations('back')}

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { BodyLong, Button, Heading, LinkPanel } from '@navikt/ds-react';
+import { Button, Heading, LinkPanel } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { ThemedPageHeader } from '../../_common/headers/themed-page-header/ThemedPageHeader';
 import { FormIntermediateStepPageProps } from 'types/content-props/form-intermediate-step';
@@ -104,7 +104,7 @@ export const FormIntermediateStepPage = (
                 <div className={styles.stepOptionsWrapper}>
                     <ParsedHtml htmlProps={currentStepData.editorial} />
                     {currentStepData.stepsHeadline && (
-                        <Heading level="3" size="small" spacing>
+                        <Heading level="2" size="medium" spacing>
                             {currentStepData.stepsHeadline}
                         </Heading>
                     )}
@@ -139,19 +139,12 @@ export const FormIntermediateStepPage = (
                                                 </LenkeBase>
                                             )}
                                         >
-                                            <div className={styles.innhold}>
-                                                <Heading
-                                                    as = "span"
-                                                    level="2"
-                                                    size="small"
-                                                    className="navds-link-panel__title"
-                                                >
-                                                    {step.label}
-                                                </Heading>
-                                                <BodyLong>
-                                                    {step.explanation}
-                                                </BodyLong>
-                                            </div>
+                                            <LinkPanel.Title>
+                                                {step.label}
+                                            </LinkPanel.Title>
+                                            <LinkPanel.Description>
+                                                {step.explanation}
+                                            </LinkPanel.Description>
                                         </LinkPanel>
                                     </li>
                                 );

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
@@ -135,22 +135,23 @@ export const FormIntermediateStepPage = (
                                                     analyticsLabel={step.label}
                                                     {...props}
                                                 >
-                                                    <div className={styles.innhold}>
-                                                        <Heading
-                                                            as = "span"
-                                                            level="2"
-                                                            size="small"
-                                                            className="navds-link-panel__title"
-                                                        >
-                                                            {step.label}
-                                                        </Heading>
-                                                        <BodyLong>
-                                                            {step.explanation}
-                                                        </BodyLong>
-                                                    </div>
+                                                    {props.children}
                                                 </LenkeBase>
                                             )}
                                         >
+                                            <div className={styles.innhold}>
+                                                <Heading
+                                                    as = "span"
+                                                    level="2"
+                                                    size="small"
+                                                    className="navds-link-panel__title"
+                                                >
+                                                    {step.label}
+                                                </Heading>
+                                                <BodyLong>
+                                                    {step.explanation}
+                                                </BodyLong>
+                                            </div>
                                         </LinkPanel>
                                     </li>
                                 );


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Gjør om fra LenkepanelNavno (legacy-komponent) til LinkPanel
- Refaktor css som følge av dette
- Fikser heading hierarki i siden (overskrift går fra h3 til h2)
- Fikser mangelfulle data til Amplitude

Er nå mer likt standard Linkpanel fra Aksel. Fjerner bl.a. h2. 
Beholdt fargemessig overstyring av Aksel.

## Testing
Har testet selv i dev

## Trenger et ekstra blikk på dette
SonarCloud liker ikke at vi sender inn `as={(props)=> <Lenkebase props>props.children</Lenkebase>}`
Dette er et pattern vi bruker flere steder, bl.a. AreaCard, for å sikre Amplitude logging.
Har litt trøbbel med Amplitude, men det ser ut som dette skjer i prod også akkurat nå.


