### PR TITLE
Håndterer ekspandering ved internt søk på Trekkspill

### DIFF
--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -7,6 +7,8 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
 import styles from './Accordion.module.scss';
+import { Shortcuts, UseShortcuts } from 'utils/useShortcuts';
+import { useState } from 'react';
 
 type AccordionProps = AccordionPartProps['config'];
 type PanelItem = AccordionProps['accordion'][0];
@@ -14,8 +16,24 @@ type PanelItem = AccordionProps['accordion'][0];
 export const Accordion = ({ accordion }: AccordionProps) => {
     const { pageConfig } = usePageConfig();
     const { editorView } = pageConfig;
+    const [openAccordions, setOpenAccordions] = useState<number[]>([]);
 
-    const openChangeHandler = (isOpen: boolean, title: string) => {
+    const expandAll = () => {
+        setOpenAccordions(accordion.map((_, index) => index));
+    };
+
+    UseShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
+
+    const openChangeHandler = (
+        isOpen: boolean,
+        title: string,
+        index: number
+    ) => {
+        if (isOpen) {
+            setOpenAccordions([...openAccordions, index]);
+        } else {
+            setOpenAccordions(openAccordions.filter((i) => i !== index));
+        }
         logAmplitudeEvent(
             isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
             {
@@ -40,8 +58,9 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                     <DSAccordion.Item
                         key={index}
                         className={styles.item}
+                        open={openAccordions.includes(index)}
                         onOpenChange={(open) =>
-                            openChangeHandler(open, item.title)
+                            openChangeHandler(open, item.title, index)
                         }
                     >
                         <DSAccordion.Header className={styles.header}>

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -7,7 +7,7 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 
 import styles from './Accordion.module.scss';
-import { Shortcuts, UseShortcuts } from 'utils/useShortcuts';
+import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { useState } from 'react';
 
 type AccordionProps = AccordionPartProps['config'];
@@ -22,7 +22,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
         setOpenAccordions(accordion.map((_, index) => index));
     };
 
-    UseShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
+    useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
 
     const openChangeHandler = (
         isOpen: boolean,

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -3,9 +3,9 @@ import { Accordion } from '@navikt/ds-react';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
+import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 
 import style from './Expandable.module.scss';
-import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 
 type Props = {
     title: string;

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -5,6 +5,7 @@ import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 
 import style from './Expandable.module.scss';
+import { Shortcuts, UseShortcuts } from 'utils/useShortcuts';
 
 type Props = {
     title: string;
@@ -23,6 +24,13 @@ export const Expandable = ({
 }: Props) => {
     const [isOpen, setIsOpen] = useState(false);
     const accordionRef = useRef<HTMLDivElement | null>(null);
+
+    UseShortcuts({
+        shortcut: Shortcuts.SEARCH,
+        callback: () => {
+            setIsOpen(true);
+        },
+    });
 
     const toggleExpandCollapse = () => {
         logAmplitudeEvent(
@@ -62,17 +70,9 @@ export const Expandable = ({
     };
 
     useEffect(() => {
-        const openOnBrowserSearch = (e: KeyboardEvent) => {
-            if (e.ctrlKey && e.code === 'KeyF') {
-                setIsOpen(true);
-            }
-        };
-
-        window.addEventListener('keydown', openOnBrowserSearch);
         window.addEventListener('hashchange', hashChangeHandler);
 
         return () => {
-            window.removeEventListener('keydown', openOnBrowserSearch);
             window.removeEventListener('hashchange', hashChangeHandler);
         };
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -5,7 +5,7 @@ import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 
 import style from './Expandable.module.scss';
-import { Shortcuts, UseShortcuts } from 'utils/useShortcuts';
+import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 
 type Props = {
     title: string;
@@ -25,7 +25,7 @@ export const Expandable = ({
     const [isOpen, setIsOpen] = useState(false);
     const accordionRef = useRef<HTMLDivElement | null>(null);
 
-    UseShortcuts({
+    useShortcuts({
         shortcut: Shortcuts.SEARCH,
         callback: () => {
             setIsOpen(true);

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ReadMorePartProps } from 'types/component-props/parts/read-more';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ReadMore } from '@navikt/ds-react';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { useShortcuts, Shortcuts } from 'utils/useShortcuts';
 
 export const ReadMorePart = ({ config }: ReadMorePartProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    useShortcuts({
+        shortcut: Shortcuts.SEARCH,
+        callback: () => setIsOpen(true),
+    });
+
     if (!config?.html || !config?.title) {
         return (
             <EditorHelp
@@ -16,6 +23,7 @@ export const ReadMorePart = ({ config }: ReadMorePartProps) => {
     }
 
     const openChangeHandler = (isOpen: boolean, _title: string) => {
+        setIsOpen(isOpen);
         logAmplitudeEvent(
             isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
             {
@@ -30,6 +38,7 @@ export const ReadMorePart = ({ config }: ReadMorePartProps) => {
     return (
         <ReadMore
             header={title}
+            open={isOpen}
             onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
         >
             <ParsedHtml htmlProps={html} />

--- a/src/utils/useShortcuts.ts
+++ b/src/utils/useShortcuts.ts
@@ -14,7 +14,7 @@ export const useShortcuts = ({ shortcut, callback }: UseShortcutsProps) => {
         if (
             shortcut === Shortcuts.SEARCH &&
             (e.ctrlKey || e.metaKey) &&
-            e.key === 'f'
+            e.key.toLowerCase() === 'f'
         ) {
             callback();
         }

--- a/src/utils/useShortcuts.ts
+++ b/src/utils/useShortcuts.ts
@@ -9,7 +9,7 @@ type UseShortcutsProps = {
     callback: () => void;
 };
 
-export const UseShortcuts = ({ shortcut, callback }: UseShortcutsProps) => {
+export const useShortcuts = ({ shortcut, callback }: UseShortcutsProps) => {
     const handleKeyDown = (e: KeyboardEvent) => {
         if (
             shortcut === Shortcuts.SEARCH &&
@@ -25,5 +25,5 @@ export const UseShortcuts = ({ shortcut, callback }: UseShortcutsProps) => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, []); 
+    }, []);
 };

--- a/src/utils/useShortcuts.ts
+++ b/src/utils/useShortcuts.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+export enum Shortcuts {
+    SEARCH = 'SEARCH',
+}
+
+type UseShortcutsProps = {
+    shortcut: Shortcuts;
+    callback: () => void;
+};
+
+export const UseShortcuts = ({ shortcut, callback }: UseShortcutsProps) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (
+            shortcut === Shortcuts.SEARCH &&
+            (e.ctrlKey || e.metaKey) &&
+            e.key === 'f'
+        ) {
+            callback();
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []); 
+};


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Samler håndtering av tastatursnarveier til én hook som kan utvides til å håndtere andre typer.
- Støtter nå internt søk i Safari som er MetaKey+f (Apple key)
- Endrer Trekkspill og Readmore til å være controlled siden vi trenger å kunne ekspandere panelene selv.

## Testing
Testes i dev
