### PR TITLE
Tweaker rolling updates ved deploy

### DIFF
--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -39,6 +39,9 @@ spec:
   env:
     - name: NPM_CONFIG_CACHE
       value: /tmp/npm-cache
+  strategy:
+    rollingUpdate:
+      maxSurge: 3
   replicas:
   {{#with replicas}}
     min: {{min}}

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -31,7 +31,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 75
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -22,6 +22,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
         - type: Pods
+          value: 2
           periodSeconds: 60
       selectPolicy: Max
   metrics:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -17,6 +17,13 @@ spec:
     name: nav-enonicxp-frontend-dev1
   minReplicas: 2
   maxReplicas: 4
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          periodSeconds: 60
+      selectPolicy: Max
   metrics:
     - type: Resource
       resource:

--- a/.nais/hpa/hpa-dev2.yml
+++ b/.nais/hpa/hpa-dev2.yml
@@ -23,11 +23,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
-    - type: Pods
-      pods:
-        metric:
-          name: http_request_duration_seconds_count
-        target:
-          type: AverageValue
-          averageValue: '250'
+          averageUtilization: 75

--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -17,6 +17,14 @@ spec:
     name: nav-enonicxp-frontend
   minReplicas: 2
   maxReplicas: 40
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+      selectPolicy: Max
   metrics:
     - type: Resource
       resource:

--- a/.nais/vars/vars-dev1.yml
+++ b/.nais/vars/vars-dev1.yml
@@ -14,7 +14,7 @@ resources:
     cpu: 500m
     memory: 1000Mi
   limits:
-    memory: 1000Mi
+    memory: 2000Mi
 replicas:
   min: 2
   max: 2

--- a/.nais/vars/vars-dev2.yml
+++ b/.nais/vars/vars-dev2.yml
@@ -14,7 +14,7 @@ resources:
     cpu: 250m
     memory: 500Mi
   limits:
-    memory: 500Mi
+    memory: 1000Mi
 replicas:
   min: 1
   max: 2

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -2,17 +2,12 @@ import FileSystemCache from 'next/dist/server/lib/incremental-cache/file-system-
 import { LRUCache } from 'lru-cache';
 import { CacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
 import { RedisCache } from 'srcCommon/redis';
-import { CACHE_TTL_72_HOURS_IN_MS } from 'srcCommon/constants';
 import { pathToCacheKey } from 'srcCommon/cache-key';
-
-const TTL_RESOLUTION_MS = 60 * 1000;
 
 export const redisCache = new RedisCache();
 
 const localCache = new LRUCache<string, CacheHandlerValue>({
-    max: 4000,
-    ttl: CACHE_TTL_72_HOURS_IN_MS,
-    ttlResolution: TTL_RESOLUTION_MS,
+    max: 5000,
 });
 
 export default class PageCacheHandler {
@@ -29,17 +24,7 @@ export default class PageCacheHandler {
             return null;
         }
 
-        const ttlRemaining = fromRedisCache.lastModified
-            ? fromRedisCache.lastModified +
-              CACHE_TTL_72_HOURS_IN_MS -
-              Date.now()
-            : CACHE_TTL_72_HOURS_IN_MS;
-
-        if (ttlRemaining > TTL_RESOLUTION_MS) {
-            localCache.set(key, fromRedisCache, {
-                ttl: ttlRemaining,
-            });
-        }
+        localCache.set(key, fromRedisCache);
 
         return fromRedisCache;
     }


### PR DESCRIPTION
Prøver å tweaker litt for at flere podder startes samtidig ved deploy, slik at den første ikke skal få all trøkk det første ~minuttet.

Fjerner også ttl for den lokale cachen. Next.js håndterer dette uansett ut fra revalidate-parameteret på page route'ene våre.