### PR TITLE
Flere HPA tweaks

### DIFF
--- a/.nais/config-failover.yml
+++ b/.nais/config-failover.yml
@@ -35,10 +35,7 @@ spec:
     - name: NPM_CONFIG_CACHE
       value: /tmp/npm-cache
   replicas:
-  {{#with replicas}}
-    min: {{min}}
-    max: {{max}}
-  {{/with}}
+    disableAutoScaling: true
   accessPolicy:
     outbound:
       rules:

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -43,10 +43,7 @@ spec:
     rollingUpdate:
       maxSurge: 3
   replicas:
-  {{#with replicas}}
-    min: {{min}}
-    max: {{max}}
-  {{/with}}
+    disableAutoScaling: true
   accessPolicy:
     outbound:
       rules:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -5,11 +5,6 @@ metadata:
   namespace: personbruker
   labels:
     team: personbruker
-  ownerReferences:
-    - apiVersion: nais.io/v1alpha1
-      kind: Application
-      name: nav-enonicxp-frontend-dev1
-      uid: bd92454a-03ea-4c28-9f1d-332ee70b77e6
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -26,7 +26,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 60
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -31,7 +31,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 1
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -26,7 +26,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 1
+          averageUtilization: 10
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-dev1.yml
+++ b/.nais/hpa/hpa-dev1.yml
@@ -26,7 +26,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 10
+          averageUtilization: 75
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-dev2.yml
+++ b/.nais/hpa/hpa-dev2.yml
@@ -18,4 +18,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 60

--- a/.nais/hpa/hpa-dev2.yml
+++ b/.nais/hpa/hpa-dev2.yml
@@ -5,11 +5,6 @@ metadata:
   namespace: personbruker
   labels:
     team: personbruker
-  ownerReferences:
-    - apiVersion: nais.io/v1alpha1
-      kind: Application
-      name: nav-enonicxp-frontend-dev2
-      uid: d5a2e4bc-116c-4bca-adde-c16639e476b6
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/.nais/hpa/hpa-prod-failover.yml
+++ b/.nais/hpa/hpa-prod-failover.yml
@@ -18,7 +18,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 60
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-prod-failover.yml
+++ b/.nais/hpa/hpa-prod-failover.yml
@@ -5,11 +5,6 @@ metadata:
   namespace: personbruker
   labels:
     team: personbruker
-  ownerReferences:
-    - apiVersion: nais.io/v1alpha1
-      kind: Application
-      name: nav-enonicxp-frontend-failover
-      uid: ac65a21c-d6c1-4370-822e-7bb14d887b51
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -23,7 +18,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 60
+          averageUtilization: 75
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -26,7 +26,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 60
     - type: Pods
       pods:
         metric:

--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -5,11 +5,6 @@ metadata:
   namespace: personbruker
   labels:
     team: personbruker
-  ownerReferences:
-    - apiVersion: nais.io/v1alpha1
-      kind: Application
-      name: nav-enonicxp-frontend
-      uid: 475b12cf-c445-4490-ada3-fdcf73ffc510
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/.nais/vars/vars-dev1-failover.yml
+++ b/.nais/vars/vars-dev1-failover.yml
@@ -15,6 +15,3 @@ resources:
     memory: 250Mi
   limits:
     memory: 250Mi
-replicas:
-  min: 1
-  max: 2

--- a/.nais/vars/vars-dev1.yml
+++ b/.nais/vars/vars-dev1.yml
@@ -15,9 +15,6 @@ resources:
     memory: 1000Mi
   limits:
     memory: 2000Mi
-replicas:
-  min: 2
-  max: 2
 redis:
   plan: hobbyist
   project: nav-dev

--- a/.nais/vars/vars-dev2-failover.yml
+++ b/.nais/vars/vars-dev2-failover.yml
@@ -15,6 +15,3 @@ resources:
     memory: 250Mi
   limits:
     memory: 250Mi
-replicas:
-  min: 1
-  max: 2

--- a/.nais/vars/vars-dev2.yml
+++ b/.nais/vars/vars-dev2.yml
@@ -15,9 +15,6 @@ resources:
     memory: 500Mi
   limits:
     memory: 1000Mi
-replicas:
-  min: 1
-  max: 2
 redis:
   plan: hobbyist
   project: nav-dev

--- a/.nais/vars/vars-prod-failover.yml
+++ b/.nais/vars/vars-prod-failover.yml
@@ -13,6 +13,3 @@ resources:
     memory: 750Mi
   limits:
     memory: 750Mi
-replicas:
-  min: 2
-  max: 2

--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -13,9 +13,6 @@ resources:
     memory: 2048Mi
   limits:
     memory: 4096Mi
-replicas:
-  min: 3
-  max: 3
 redis:
   plan: startup-4
   project: nav-prod


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Setter disableAutoScaling:true istedenfor å sette min=max replicas (skal gjøre samme nytten, men tydeligere)
- Fjerner ownerReferences fra HPA config (skal ikke lengre være nødvendig, naiserator håndterer dette nå)
- Setter CPU target tilbake til 60%