### PR TITLE
Oppgraderer til nav-dekoratoren-moduler 2.1.6

### DIFF
--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -9,7 +9,7 @@ ingresses:
   - https://www.nav.no
 resources:
   requests:
-    cpu: 750m
+    cpu: 1000m
     memory: 2048Mi
   limits:
     memory: 4096Mi

--- a/nodeenv.d.ts
+++ b/nodeenv.d.ts
@@ -22,6 +22,7 @@ declare global {
             REDIS_URI_PAGECACHE: string;
             REDIS_USERNAME_PAGECACHE: string;
             REDIS_PASSWORD_PAGECACHE: string;
+            DECORATOR_NOCACHE?: 'true' | 'false';
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@navikt/ds-css": "5.17.5",
                 "@navikt/ds-react": "5.17.5",
                 "@navikt/ds-tokens": "5.17.5",
-                "@navikt/nav-dekoratoren-moduler": "2.1.5",
+                "@navikt/nav-dekoratoren-moduler": "2.1.6",
                 "@reduxjs/toolkit": "1.9.7",
                 "csp-header": "5.2.1",
                 "dayjs": "1.11.10",
@@ -2556,9 +2556,9 @@
             "license": "MIT"
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
-            "version": "2.1.5",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/2.1.5/ac9f8598a7535bed617e5df31f435819092acc9b",
-            "integrity": "sha512-6l5yy9c9f+SS/d8dTQ3CgxxEGCMFZx7EF+0SjecCOCyijWVQYci9hroEGTGxa23no3ZIUY9ePZHz36o4EXgWbQ==",
+            "version": "2.1.6",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/2.1.6/049e1daeecff43519e41e387f21fd7e3634c2bd3",
+            "integrity": "sha512-P9c+a8/HuIY6XScNr/DVS7lZ0UtndzYAMEaIVdAzCOrG4SudY4tXSp+44g1V58GKml1RjdzOfGVF4hxmFv3SiA==",
             "license": "MIT",
             "dependencies": {
                 "csp-header": "^5.1.0",
@@ -17469,9 +17469,9 @@
             "integrity": "sha512-K9d65U/5ttInA6NLtgUxoiUe2AQKjJ1wDm0DH377JcJiRYIrXBDOZGQ91cJtCZsE/+VyjAZqAg2EHeVUiDoEsg=="
         },
         "@navikt/nav-dekoratoren-moduler": {
-            "version": "2.1.5",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/2.1.5/ac9f8598a7535bed617e5df31f435819092acc9b",
-            "integrity": "sha512-6l5yy9c9f+SS/d8dTQ3CgxxEGCMFZx7EF+0SjecCOCyijWVQYci9hroEGTGxa23no3ZIUY9ePZHz36o4EXgWbQ==",
+            "version": "2.1.6",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/2.1.6/049e1daeecff43519e41e387f21fd7e3634c2bd3",
+            "integrity": "sha512-P9c+a8/HuIY6XScNr/DVS7lZ0UtndzYAMEaIVdAzCOrG4SudY4tXSp+44g1V58GKml1RjdzOfGVF4hxmFv3SiA==",
             "requires": {
                 "csp-header": "^5.1.0",
                 "html-react-parser": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@navikt/ds-css": "5.17.5",
         "@navikt/ds-react": "5.17.5",
         "@navikt/ds-tokens": "5.17.5",
-        "@navikt/nav-dekoratoren-moduler": "2.1.5",
+        "@navikt/nav-dekoratoren-moduler": "2.1.6",
         "@reduxjs/toolkit": "1.9.7",
         "csp-header": "5.2.1",
         "dayjs": "1.11.10",

--- a/src/utils/decorator/decorator-utils-serverside.ts
+++ b/src/utils/decorator/decorator-utils-serverside.ts
@@ -19,17 +19,11 @@ const envMap: Record<AppEnv, DecoratorEnv> = {
 
 const decoratorEnv = envMap[process.env.ENV] || 'prod';
 
-const envProps: DecoratorFetchProps =
-    decoratorEnv === 'localhost'
-        ? ({
-              env: decoratorEnv,
-              localUrl: DECORATOR_URL,
-              noCache: process.env.DECORATOR_NOCACHE === 'true',
-          } as const)
-        : ({
-              env: decoratorEnv,
-              noCache: process.env.DECORATOR_NOCACHE === 'true',
-          } as const);
+const envProps: DecoratorFetchProps = {
+    env: decoratorEnv,
+    noCache: process.env.DECORATOR_NOCACHE === 'true',
+    ...(decoratorEnv === 'localhost' && { localUrl: DECORATOR_URL }),
+} as const;
 
 export const getDecoratorComponents = async (params?: DecoratorParams) => {
     const decoratorComponents = fetchDecoratorReact({

--- a/src/utils/decorator/decorator-utils-serverside.ts
+++ b/src/utils/decorator/decorator-utils-serverside.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     DecoratorEnvProps,
     fetchDecoratorReact,
@@ -30,7 +29,11 @@ const envProps =
           } as const);
 
 export const getDecoratorComponents = async (params?: DecoratorParams) => {
-    const decoratorComponents = fetchDecoratorReact({ ...envProps, params });
+    const decoratorComponents = fetchDecoratorReact({
+        ...envProps,
+        params,
+        noCache: process.env.DECORATOR_NOCACHE === 'true',
+    });
 
     return decoratorComponents;
 };

--- a/src/utils/decorator/decorator-utils-serverside.ts
+++ b/src/utils/decorator/decorator-utils-serverside.ts
@@ -1,5 +1,6 @@
 import {
     DecoratorEnvProps,
+    DecoratorFetchProps,
     fetchDecoratorReact,
 } from '@navikt/nav-dekoratoren-moduler/ssr';
 import { DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
@@ -18,21 +19,22 @@ const envMap: Record<AppEnv, DecoratorEnv> = {
 
 const decoratorEnv = envMap[process.env.ENV] || 'prod';
 
-const envProps =
+const envProps: DecoratorFetchProps =
     decoratorEnv === 'localhost'
         ? ({
               env: decoratorEnv,
               localUrl: DECORATOR_URL,
+              noCache: process.env.DECORATOR_NOCACHE === 'true',
           } as const)
         : ({
               env: decoratorEnv,
+              noCache: process.env.DECORATOR_NOCACHE === 'true',
           } as const);
 
 export const getDecoratorComponents = async (params?: DecoratorParams) => {
     const decoratorComponents = fetchDecoratorReact({
         ...envProps,
         params,
-        noCache: process.env.DECORATOR_NOCACHE === 'true',
     });
 
     return decoratorComponents;


### PR DESCRIPTION
Oppgraderer til nav-dekoratoren-moduler 2.1.6. Eneste endring her er mulighet for å sette et parameter for å forbigå den innebygde cachingen, slik at det er enklere å teste endringer i dekoratøren fortløpende.

Skrur også opp CPU-allokering i prod tilbake til 1 CPU. Usikker på hvorfor, men ser høyere responsetider litt andre rare ting i metrikkene etter at den ble skrudd ned til 0.75. 🤔 