### PR TITLE
Lukker menyer i decorator-next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "lru-cache": "10.1.0",
                 "next": "14.1.0",
                 "node-cache": "5.1.2",
-                "p-limit": "5.0.0",
+                "p-limit": "4.0.0",
                 "pino": "8.18.0",
                 "react": "18.2.0",
                 "react-collapse": "5.1.1",
@@ -12522,14 +12522,14 @@
             }
         },
         "node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
             "dependencies": {
                 "yocto-queue": "^1.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -24725,9 +24725,9 @@
             "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
         },
         "p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
             "requires": {
                 "yocto-queue": "^1.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "server"
     ],
     "dependenciesComments": {
+        "p-limit": "Version 5.0.0 causes issues with webpack import caching",
         "tough-cookie": "Transitive dependency only, bumped directly due to vulnerability alert",
         "word-wrap": "Transitive dependency only, bumped directly due to vulnerability alert"
     },
@@ -54,7 +55,7 @@
         "lru-cache": "10.1.0",
         "next": "14.1.0",
         "node-cache": "5.1.2",
-        "p-limit": "5.0.0",
+        "p-limit": "4.0.0",
         "pino": "8.18.0",
         "react": "18.2.0",
         "react-collapse": "5.1.1",

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -16,6 +16,12 @@ const getLinkHref = (element: HTMLElement | null): string | null => {
     return getLinkHref(element.parentElement);
 };
 
+// TODO: should affect prod as well once decorator-next is released
+const closeDecoratorMenus =
+    process.env.ENV === 'prod'
+        ? () => {}
+        : () => window.dispatchEvent(new CustomEvent('closemenus'));
+
 export const hookAndInterceptInternalLink =
     (router: NextRouter, isEditorView: boolean) => (e: MouseEvent) => {
         const href = getLinkHref(e.target as HTMLElement);
@@ -23,6 +29,7 @@ export const hookAndInterceptInternalLink =
             e.preventDefault();
             const path = getInternalRelativePath(href, isEditorView);
             router.push(path);
+            closeDecoratorMenus();
         }
     };
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sender event som lukker dekoratør-menyer når vi fanger click-events på lenker i dekoratøren
- Nedgraderer p-limit til 4.0.0, ettersom 5.0.0 forårsaker noen feil (usikker på om feilene har hatt noen praktiske konsekvenser, men det er i hvertfall irriterende mye log-spam fra den 😅 ).