### PR TITLE
Fjern hardkoding av URLer i CSS

### DIFF
--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -84,12 +84,12 @@ export const CallOption = (props: CallOptionProps) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon(
-                        'phone.svg',
-                        'phone-filled.svg',
-                        isActive,
-                        style.icon
-                    )}
+                    {hoverFocusIcon({
+                        iconDefault: 'phone.svg',
+                        iconActive: 'phone-filled.svg',
+                        isActive: isActive,
+                        style: style.icon,
+                    })}
                     <Heading level="3" size="small" className={style.link}>
                         {title || callTranslations.title}
                     </Heading>

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -71,7 +71,7 @@ export const CallOption = (props: CallOptionProps) => {
             : audienceUrls.en;
     };
 
-    const [isActive, bind] = useHoverAndFocus();
+    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
 
     return (
         <div className={style.contactOption}>
@@ -81,7 +81,7 @@ export const CallOption = (props: CallOptionProps) => {
                 analyticsEvent={AnalyticsEvents.CALL}
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
-                {...bind}
+                {...hoverAndFocusHandlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('phone', isActive)}

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -71,7 +71,7 @@ export const CallOption = (props: CallOptionProps) => {
             : audienceUrls.en;
     };
 
-    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
+    const { handlers, isActive } = useHoverAndFocus();
 
     return (
         <div className={style.contactOption}>
@@ -81,7 +81,7 @@ export const CallOption = (props: CallOptionProps) => {
                 analyticsEvent={AnalyticsEvents.CALL}
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
-                {...hoverAndFocusHandlers}
+                {...handlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('phone', isActive)}

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -73,8 +73,6 @@ export const CallOption = (props: CallOptionProps) => {
 
     const [isActive, bind] = useHoverAndFocus();
 
-    const appOrigin = process.env.APP_ORIGIN;
-
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -86,7 +84,7 @@ export const CallOption = (props: CallOptionProps) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates(appOrigin, 'phone', isActive)}
+                    {iconWithTwoStates('phone', isActive)}
                     <Heading level="3" size="small" className={style.link}>
                         {title || callTranslations.title}
                     </Heading>

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -84,7 +84,12 @@ export const CallOption = (props: CallOptionProps) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon('phone', isActive)}
+                    {hoverFocusIcon(
+                        'phone.svg',
+                        'phone-filled.svg',
+                        isActive,
+                        style.icon
+                    )}
                     <Heading level="3" size="small" className={style.link}>
                         {title || callTranslations.title}
                     </Heading>

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -11,7 +11,7 @@ import { OpeningInfo } from 'components/_common/contact-option/opening-info/Open
 import { Audience, getAudience } from 'types/component-props/_mixins';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import {
-    iconWithTwoStates,
+    hoverFocusIcon,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
 
@@ -84,7 +84,7 @@ export const CallOption = (props: CallOptionProps) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates('phone', isActive)}
+                    {hoverFocusIcon('phone', isActive)}
                     <Heading level="3" size="small" className={style.link}>
                         {title || callTranslations.title}
                     </Heading>

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { translator } from 'translations';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
-import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { TelephoneData } from 'types/component-props/parts/contact-option';
@@ -11,6 +10,10 @@ import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import { OpeningInfo } from 'components/_common/contact-option/opening-info/OpeningInfo';
 import { Audience, getAudience } from 'types/component-props/_mixins';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+import {
+    iconWithTwoStates,
+    useHoverAndFocus,
+} from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 
@@ -68,6 +71,10 @@ export const CallOption = (props: CallOptionProps) => {
             : audienceUrls.en;
     };
 
+    const [isActive, bind] = useHoverAndFocus();
+
+    const appOrigin = process.env.APP_ORIGIN;
+
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -76,12 +83,10 @@ export const CallOption = (props: CallOptionProps) => {
                 analyticsEvent={AnalyticsEvents.CALL}
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
+                {...bind}
             >
                 <div className={style.linkContent}>
-                    <img
-                        alt=""
-                        className={classNames(style.icon, style.call)}
-                    />
+                    {iconWithTwoStates(appOrigin, 'phone', isActive)}
                     <Heading level="3" size="small" className={style.link}>
                         {title || callTranslations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -37,6 +37,31 @@ export default function useHoverAndFocus(): [
     return [isHovered || isFocused, bind];
 }
 
+const iconWithTwoStates = (
+    defaultImg: string,
+    activeImg: string,
+    isActive: boolean
+) => (
+    <>
+        <img
+            alt=""
+            className={classNames(style.icon)}
+            src={defaultImg}
+            style={{
+                display: isActive ? 'none' : 'block',
+            }}
+        />
+        <img
+            alt=""
+            className={classNames(style.icon)}
+            src={activeImg}
+            style={{
+                display: isActive ? 'block' : 'none',
+            }}
+        />
+    </>
+);
+
 export const ChatOption = (props: ChatData) => {
     const {
         ingress,
@@ -53,27 +78,6 @@ export const ChatOption = (props: ChatData) => {
     const translations = translator('contactPoint', language)('chat');
 
     const [isActive, bind] = useHoverAndFocus();
-
-    const iconWithTwoStates = (defaultImg: string, activeImg: string) => (
-        <>
-            <img
-                alt=""
-                className={classNames(style.icon)}
-                src={defaultImg}
-                style={{
-                    display: isActive ? 'none' : 'block',
-                }}
-            />
-            <img
-                alt=""
-                className={classNames(style.icon)}
-                src={activeImg}
-                style={{
-                    display: isActive ? 'block' : 'none',
-                }}
-            />
-        </>
-    );
 
     return (
         <div className={style.contactOption}>
@@ -92,7 +96,8 @@ export const ChatOption = (props: ChatData) => {
                 <div className={style.linkContent}>
                     {iconWithTwoStates(
                         'https://www.nav.no/gfx/chat.svg',
-                        'https://www.nav.no/gfx/chat-filled.svg'
+                        'https://www.nav.no/gfx/chat-filled.svg',
+                        isActive
                     )}
                     <Heading level="3" size="small">
                         {title || translations.title}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
 import { ChatData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
@@ -14,6 +14,14 @@ import { OpeningInfo } from './opening-info/OpeningInfo';
 
 import style from './ContactOption.module.scss';
 
+// preloadImages.js
+function preloadImages(imageUrls) {
+    return imageUrls.map((imageUrl) => {
+        const img = new Image();
+        img.src = imageUrl;
+        return img;
+    });
+}
 export const ChatOption = (props: ChatData) => {
     const {
         ingress,
@@ -29,6 +37,28 @@ export const ChatOption = (props: ChatData) => {
 
     const translations = translator('contactPoint', language)('chat');
 
+    const [isHovered, setIsHovered] = React.useState(false);
+
+    const [images, setImages] = useState([]);
+
+    useEffect(() => {
+        setImages(
+            preloadImages([
+                'https://www.nav.no/gfx/chat-filled.svg',
+                'https://www.nav.no/gfx/chat.svg',
+                // ... other images ...
+            ])
+        );
+    }, []);
+
+    // Find the preloaded images
+    const chatFilledImg = images.find(
+        (img) => img.src === 'https://www.nav.no/gfx/chat-filled.svg'
+    );
+    const chatImg = images.find(
+        (img) => img.src === 'https://www.nav.no/gfx/chat.svg'
+    );
+
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -42,10 +72,15 @@ export const ChatOption = (props: ChatData) => {
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
             >
-                <div className={style.linkContent}>
+                <div
+                    className={style.linkContent}
+                    onMouseEnter={() => setIsHovered(true)}
+                    onMouseLeave={() => setIsHovered(false)}
+                >
                     <img
                         alt=""
                         className={classNames(style.icon, style.chat)}
+                        src={isHovered ? chatFilledImg?.src : chatImg?.src}
                     />
                     <Heading level="3" size="small">
                         {title || translations.title}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -49,7 +49,7 @@ export const ChatOption = (props: ChatData) => {
                 {...hoverAndFocusHandlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon('chat', isActive)}
+                    {hoverFocusIcon('chat', isActive, style.chatIcon)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -11,7 +11,7 @@ import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import TextWithIndicator from '../text-with-indicator/TextWithIndicator';
 import { OpeningInfo } from './opening-info/OpeningInfo';
 import {
-    iconWithTwoStates,
+    hoverFocusIcon,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
 
@@ -49,7 +49,7 @@ export const ChatOption = (props: ChatData) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates('chat', isActive)}
+                    {hoverFocusIcon('chat', isActive)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -51,11 +51,7 @@ export const ChatOption = (props: ChatData) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates(
-                        `${appOrigin}/gfx/chat.svg`,
-                        `${appOrigin}/gfx/chat-filled.svg`,
-                        isActive
-                    )}
+                    {iconWithTwoStates(appOrigin, 'chat', isActive)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
 import { ChatData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -49,7 +49,12 @@ export const ChatOption = (props: ChatData) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon('chat', isActive, style.chatIcon)}
+                    {hoverFocusIcon(
+                        'chat.svg',
+                        'chat-filled.svg',
+                        isActive,
+                        `${style.icon} ${style.chatIcon}`
+                    )}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -38,6 +38,7 @@ export const ChatOption = (props: ChatData) => {
     const translations = translator('contactPoint', language)('chat');
 
     const [isHovered, setIsHovered] = React.useState(false);
+    const [isFocused, setIsFocused] = React.useState(false);
 
     const [images, setImages] = useState([]);
 
@@ -71,16 +72,20 @@ export const ChatOption = (props: ChatData) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
+                onMouseEnter={() => setIsHovered(true)}
+                onMouseLeave={() => setIsHovered(false)}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
             >
-                <div
-                    className={style.linkContent}
-                    onMouseEnter={() => setIsHovered(true)}
-                    onMouseLeave={() => setIsHovered(false)}
-                >
+                <div className={style.linkContent}>
                     <img
                         alt=""
                         className={classNames(style.icon, style.chat)}
-                        src={isHovered ? chatFilledImg?.src : chatImg?.src}
+                        src={
+                            isHovered || isFocused
+                                ? chatFilledImg?.src
+                                : chatImg?.src
+                        }
                     />
                     <Heading level="3" size="small">
                         {title || translations.title}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -54,8 +54,26 @@ export const ChatOption = (props: ChatData) => {
 
     const [isActive, bind] = useHoverAndFocus();
 
-    const defaultImg = 'https://www.nav.no/gfx/chat.svg';
-    const hoveredImg = 'https://www.nav.no/gfx/chat-filled.svg';
+    const iconWithTwoStates = (defaultImg: string, activeImg: string) => (
+        <>
+            <img
+                alt=""
+                className={classNames(style.icon)}
+                src={defaultImg}
+                style={{
+                    display: isActive ? 'none' : 'block',
+                }}
+            />
+            <img
+                alt=""
+                className={classNames(style.icon)}
+                src={activeImg}
+                style={{
+                    display: isActive ? 'block' : 'none',
+                }}
+            />
+        </>
+    );
 
     return (
         <div className={style.contactOption}>
@@ -72,22 +90,10 @@ export const ChatOption = (props: ChatData) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    <img
-                        alt=""
-                        className={classNames(style.icon, style.chat)}
-                        src={hoveredImg}
-                        style={{
-                            display: isActive ? 'block' : 'none',
-                        }}
-                    />
-                    <img
-                        alt=""
-                        className={classNames(style.icon, style.chat)}
-                        src={defaultImg}
-                        style={{
-                            display: isActive ? 'none' : 'block',
-                        }}
-                    />
+                    {iconWithTwoStates(
+                        'https://www.nav.no/gfx/chat.svg',
+                        'https://www.nav.no/gfx/chat-filled.svg'
+                    )}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -32,7 +32,7 @@ export const ChatOption = (props: ChatData) => {
 
     const translations = translator('contactPoint', language)('chat');
 
-    const [isActive, bind] = useHoverAndFocus();
+    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
 
     return (
         <div className={style.contactOption}>
@@ -46,7 +46,7 @@ export const ChatOption = (props: ChatData) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...bind}
+                {...hoverAndFocusHandlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('chat', isActive)}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -32,7 +32,7 @@ export const ChatOption = (props: ChatData) => {
 
     const translations = translator('contactPoint', language)('chat');
 
-    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
+    const { isActive, handlers } = useHoverAndFocus();
 
     return (
         <div className={style.contactOption}>
@@ -46,7 +46,7 @@ export const ChatOption = (props: ChatData) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...hoverAndFocusHandlers}
+                {...handlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('chat', isActive, style.chatIcon)}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -49,12 +49,12 @@ export const ChatOption = (props: ChatData) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon(
-                        'chat.svg',
-                        'chat-filled.svg',
-                        isActive,
-                        `${style.icon} ${style.chatIcon}`
-                    )}
+                    {hoverFocusIcon({
+                        iconDefault: 'chat.svg',
+                        iconActive: 'chat-filled.svg',
+                        isActive: isActive,
+                        style: `${style.icon} ${style.chatIcon}`,
+                    })}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
 import { ChatData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { classNames } from 'utils/classnames';
 import { AnalyticsEvents } from 'utils/amplitude';
 import { useLayoutConfig } from '../../layouts/useLayoutConfig';
 import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
@@ -13,54 +12,10 @@ import TextWithIndicator from '../text-with-indicator/TextWithIndicator';
 import { OpeningInfo } from './opening-info/OpeningInfo';
 
 import style from './ContactOption.module.scss';
-
-export default function useHoverAndFocus(): [
-    //TODO gjenbruk
-    boolean,
-    {
-        onMouseEnter: () => void;
-        onMouseLeave: () => void;
-        onFocus: () => void;
-        onBlur: () => void;
-    },
-] {
-    const [isHovered, setIsHovered] = useState(false);
-    const [isFocused, setIsFocused] = useState(false);
-
-    const bind = {
-        onMouseEnter: () => setIsHovered(true),
-        onMouseLeave: () => setIsHovered(false),
-        onFocus: () => setIsFocused(true),
-        onBlur: () => setIsFocused(false),
-    };
-
-    return [isHovered || isFocused, bind];
-}
-
-const iconWithTwoStates = (
-    defaultImg: string,
-    activeImg: string,
-    isActive: boolean
-) => (
-    <>
-        <img
-            alt=""
-            className={classNames(style.icon)}
-            src={defaultImg}
-            style={{
-                display: isActive ? 'none' : 'block',
-            }}
-        />
-        <img
-            alt=""
-            className={classNames(style.icon)}
-            src={activeImg}
-            style={{
-                display: isActive ? 'block' : 'none',
-            }}
-        />
-    </>
-);
+import {
+    iconWithTwoStates,
+    useHoverAndFocus,
+} from './opening-info/helpers/iconUtils';
 
 export const ChatOption = (props: ChatData) => {
     const {

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
 import { ChatData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
@@ -14,14 +14,6 @@ import { OpeningInfo } from './opening-info/OpeningInfo';
 
 import style from './ContactOption.module.scss';
 
-// preloadImages.js
-function preloadImages(imageUrls) {
-    return imageUrls.map((imageUrl) => {
-        const img = new Image();
-        img.src = imageUrl;
-        return img;
-    });
-}
 export const ChatOption = (props: ChatData) => {
     const {
         ingress,
@@ -37,28 +29,11 @@ export const ChatOption = (props: ChatData) => {
 
     const translations = translator('contactPoint', language)('chat');
 
-    const [isHovered, setIsHovered] = React.useState(false);
-    const [isFocused, setIsFocused] = React.useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
 
-    const [images, setImages] = useState([]);
-
-    useEffect(() => {
-        setImages(
-            preloadImages([
-                'https://www.nav.no/gfx/chat-filled.svg',
-                'https://www.nav.no/gfx/chat.svg',
-                // ... other images ...
-            ])
-        );
-    }, []);
-
-    // Find the preloaded images
-    const chatFilledImg = images.find(
-        (img) => img.src === 'https://www.nav.no/gfx/chat-filled.svg'
-    );
-    const chatImg = images.find(
-        (img) => img.src === 'https://www.nav.no/gfx/chat.svg'
-    );
+    const defaultImg = 'https://www.nav.no/gfx/chat.svg';
+    const hoveredImg = 'https://www.nav.no/gfx/chat-filled.svg';
 
     return (
         <div className={style.contactOption}>
@@ -81,11 +56,18 @@ export const ChatOption = (props: ChatData) => {
                     <img
                         alt=""
                         className={classNames(style.icon, style.chat)}
-                        src={
-                            isHovered || isFocused
-                                ? chatFilledImg?.src
-                                : chatImg?.src
-                        }
+                        src={hoveredImg}
+                        style={{
+                            display: isHovered || isFocused ? 'block' : 'none',
+                        }}
+                    />
+                    <img
+                        alt=""
+                        className={classNames(style.icon, style.chat)}
+                        src={defaultImg}
+                        style={{
+                            display: isHovered || isFocused ? 'none' : 'block',
+                        }}
                     />
                     <Heading level="3" size="small">
                         {title || translations.title}

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -14,6 +14,29 @@ import { OpeningInfo } from './opening-info/OpeningInfo';
 
 import style from './ContactOption.module.scss';
 
+export default function useHoverAndFocus(): [
+    //TODO gjenbruk
+    boolean,
+    {
+        onMouseEnter: () => void;
+        onMouseLeave: () => void;
+        onFocus: () => void;
+        onBlur: () => void;
+    },
+] {
+    const [isHovered, setIsHovered] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+
+    const bind = {
+        onMouseEnter: () => setIsHovered(true),
+        onMouseLeave: () => setIsHovered(false),
+        onFocus: () => setIsFocused(true),
+        onBlur: () => setIsFocused(false),
+    };
+
+    return [isHovered || isFocused, bind];
+}
+
 export const ChatOption = (props: ChatData) => {
     const {
         ingress,
@@ -29,8 +52,7 @@ export const ChatOption = (props: ChatData) => {
 
     const translations = translator('contactPoint', language)('chat');
 
-    const [isHovered, setIsHovered] = useState(false);
-    const [isFocused, setIsFocused] = useState(false);
+    const [isActive, bind] = useHoverAndFocus();
 
     const defaultImg = 'https://www.nav.no/gfx/chat.svg';
     const hoveredImg = 'https://www.nav.no/gfx/chat-filled.svg';
@@ -47,10 +69,7 @@ export const ChatOption = (props: ChatData) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
+                {...bind}
             >
                 <div className={style.linkContent}>
                     <img
@@ -58,7 +77,7 @@ export const ChatOption = (props: ChatData) => {
                         className={classNames(style.icon, style.chat)}
                         src={hoveredImg}
                         style={{
-                            display: isHovered || isFocused ? 'block' : 'none',
+                            display: isActive ? 'block' : 'none',
                         }}
                     />
                     <img
@@ -66,7 +85,7 @@ export const ChatOption = (props: ChatData) => {
                         className={classNames(style.icon, style.chat)}
                         src={defaultImg}
                         style={{
-                            display: isHovered || isFocused ? 'none' : 'block',
+                            display: isActive ? 'none' : 'block',
                         }}
                     />
                     <Heading level="3" size="small">

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -34,8 +34,6 @@ export const ChatOption = (props: ChatData) => {
 
     const [isActive, bind] = useHoverAndFocus();
 
-    const appOrigin = process.env.APP_ORIGIN;
-
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -51,7 +49,7 @@ export const ChatOption = (props: ChatData) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates(appOrigin, 'chat', isActive)}
+                    {iconWithTwoStates('chat', isActive)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -10,12 +10,12 @@ import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import TextWithIndicator from '../text-with-indicator/TextWithIndicator';
 import { OpeningInfo } from './opening-info/OpeningInfo';
-
-import style from './ContactOption.module.scss';
 import {
     iconWithTwoStates,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
+
+import style from './ContactOption.module.scss';
 
 export const ChatOption = (props: ChatData) => {
     const {
@@ -34,6 +34,8 @@ export const ChatOption = (props: ChatData) => {
 
     const [isActive, bind] = useHoverAndFocus();
 
+    const appOrigin = process.env.APP_ORIGIN;
+
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -50,8 +52,8 @@ export const ChatOption = (props: ChatData) => {
             >
                 <div className={style.linkContent}>
                     {iconWithTwoStates(
-                        'https://www.nav.no/gfx/chat.svg',
-                        'https://www.nav.no/gfx/chat-filled.svg',
+                        `${appOrigin}/gfx/chat.svg`,
+                        `${appOrigin}/gfx/chat-filled.svg`,
                         isActive
                     )}
                     <Heading level="3" size="small">

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -31,16 +31,6 @@
                 &.call {
                     content: url('https://www.nav.no/gfx/phone-filled.svg');
                 }
-                &.navoffice,
-                &.aidcentral {
-                    content: url('https://www.nav.no/gfx/place-filled.svg');
-                }
-                &.facebook {
-                    content: url('https://www.nav.no/gfx/facebook-filled.svg');
-                }
-                &.linkedin {
-                    content: url('https://www.nav.no/gfx/linkedin-filled.svg');
-                }
             }
         }
     }
@@ -76,25 +66,14 @@
         &.call {
             content: url('https://www.nav.no/gfx/phone.svg');
         }
-        &.facebook {
-            content: url('https://www.nav.no/gfx/facebook.svg');
-        }
-        &.navoffice,
-        &.aidcentral {
-            content: url('https://www.nav.no/gfx/place.svg');
-        }
-        &.linkedin {
-            content: url('https://www.nav.no/gfx/linkedin.svg');
-        }
+
         &:after {
             // preload mouseover icons
             position: absolute;
             z-index: -1;
             content: url('https://www.nav.no/gfx/chat-filled.svg')
                 url('https://www.nav.no/gfx/message-filled.svg')
-                url('https://www.nav.no/gfx/phone-filled.svg')
-                url('https://www.nav.no/gfx/facebook-filled.svg')
-                url('https://www.nav.no/gfx/linkedin-filled.svg');
+                url('https://www.nav.no/gfx/phone-filled.svg');
         }
     }
 

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -20,18 +20,6 @@
         &:hover,
         &:focus {
             text-decoration-line: none;
-
-            // .icon {
-            //     &.chat {
-            //         content: url('https://www.nav.no/gfx/chat-filled.svg');
-            //     }
-            //     &.write {
-            //         content: url('https://www.nav.no/gfx/message-filled.svg');
-            //     }
-            //     &.call {
-            //         content: url('https://www.nav.no/gfx/phone-filled.svg');
-            //     }
-            // }
         }
     }
 
@@ -55,26 +43,6 @@
         background-repeat: no-repeat;
         background-position: center left;
         margin-right: 0.5rem;
-
-        // &.chat {
-        //     margin-right: 0.7rem;
-        //     content: url('https://www.nav.no/gfx/chat.svg');
-        // }
-        // &.write {
-        //     content: url('https://www.nav.no/gfx/message.svg');
-        // }
-        // &.call {
-        //     content: url('https://www.nav.no/gfx/phone.svg');
-        // }
-
-        // &:after {
-        //     // preload mouseover icons
-        //     position: absolute;
-        //     z-index: -1;
-        //     content: url('https://www.nav.no/gfx/chat-filled.svg')
-        //         url('https://www.nav.no/gfx/message-filled.svg')
-        //         url('https://www.nav.no/gfx/phone-filled.svg');
-        // }
     }
 
     .text {

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -28,7 +28,6 @@
                 &.write {
                     content: url('https://www.nav.no/gfx/message-filled.svg');
                 }
-
                 &.call {
                     content: url('https://www.nav.no/gfx/phone-filled.svg');
                 }
@@ -75,7 +74,6 @@
             content: url('https://www.nav.no/gfx/message.svg');
         }
         &.call {
-            margin-right: 0.5rem;
             content: url('https://www.nav.no/gfx/phone.svg');
         }
         &.facebook {
@@ -92,12 +90,11 @@
             // preload mouseover icons
             position: absolute;
             z-index: -1;
-            content:
-                url('https://www.nav.no/gfx/chat-filled.svg')
+            content: url('https://www.nav.no/gfx/chat-filled.svg')
                 url('https://www.nav.no/gfx/message-filled.svg')
                 url('https://www.nav.no/gfx/phone-filled.svg')
                 url('https://www.nav.no/gfx/facebook-filled.svg')
-                url('https://www.nav.no/gfx/linkedin-filled.svg')
+                url('https://www.nav.no/gfx/linkedin-filled.svg');
         }
     }
 

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -21,17 +21,17 @@
         &:focus {
             text-decoration-line: none;
 
-            .icon {
-                &.chat {
-                    content: url('https://www.nav.no/gfx/chat-filled.svg');
-                }
-                &.write {
-                    content: url('https://www.nav.no/gfx/message-filled.svg');
-                }
-                &.call {
-                    content: url('https://www.nav.no/gfx/phone-filled.svg');
-                }
-            }
+            // .icon {
+            //     &.chat {
+            //         content: url('https://www.nav.no/gfx/chat-filled.svg');
+            //     }
+            //     &.write {
+            //         content: url('https://www.nav.no/gfx/message-filled.svg');
+            //     }
+            //     &.call {
+            //         content: url('https://www.nav.no/gfx/phone-filled.svg');
+            //     }
+            // }
         }
     }
 
@@ -56,25 +56,25 @@
         background-position: center left;
         margin-right: 0.5rem;
 
-        &.chat {
-            margin-right: 0.7rem;
-            content: url('https://www.nav.no/gfx/chat.svg');
-        }
-        &.write {
-            content: url('https://www.nav.no/gfx/message.svg');
-        }
-        &.call {
-            content: url('https://www.nav.no/gfx/phone.svg');
-        }
+        // &.chat {
+        //     margin-right: 0.7rem;
+        //     content: url('https://www.nav.no/gfx/chat.svg');
+        // }
+        // &.write {
+        //     content: url('https://www.nav.no/gfx/message.svg');
+        // }
+        // &.call {
+        //     content: url('https://www.nav.no/gfx/phone.svg');
+        // }
 
-        &:after {
-            // preload mouseover icons
-            position: absolute;
-            z-index: -1;
-            content: url('https://www.nav.no/gfx/chat-filled.svg')
-                url('https://www.nav.no/gfx/message-filled.svg')
-                url('https://www.nav.no/gfx/phone-filled.svg');
-        }
+        // &:after {
+        //     // preload mouseover icons
+        //     position: absolute;
+        //     z-index: -1;
+        //     content: url('https://www.nav.no/gfx/chat-filled.svg')
+        //         url('https://www.nav.no/gfx/message-filled.svg')
+        //         url('https://www.nav.no/gfx/phone-filled.svg');
+        // }
     }
 
     .text {

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -45,6 +45,10 @@
         margin-right: 0.5rem;
     }
 
+    .chatIcon {
+        margin-right: 0.7rem;
+    }
+
     .text {
         color: black;
         margin-bottom: 0.5rem;

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -13,12 +13,12 @@ import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import Config from 'config';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-
-import style from './ContactOption.module.scss';
 import {
     iconWithTwoStates,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
+
+import style from './ContactOption.module.scss';
 
 type Props = DefaultContactData & {
     channel: ChannelType;

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -105,15 +105,7 @@ export const DefaultOption = (props: Props) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates('message', isActive)}
-
-                    {/* <img TODO style icon
-                        alt={''}
-                        className={classNames(
-                            style.icon,
-                            style[icon || channel]
-                        )}
-                    /> */}
+                    {iconWithTwoStates(icon || 'place', isActive)}
                     {titleActual ? (
                         <Heading level={'3'} size={'small'}>
                             {titleActual}

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -96,12 +96,12 @@ export const DefaultOption = (props: Props) => {
         (channel !== 'custom' ? getTranslations(channel).ingress : null);
 
     const iconName = icon || 'place';
-    const iconElement = hoverFocusIcon(
-        `${iconName}.svg`,
-        `${iconName}-filled.svg`,
-        isActive,
-        style.icon
-    );
+    const iconElement = hoverFocusIcon({
+        iconDefault: `${iconName}.svg`,
+        iconActive: `${iconName}-filled.svg`,
+        isActive: isActive,
+        style: style.icon,
+    });
 
     return (
         <div className={style.contactOption}>

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -14,7 +14,7 @@ import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import Config from 'config';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import {
-    iconWithTwoStates,
+    hoverFocusIcon,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
 
@@ -105,7 +105,7 @@ export const DefaultOption = (props: Props) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates(icon || 'place', isActive)}
+                    {hoverFocusIcon(icon || 'place', isActive)}
                     {titleActual ? (
                         <Heading level={'3'} size={'small'}>
                             {titleActual}

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -95,6 +95,14 @@ export const DefaultOption = (props: Props) => {
         ingress ||
         (channel !== 'custom' ? getTranslations(channel).ingress : null);
 
+    const iconName = icon || 'place';
+    const iconElement = hoverFocusIcon(
+        `${iconName}.svg`,
+        `${iconName}-filled.svg`,
+        isActive,
+        style.icon
+    );
+
     return (
         <div className={style.contactOption}>
             <LenkeBase
@@ -105,7 +113,7 @@ export const DefaultOption = (props: Props) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon(icon || 'place', isActive)}
+                    {iconElement}
                     {titleActual ? (
                         <Heading level={'3'} size={'small'}>
                             {titleActual}

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -28,7 +28,7 @@ export const DefaultOption = (props: Props) => {
     const { ingress, channel, title, url, icon } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
-    const [isActive, bind] = useHoverAndFocus();
+    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
     const getTranslations = translator('contactPoint', language);
 
     // In order to open chatbot, onClick is needed instead of href. Therefore
@@ -102,7 +102,7 @@ export const DefaultOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...bind}
+                {...hoverAndFocusHandlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon(icon || 'place', isActive)}

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -28,7 +28,7 @@ export const DefaultOption = (props: Props) => {
     const { ingress, channel, title, url, icon } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
-    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
+    const { isActive, handlers } = useHoverAndFocus();
     const getTranslations = translator('contactPoint', language);
 
     // In order to open chatbot, onClick is needed instead of href. Therefore
@@ -102,7 +102,7 @@ export const DefaultOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...hoverAndFocusHandlers}
+                {...handlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon(icon || 'place', isActive)}

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -7,7 +7,6 @@ import {
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { classNames } from 'utils/classnames';
 import { AnalyticsEvents } from 'utils/amplitude';
 import { useLayoutConfig } from '../../layouts/useLayoutConfig';
 import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
@@ -16,6 +15,10 @@ import Config from 'config';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 import style from './ContactOption.module.scss';
+import {
+    iconWithTwoStates,
+    useHoverAndFocus,
+} from './opening-info/helpers/iconUtils';
 
 type Props = DefaultContactData & {
     channel: ChannelType;
@@ -25,6 +28,7 @@ export const DefaultOption = (props: Props) => {
     const { ingress, channel, title, url, icon } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
+    const [isActive, bind] = useHoverAndFocus();
     const getTranslations = translator('contactPoint', language);
 
     // In order to open chatbot, onClick is needed instead of href. Therefore
@@ -98,15 +102,18 @@ export const DefaultOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
+                {...bind}
             >
                 <div className={style.linkContent}>
-                    <img
+                    {iconWithTwoStates('message', isActive)}
+
+                    {/* <img TODO style icon
                         alt={''}
                         className={classNames(
                             style.icon,
                             style[icon || channel]
                         )}
-                    />
+                    /> */}
                     {titleActual ? (
                         <Heading level={'3'} size={'small'}>
                             {titleActual}

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -8,7 +8,7 @@ import { useLayoutConfig } from '../../layouts/useLayoutConfig';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import Config from 'config';
 import {
-    iconWithTwoStates,
+    hoverFocusIcon,
     useHoverAndFocus,
 } from './opening-info/helpers/iconUtils';
 
@@ -36,7 +36,7 @@ export const WriteOption = (props: Props) => {
                 {...bind}
             >
                 <div className={style.linkContent}>
-                    {iconWithTwoStates('message', isActive)}
+                    {hoverFocusIcon('message', isActive)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -22,7 +22,7 @@ export const WriteOption = (props: Props) => {
     const { ingress, url, alertText, title } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
-    const [isActive, bind] = useHoverAndFocus();
+    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
 
     const translations = translator('contactPoint', language)('write');
 
@@ -33,7 +33,7 @@ export const WriteOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...bind}
+                {...hoverAndFocusHandlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('message', isActive)}

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -4,10 +4,13 @@ import { WriteData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { classNames } from 'utils/classnames';
 import { useLayoutConfig } from '../../layouts/useLayoutConfig';
 import { ParsedHtml } from '../parsed-html/ParsedHtml';
 import Config from 'config';
+import {
+    iconWithTwoStates,
+    useHoverAndFocus,
+} from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 
@@ -19,6 +22,7 @@ export const WriteOption = (props: Props) => {
     const { ingress, url, alertText, title } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
+    const [isActive, bind] = useHoverAndFocus();
 
     const translations = translator('contactPoint', language)('write');
 
@@ -29,12 +33,10 @@ export const WriteOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
+                {...bind}
             >
                 <div className={style.linkContent}>
-                    <img
-                        alt=""
-                        className={classNames(style.icon, style['write'])}
-                    />
+                    {iconWithTwoStates('message', isActive)}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -36,7 +36,12 @@ export const WriteOption = (props: Props) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon('message', isActive)}
+                    {hoverFocusIcon(
+                        'message.svg',
+                        'message-filled.svg',
+                        isActive,
+                        style.icon
+                    )}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -22,7 +22,7 @@ export const WriteOption = (props: Props) => {
     const { ingress, url, alertText, title } = props;
     const { language } = usePageConfig();
     const { layoutConfig } = useLayoutConfig();
-    const [isActive, hoverAndFocusHandlers] = useHoverAndFocus();
+    const { isActive, handlers } = useHoverAndFocus();
 
     const translations = translator('contactPoint', language)('write');
 
@@ -33,7 +33,7 @@ export const WriteOption = (props: Props) => {
                 analyticsLinkGroup={layoutConfig.title}
                 analyticsComponent={'Kontakt-oss kanal'}
                 className={style.link}
-                {...hoverAndFocusHandlers}
+                {...handlers}
             >
                 <div className={style.linkContent}>
                     {hoverFocusIcon('message', isActive)}

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -36,12 +36,12 @@ export const WriteOption = (props: Props) => {
                 {...handlers}
             >
                 <div className={style.linkContent}>
-                    {hoverFocusIcon(
-                        'message.svg',
-                        'message-filled.svg',
-                        isActive,
-                        style.icon
-                    )}
+                    {hoverFocusIcon({
+                        iconDefault: 'message.svg',
+                        iconActive: 'message-filled.svg',
+                        isActive: isActive,
+                        style: style.icon,
+                    })}
                     <Heading level="3" size="small">
                         {title || translations.title}
                     </Heading>

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -3,28 +3,28 @@ import style from '../../ContactOption.module.scss';
 
 const appOrigin = process.env.APP_ORIGIN;
 
-type UseHoverAndFocus = [
-    boolean,
-    {
+type UseHoverAndFocus = {
+    isActive: boolean;
+    handlers: {
         onMouseEnter: () => void;
         onMouseLeave: () => void;
         onFocus: () => void;
         onBlur: () => void;
-    },
-];
+    };
+};
 
 export function useHoverAndFocus(): UseHoverAndFocus {
     const [isHovered, setIsHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
 
-    const hoverAndFocusHandlers = {
+    const handlers = {
         onMouseEnter: () => setIsHovered(true),
         onMouseLeave: () => setIsHovered(false),
         onFocus: () => setIsFocused(true),
         onBlur: () => setIsFocused(false),
     };
 
-    return [isHovered || isFocused, hoverAndFocusHandlers];
+    return { isActive: isHovered || isFocused, handlers };
 }
 
 export const hoverFocusIcon = (

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -26,12 +26,19 @@ export function useHoverAndFocus(): UseHoverAndFocus {
     return { isActive: isHovered || isFocused, handlers };
 }
 
-export const hoverFocusIcon = (
-    iconDefault: string,
-    iconActive: string,
-    isActive: boolean,
-    style: string = ''
-) => (
+interface HoverFocusIconProps {
+    iconDefault: string;
+    iconActive: string;
+    isActive: boolean;
+    style?: string;
+}
+
+export const hoverFocusIcon = ({
+    iconDefault,
+    iconActive,
+    isActive,
+    style = '',
+}: HoverFocusIconProps) => (
     <>
         <img
             alt=""

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -27,11 +27,15 @@ export function useHoverAndFocus(): UseHoverAndFocus {
     return [isHovered || isFocused, hoverAndFocusHandlers];
 }
 
-export const hoverFocusIcon = (iconName: string, isActive: boolean) => (
+export const hoverFocusIcon = (
+    iconName: string,
+    isActive: boolean,
+    customStyle: string = ''
+) => (
     <>
         <img
             alt=""
-            className={style.icon}
+            className={`${style.icon} ${customStyle}`}
             src={`${appOrigin}/gfx/${iconName}.svg`}
             style={{
                 display: isActive ? 'none' : 'block',
@@ -39,7 +43,7 @@ export const hoverFocusIcon = (iconName: string, isActive: boolean) => (
         />
         <img
             alt=""
-            className={style.icon}
+            className={`${style.icon} ${customStyle}`}
             src={`${appOrigin}/gfx/${iconName}-filled.svg`}
             style={{
                 display: isActive ? 'block' : 'none',

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+export function useHoverAndFocus(): [
+    boolean,
+    {
+        onMouseEnter: () => void;
+        onMouseLeave: () => void;
+        onFocus: () => void;
+        onBlur: () => void;
+    },
+] {
+    const [isHovered, setIsHovered] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+
+    const bind = {
+        onMouseEnter: () => setIsHovered(true),
+        onMouseLeave: () => setIsHovered(false),
+        onFocus: () => setIsFocused(true),
+        onBlur: () => setIsFocused(false),
+    };
+
+    return [isHovered || isFocused, bind];
+}
+
+export const iconWithTwoStates = (
+    defaultImg: string,
+    activeImg: string,
+    isActive: boolean
+) => (
+    <>
+        <img
+            alt=""
+            // className={style.icon}
+            src={defaultImg}
+            style={{
+                display: isActive ? 'none' : 'block',
+            }}
+        />
+        <img
+            alt=""
+            // className={style.icon}
+            src={activeImg}
+            style={{
+                display: isActive ? 'block' : 'none',
+            }}
+        />
+    </>
+);

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -23,11 +23,9 @@ export function useHoverAndFocus(): [
     return [isHovered || isFocused, bind];
 }
 
-export const iconWithTwoStates = (
-    appOrigin: string,
-    iconName: string,
-    isActive: boolean
-) => (
+const appOrigin = process.env.APP_ORIGIN;
+
+export const iconWithTwoStates = (iconName: string, isActive: boolean) => (
     <>
         <img
             alt=""

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -23,15 +23,15 @@ export function useHoverAndFocus(): [
 }
 
 export const iconWithTwoStates = (
-    defaultImg: string,
-    activeImg: string,
+    appOrigin: string,
+    iconName: string,
     isActive: boolean
 ) => (
     <>
         <img
             alt=""
             // className={style.icon}
-            src={defaultImg}
+            src={`${appOrigin}/gfx/${iconName}.svg`}
             style={{
                 display: isActive ? 'none' : 'block',
             }}
@@ -39,7 +39,7 @@ export const iconWithTwoStates = (
         <img
             alt=""
             // className={style.icon}
-            src={activeImg}
+            src={`${appOrigin}/gfx/${iconName}-filled.svg`}
             style={{
                 display: isActive ? 'block' : 'none',
             }}

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -28,23 +28,26 @@ export function useHoverAndFocus(): UseHoverAndFocus {
 }
 
 export const hoverFocusIcon = (
-    iconName: string,
+    iconDefault: string,
+    iconActive: string,
     isActive: boolean,
     customStyle: string = ''
 ) => (
     <>
         <img
             alt=""
-            className={`${style.icon} ${customStyle}`}
-            src={`${appOrigin}/gfx/${iconName}.svg`}
+            // className={`${style.icon} ${customStyle}`}
+            className={`${customStyle}`}
+            src={`${appOrigin}/gfx/${iconDefault}`}
             style={{
                 display: isActive ? 'none' : 'block',
             }}
         />
         <img
             alt=""
-            className={`${style.icon} ${customStyle}`}
-            src={`${appOrigin}/gfx/${iconName}-filled.svg`}
+            // className={`${style.icon} ${customStyle}`}
+            className={`${customStyle}`}
+            src={`${appOrigin}/gfx/${iconActive}`}
             style={{
                 display: isActive ? 'block' : 'none',
             }}

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import style from '../../ContactOption.module.scss';
 
 const appOrigin = process.env.APP_ORIGIN;
 
@@ -31,13 +30,12 @@ export const hoverFocusIcon = (
     iconDefault: string,
     iconActive: string,
     isActive: boolean,
-    customStyle: string = ''
+    style: string = ''
 ) => (
     <>
         <img
             alt=""
-            // className={`${style.icon} ${customStyle}`}
-            className={`${customStyle}`}
+            className={`${style}`}
             src={`${appOrigin}/gfx/${iconDefault}`}
             style={{
                 display: isActive ? 'none' : 'block',
@@ -45,8 +43,7 @@ export const hoverFocusIcon = (
         />
         <img
             alt=""
-            // className={`${style.icon} ${customStyle}`}
-            className={`${customStyle}`}
+            className={`${style}`}
             src={`${appOrigin}/gfx/${iconActive}`}
             style={{
                 display: isActive ? 'block' : 'none',

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -25,7 +25,7 @@ export function useHoverAndFocus(): [
 
 const appOrigin = process.env.APP_ORIGIN;
 
-export const iconWithTwoStates = (iconName: string, isActive: boolean) => (
+export const hoverFocusIcon = (iconName: string, isActive: boolean) => (
     <>
         <img
             alt=""

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -17,14 +17,14 @@ export function useHoverAndFocus(): UseHoverAndFocus {
     const [isHovered, setIsHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
 
-    const bind = {
+    const hoverAndFocusHandlers = {
         onMouseEnter: () => setIsHovered(true),
         onMouseLeave: () => setIsHovered(false),
         onFocus: () => setIsFocused(true),
         onBlur: () => setIsFocused(false),
     };
 
-    return [isHovered || isFocused, bind];
+    return [isHovered || isFocused, hoverAndFocusHandlers];
 }
 
 export const hoverFocusIcon = (iconName: string, isActive: boolean) => (

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import style from '../../ContactOption.module.scss';
 
-export function useHoverAndFocus(): [
+const appOrigin = process.env.APP_ORIGIN;
+
+type UseHoverAndFocus = [
     boolean,
     {
         onMouseEnter: () => void;
@@ -9,7 +11,9 @@ export function useHoverAndFocus(): [
         onFocus: () => void;
         onBlur: () => void;
     },
-] {
+];
+
+export function useHoverAndFocus(): UseHoverAndFocus {
     const [isHovered, setIsHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
 
@@ -22,8 +26,6 @@ export function useHoverAndFocus(): [
 
     return [isHovered || isFocused, bind];
 }
-
-const appOrigin = process.env.APP_ORIGIN;
 
 export const hoverFocusIcon = (iconName: string, isActive: boolean) => (
     <>

--- a/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
+++ b/src/components/_common/contact-option/opening-info/helpers/iconUtils.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import style from '../../ContactOption.module.scss';
 
 export function useHoverAndFocus(): [
     boolean,
@@ -30,7 +31,7 @@ export const iconWithTwoStates = (
     <>
         <img
             alt=""
-            // className={style.icon}
+            className={style.icon}
             src={`${appOrigin}/gfx/${iconName}.svg`}
             style={{
                 display: isActive ? 'none' : 'block',
@@ -38,7 +39,7 @@ export const iconWithTwoStates = (
         />
         <img
             alt=""
-            // className={style.icon}
+            className={style.icon}
             src={`${appOrigin}/gfx/${iconName}-filled.svg`}
             style={{
                 display: isActive ? 'block' : 'none',

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
@@ -27,38 +27,38 @@
         &:hover {
             background-color: var(--a-text-action);
 
-            .twitter {
-                content: url('https://www.nav.no/gfx/twitter-inverted.svg');
-            }
-            .facebook {
-                content: url('https://www.nav.no/gfx/facebook-inverted.svg');
-            }
-            .linkedin {
-                content: url('https://www.nav.no/gfx/linkedin-inverted.svg');
-            }
+            // .twitter {
+            //     content: url('https://www.nav.no/gfx/twitter-inverted.svg');
+            // }
+            // .facebook {
+            //     content: url('https://www.nav.no/gfx/facebook-inverted.svg');
+            // }
+            // .linkedin {
+            //     content: url('https://www.nav.no/gfx/linkedin-inverted.svg');
+            // }
         }
     }
     img {
         height: 1rem;
 
-        &.twitter {
-            content: url('https://www.nav.no/gfx/twitter-filled.svg');
-        }
-        &.facebook {
-            content: url('https://www.nav.no/gfx/facebook-filled.svg');
-        }
-        &.linkedin {
-            content: url('https://www.nav.no/gfx/linkedin-filled.svg');
-        }
+        // &.twitter {
+        //     content: url('https://www.nav.no/gfx/twitter-filled.svg');
+        // }
+        // &.facebook {
+        //     content: url('https://www.nav.no/gfx/facebook-filled.svg');
+        // }
+        // &.linkedin {
+        //     content: url('https://www.nav.no/gfx/linkedin-filled.svg');
+        // }
     }
 
-    &:after {
-        // preload mouseover icons
-        position: absolute;
-        z-index: -1;
-        content:
-            url('https://www.nav.no/gfx/twitter-inverted.svg')
-            url('https://www.nav.no/gfx/facebook-inverted.svg')
-            url('https://www.nav.no/gfx/linkedin-inverted.svg');
-    }
+    // &:after {
+    //     // preload mouseover icons
+    //     position: absolute;
+    //     z-index: -1;
+    //     content:
+    //         url('https://www.nav.no/gfx/twitter-inverted.svg')
+    //         url('https://www.nav.no/gfx/facebook-inverted.svg')
+    //         url('https://www.nav.no/gfx/linkedin-inverted.svg');
+    // }
 }

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
@@ -26,39 +26,9 @@
 
         &:hover {
             background-color: var(--a-text-action);
-
-            // .twitter {
-            //     content: url('https://www.nav.no/gfx/twitter-inverted.svg');
-            // }
-            // .facebook {
-            //     content: url('https://www.nav.no/gfx/facebook-inverted.svg');
-            // }
-            // .linkedin {
-            //     content: url('https://www.nav.no/gfx/linkedin-inverted.svg');
-            // }
         }
     }
     img {
         height: 1rem;
-
-        // &.twitter {
-        //     content: url('https://www.nav.no/gfx/twitter-filled.svg');
-        // }
-        // &.facebook {
-        //     content: url('https://www.nav.no/gfx/facebook-filled.svg');
-        // }
-        // &.linkedin {
-        //     content: url('https://www.nav.no/gfx/linkedin-filled.svg');
-        // }
     }
-
-    // &:after {
-    //     // preload mouseover icons
-    //     position: absolute;
-    //     z-index: -1;
-    //     content:
-    //         url('https://www.nav.no/gfx/twitter-inverted.svg')
-    //         url('https://www.nav.no/gfx/facebook-inverted.svg')
-    //         url('https://www.nav.no/gfx/linkedin-inverted.svg');
-    // }
 }

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.module.scss
@@ -24,6 +24,7 @@
         border-radius: 50%;
         border: 1px solid var(--a-text-action);
 
+        &:focus,
         &:hover {
             background-color: var(--a-text-action);
         }

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
@@ -56,8 +56,7 @@ const Icon = ({ type, text, href }) => {
                 {hoverFocusIcon(
                     `${type}-filled.svg`,
                     `${type}-inverted.svg`,
-                    isActive,
-                    style[type]
+                    isActive
                 )}
             </LenkeBase>
         </li>

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
@@ -5,6 +5,10 @@ import { SocialMedia } from 'types/content-props/main-article-props';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
 import style from './SosialeMedier.module.scss';
+import {
+    hoverFocusIcon,
+    useHoverAndFocus,
+} from 'components/_common/contact-option/opening-info/helpers/iconUtils';
 
 type LinkData = { type: string; text: string; href: string };
 
@@ -40,6 +44,7 @@ type Props = {
 
 export const SosialeMedier = ({ social, contentPath, displayName }: Props) => {
     const { pageConfig } = usePageConfig();
+    const { isActive, handlers } = useHoverAndFocus();
 
     if (social.length === 0) {
         return null;
@@ -72,8 +77,15 @@ export const SosialeMedier = ({ social, contentPath, displayName }: Props) => {
                             href={item.href}
                             analyticsLabel={item.text}
                             className={style.ikon}
+                            {...handlers}
                         >
-                            <img alt={item.text} className={style[item.type]} />
+                            {/* <img alt={item.text} className={style[item.type]} /> */}
+                            {hoverFocusIcon(
+                                'facebook-filled.svg',
+                                'facebook-inverted.svg',
+                                isActive,
+                                style[item.type]
+                            )}
                         </LenkeBase>
                     </li>
                 ))}

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
@@ -53,11 +53,11 @@ const Icon = ({ type, text, href }) => {
                 className={style.ikon}
                 {...handlers}
             >
-                {hoverFocusIcon(
-                    `${type}-filled.svg`,
-                    `${type}-inverted.svg`,
-                    isActive
-                )}
+                {hoverFocusIcon({
+                    iconDefault: `${type}-filled.svg`,
+                    iconActive: `${type}-inverted.svg`,
+                    isActive: isActive,
+                })}
             </LenkeBase>
         </li>
     );

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
@@ -3,12 +3,12 @@ import { getInternalAbsoluteUrl } from 'utils/urls';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { SocialMedia } from 'types/content-props/main-article-props';
 import { usePageConfig } from 'store/hooks/usePageConfig';
-
-import style from './SosialeMedier.module.scss';
 import {
     hoverFocusIcon,
     useHoverAndFocus,
 } from 'components/_common/contact-option/opening-info/helpers/iconUtils';
+
+import style from './SosialeMedier.module.scss';
 
 type LinkData = { type: string; text: string; href: string };
 
@@ -42,9 +42,30 @@ type Props = {
     contentPath: string;
 };
 
+const Icon = ({ type, text, href }) => {
+    const { isActive, handlers } = useHoverAndFocus();
+
+    return (
+        <li>
+            <LenkeBase
+                href={href}
+                analyticsLabel={text}
+                className={style.ikon}
+                {...handlers}
+            >
+                {hoverFocusIcon(
+                    `${type}-filled.svg`,
+                    `${type}-inverted.svg`,
+                    isActive,
+                    style[type]
+                )}
+            </LenkeBase>
+        </li>
+    );
+};
+
 export const SosialeMedier = ({ social, contentPath, displayName }: Props) => {
     const { pageConfig } = usePageConfig();
-    const { isActive, handlers } = useHoverAndFocus();
 
     if (social.length === 0) {
         return null;
@@ -72,22 +93,7 @@ export const SosialeMedier = ({ social, contentPath, displayName }: Props) => {
         <section className={style.socialMedia}>
             <ul>
                 {linksData.map((item) => (
-                    <li key={item.type}>
-                        <LenkeBase
-                            href={item.href}
-                            analyticsLabel={item.text}
-                            className={style.ikon}
-                            {...handlers}
-                        >
-                            {/* <img alt={item.text} className={style[item.type]} /> */}
-                            {hoverFocusIcon(
-                                'facebook-filled.svg',
-                                'facebook-inverted.svg',
-                                isActive,
-                                style[item.type]
-                            )}
-                        </LenkeBase>
-                    </li>
+                    <Icon key={item.type} {...item} />
                 ))}
             </ul>
         </section>


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Setter riktig URL på ikoner som brukte hardkodede prod-URLer
-   Setter URLer i JS istedenfor CSS
-   (filled-ikoner preloades fortsatt)

## Testing

Testet selv lokalt og i dev 2
- [Side med kontakt-komponent](https://www.nav.no/jobbe-i-utlandet)
- [Legacy-artikkel med ikoner](https://www.nav.no/no/lokalt/more-og-romsdal/nav-arbeidslivssenter-more-og-romsdal/nyttig-a-vite-i-more-og-romsdal/kontaktinformasjon)

## Dette trenger jeg å få et ekstra blikk på

Det er også noen hardkodede nav.no-urler i stylingen i `_legacy/main-article/`. Skal vi bruke tid på å fikse det der også? (Ja)
