### PR TITLE
Legger til lenke ut fra aktuelt-seksjon på forside

### DIFF
--- a/src/components/_common/moreLink/MoreLink.module.scss
+++ b/src/components/_common/moreLink/MoreLink.module.scss
@@ -1,0 +1,19 @@
+.moreLink {
+    margin-top: 1rem;
+    margin-left: 1.5rem;
+    display: inline-block;
+
+    & > * {
+        font-weight: bold;
+    }
+
+    :global(.chevron) {
+        display: none;
+    }
+}
+
+.arrow {
+    transform: translateY(3px);
+    margin-left: -1.5rem;
+    margin-right: 0.625rem;
+}

--- a/src/components/_common/moreLink/MoreLink.tsx
+++ b/src/components/_common/moreLink/MoreLink.tsx
@@ -1,0 +1,25 @@
+import { LinkSelectable } from 'types/component-props/_mixins';
+import { getSelectableLinkProps } from 'utils/links-from-content';
+import { LenkeStandalone } from '../lenke/LenkeStandalone';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
+
+import styles from './MoreLink.module.scss';
+
+export const MoreLink = ({ link }: { link?: LinkSelectable }) => {
+    if (!link) {
+        return null;
+    }
+
+    const { text, url } = getSelectableLinkProps(link);
+
+    return (
+        <LenkeStandalone
+            href={url}
+            className={styles.moreLink}
+            withChevron={false}
+        >
+            <ArrowRightIcon aria-hidden={true} className={styles.arrow} />
+            {text}
+        </LenkeStandalone>
+    );
+};

--- a/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.module.scss
+++ b/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.module.scss
@@ -29,23 +29,3 @@
         display: none;
     }
 }
-
-.myPage {
-    margin-top: 1rem;
-    margin-left: 1.5rem;
-    display: inline-block;
-
-    & > * {
-        font-weight: bold;
-    }
-
-    :global(.chevron) {
-        display: none;
-    }
-}
-
-.arrow {
-    transform: translateY(3px);
-    margin-left: -1.5rem;
-    margin-right: 0.625rem;
-}

--- a/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
+++ b/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
@@ -5,36 +5,14 @@ import { LayoutContainer } from '../LayoutContainer';
 import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 import { Header } from '../../_common/headers/Header';
 import Region from '../Region';
-import { LenkeStandalone } from '../../_common/lenke/LenkeStandalone';
-import { getSelectableLinkProps } from '../../../utils/links-from-content';
-import { LinkSelectable } from '../../../types/component-props/_mixins';
 import { AuthDependantRender } from '../../_common/auth-dependant-render/AuthDependantRender';
 import { useAuthState } from '../../../store/hooks/useAuthState';
 import { capitalize } from '../../../utils/string';
 import { translator } from '../../../translations';
 import { usePageConfig } from '../../../store/hooks/usePageConfig';
-import { ArrowRightIcon } from '@navikt/aksel-icons';
 
 import style from './FrontpageLoggedinSectionLayout.module.scss';
-
-const MyPageLink = ({ link }: { link?: LinkSelectable }) => {
-    if (!link) {
-        return null;
-    }
-
-    const { text, url } = getSelectableLinkProps(link);
-
-    return (
-        <LenkeStandalone
-            href={url}
-            className={style.myPage}
-            withChevron={false}
-        >
-            <ArrowRightIcon aria-hidden={true} className={style.arrow} />
-            {text}
-        </LenkeStandalone>
-    );
-};
+import { MoreLink } from 'components/_common/moreLink/MoreLink';
 
 const HeaderWithName = ({ headerText }: { headerText: string }) => {
     const { language } = usePageConfig();
@@ -100,7 +78,7 @@ export const FrontpageLoggedinSectionLayout = ({
                     regionProps={regions.cards}
                     className={style.cards}
                 />
-                <MyPageLink link={mypage?.link} />
+                <MoreLink link={mypage?.link} />
             </LayoutContainer>
         </AuthDependantRender>
     );

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
@@ -6,6 +6,7 @@ import { LinkPanelNavno } from '../../_common/linkpanel/LinkPanelNavno';
 import { formatDate } from 'utils/datetime';
 import { usePageConfig } from 'store/hooks/usePageConfig';
 import { getUrlFromContent } from 'utils/links-from-content';
+import { MoreLink } from 'components/_common/moreLink/MoreLink';
 
 import style from './FrontpageCurrentTopics.module.scss';
 
@@ -13,7 +14,7 @@ export const FrontpageCurrentTopics = ({
     config,
 }: FrontpageCurrentTopicsProps) => {
     const { language } = usePageConfig();
-    const { contentList, title } = config;
+    const { contentList, title, link } = config;
 
     if (!contentList?.data.sectionContents) {
         return <EditorHelp text={'Velg en innholdsliste'} />;
@@ -59,6 +60,7 @@ export const FrontpageCurrentTopics = ({
                     );
                 })}
             </ul>
+            {link && <MoreLink link={link} />}
         </div>
     );
 };

--- a/src/types/component-props/parts/frontpage-current-topics.ts
+++ b/src/types/component-props/parts/frontpage-current-topics.ts
@@ -1,11 +1,14 @@
 import { PartType } from '../parts';
 import { PartComponentProps } from '../_component-common';
 import { ContentListData } from 'types/content-props/content-list-props';
+import { ContentProps } from 'types/content-props/_content-common';
+import { LinkSelectable } from '../_mixins';
 
 export interface FrontpageCurrentTopicsProps extends PartComponentProps {
     descriptor: PartType.FrontpageCurrentTopics;
     config: {
         title: string;
         contentList?: { data: ContentListData };
+        link: LinkSelectable;
     };
 }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Legger til funksjon for å kunne lenke ut til en annen side (intern eller ekstern) for aktuelt-seksjonen.
- Flytter Mypage-lenke til felles komponent og navner om siden disse nå er delt med `FrontpageLoggedInSectionLayout` og `FrontpageCurrentTopics`. 

## Testing
Testes i dev
