### PR TITLE
Cache og nais tweaks

### DIFF
--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -9,7 +9,7 @@ ingresses:
   - https://www.nav.no
 resources:
   requests:
-    cpu: 1000m
+    cpu: 750m
     memory: 2048Mi
   limits:
     memory: 4096Mi

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -3,6 +3,7 @@ import { LRUCache } from 'lru-cache';
 import { CacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
 import { RedisCache } from 'srcCommon/redis';
 import { pathToCacheKey } from 'srcCommon/cache-key';
+import { logger } from 'srcCommon/logger';
 
 export const redisCache = new RedisCache();
 
@@ -42,10 +43,13 @@ export default class PageCacheHandler {
     }
 
     public async clear() {
+        logger.info('Clearing local cache!');
         localCache.clear();
     }
 
     public async delete(path: string) {
-        localCache.delete(pathToCacheKey(path));
+        const key = pathToCacheKey(path);
+        logger.info(`Deleting local cache entry for ${key}`);
+        localCache.delete(key);
     }
 }

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -7,7 +7,7 @@ import { pathToCacheKey } from 'srcCommon/cache-key';
 export const redisCache = new RedisCache();
 
 const localCache = new LRUCache<string, CacheHandlerValue>({
-    max: 5000,
+    max: 2000,
 });
 
 export default class PageCacheHandler {

--- a/srcCommon/constants.ts
+++ b/srcCommon/constants.ts
@@ -1,1 +1,2 @@
-export const CACHE_TTL_72_HOURS_IN_MS = 3600 * 72 * 1000;
+export const TIME_24_HOURS_IN_MS = 3600 * 24 * 1000;
+export const TIME_72_HOURS_IN_MS = 3600 * 72 * 1000;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Senker CPU allokering for hver pod til 0.75
- Senker lokal cache max size til 2000
- Senker TTL for render redis cache, men refresher denne ved hver GET slik at den ikke vil expire'e for keys som er aktivt i bruk. Next.js re-rendrer uansett når revalidate-perioden vi har satt er utgått.