### PR TITLE
Tweaker ressurs-allokeringer og skalerings-parametre

### DIFF
--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -15,7 +15,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: nav-enonicxp-frontend
-  minReplicas: 3
+  minReplicas: 2
   maxReplicas: 40
   metrics:
     - type: Resource
@@ -23,11 +23,11 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 75
     - type: Pods
       pods:
         metric:
           name: http_request_duration_seconds_count
         target:
           type: AverageValue
-          averageValue: '250'
+          averageValue: '400'

--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -30,4 +30,4 @@ spec:
           name: http_request_duration_seconds_count
         target:
           type: AverageValue
-          averageValue: '400'
+          averageValue: '250'

--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -9,10 +9,10 @@ ingresses:
   - https://www.nav.no
 resources:
   requests:
-    cpu: 1500m
-    memory: 2500Mi
+    cpu: 1000m
+    memory: 2048Mi
   limits:
-    memory: 2500Mi
+    memory: 4096Mi
 replicas:
   min: 3
   max: 3

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -10,7 +10,7 @@ const TTL_RESOLUTION_MS = 60 * 1000;
 export const redisCache = new RedisCache();
 
 const localCache = new LRUCache<string, CacheHandlerValue>({
-    max: 3000,
+    max: 4000,
     ttl: CACHE_TTL_72_HOURS_IN_MS,
     ttlResolution: TTL_RESOLUTION_MS,
 });


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Setter min-replicas til 2 (ned fra 3)
- Skalerer opp på 75% CPU (opp fra 60%)
- Senker memory og CPU allokering
- Øker localCache max