### PR TITLE
Heading faktaboks fra h3 til h2

### DIFF
--- a/src/components/parts/_legacy/main-article/komponenter/Faktaboks.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/Faktaboks.module.scss
@@ -8,7 +8,7 @@
         margin-bottom: 1rem;
     }
 
-    h3 {
+    h2 {
         text-align: center;
     }
 
@@ -45,7 +45,7 @@
         }
     }
 
-    h3 {
+    h2 {
         color: var(--a-purple-500);
     }
 

--- a/src/components/parts/_legacy/main-article/komponenter/Faktaboks.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/Faktaboks.tsx
@@ -24,11 +24,11 @@ export const Faktaboks = ({ label, fakta, version = '1' }: Props) => {
             {version === '1' && (
                 <StaticImage
                     imageData={icon}
-                    alt={''}
+                    alt=""
                     className={style.factIcon}
                 />
             )}
-            <Heading level={'3'} size={'xsmall'} className={style.decorated}>
+            <Heading level="2" size="medium" className={style.decorated}>
                 {label}
             </Heading>
             <ParsedHtml htmlProps={fakta} />


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Heading h2 (tidligere h3). Sikrer korrekt hieraki (innholdet bruker h3 og h4).

## Testing

Har testet selv i dev

