### PR TITLE
Lenkeliste: Støtte visning som punktliste

### DIFF
--- a/src/components/_common/content-list/ContentList.tsx
+++ b/src/components/_common/content-list/ContentList.tsx
@@ -8,6 +8,7 @@ import { DateTimeKey } from 'types/datetime';
 import { ContentProps } from 'types/content-props/_content-common';
 import { getNestedValueFromKeyString } from 'utils/objects';
 import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
+import { ListType } from 'types/component-props/parts/link-list';
 
 const getDate = (content: ContentProps, dateLabelKey?: DateTimeKey): string => {
     const dateLabel =
@@ -23,7 +24,7 @@ type Props = {
     title?: string;
     hideTitle?: boolean;
     showDateLabel?: boolean;
-    withChevron?: boolean;
+    listType: ListType;
     className?: string;
 };
 
@@ -32,7 +33,7 @@ export const ContentList = ({
     title,
     hideTitle,
     showDateLabel,
-    withChevron,
+    listType,
     className,
 }: Props) => {
     if (!content?.data?.sectionContents) {
@@ -66,7 +67,7 @@ export const ContentList = ({
         <Lenkeliste
             lenker={lenkeData}
             tittel={hideTitle ? undefined : title || content.displayName}
-            withChevron={withChevron}
+            listType={listType}
             className={className}
         />
     );

--- a/src/components/_common/lenkeliste/Lenkeliste.module.scss
+++ b/src/components/_common/lenkeliste/Lenkeliste.module.scss
@@ -28,17 +28,19 @@
     }
 }
 
-.liste {
+.ulListe {
     padding-left: 1.4rem;
     margin-bottom: 1.75rem;
     margin-top: 0;
     font-size: 1.125rem;
 
-    &:last-of-type {
-        margin-bottom: 0;
-    }
-
     li:not(:last-child) {
         margin-bottom: 0.25rem;
+    }
+}
+
+:global(.part__dynamic-link-list):last-child {
+    .ulListe {
+        margin-bottom: 0;
     }
 }

--- a/src/components/_common/lenkeliste/Lenkeliste.module.scss
+++ b/src/components/_common/lenkeliste/Lenkeliste.module.scss
@@ -27,3 +27,18 @@
         color: common.$a-text-action;
     }
 }
+
+.liste {
+    padding-left: 1.4rem;
+    margin-bottom: 1.75rem;
+    margin-top: 0;
+    font-size: 1.125rem;
+
+    &:last-of-type {
+        margin-bottom: 0;
+    }
+
+    li:not(:last-child) {
+        margin-bottom: 0.25rem;
+    }
+}

--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -1,23 +1,41 @@
-import React, {useId} from 'react';
+import React, { useId } from 'react';
 import { Heading } from '@navikt/ds-react';
 import { LinkProps } from 'types/link-props';
 import { LenkeStandalone } from '../lenke/LenkeStandalone';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { classNames } from 'utils/classnames';
+import { ListType } from 'types/component-props/parts/link-list';
 
 import style from './Lenkeliste.module.scss';
 
 type Props = {
     lenker: LinkProps[];
     tittel?: string;
-    withChevron?: boolean;
+    listType?: ListType;
     className?: string;
 };
+
+const ULWrapper = ({
+    showAsList,
+    children,
+}: {
+    showAsList: boolean;
+    children: React.ReactNode;
+}) =>
+    showAsList ? <ul className={style.liste}>{children}</ul> : <>{children}</>;
+
+const LIWrapper = ({
+    showAsList,
+    children,
+}: {
+    showAsList: boolean;
+    children: React.ReactNode;
+}) => (showAsList ? <li>{children}</li> : <>{children}</>);
 
 export const Lenkeliste = ({
     tittel,
     lenker,
-    withChevron = false,
+    listType = 'default',
     className,
 }: Props) => {
     const headingId = `heading-linklist-${useId()}`;
@@ -27,27 +45,39 @@ export const Lenkeliste = ({
     }
 
     return (
-        <nav className={classNames(className, style.lenker)}
-             aria-labelledby={headingId}
+        <nav
+            className={classNames(className, style.lenker)}
+            aria-labelledby={headingId}
         >
             {tittel && (
-                <Heading className={style.tittel} id={headingId} size="small" level="2">
+                <Heading
+                    className={style.tittel}
+                    id={headingId}
+                    size="small"
+                    level="2"
+                >
                     {tittel}
                 </Heading>
             )}
-            {lenker.map((lenke, index) => (
-                <LenkeStandalone
-                    href={lenke.url}
-                    label={lenke.label}
-                    key={index}
-                    className={style.lenke}
-                    component={'link-list'}
-                    linkGroup={tittel}
-                    withChevron={withChevron}
-                >
-                    {lenke.text}
-                </LenkeStandalone>
-            ))}
+            <ULWrapper showAsList={listType === 'bulletlist'}>
+                {lenker.map((lenke, index) => (
+                    <LIWrapper
+                        showAsList={listType === 'bulletlist'}
+                        key={index}
+                    >
+                        <LenkeStandalone
+                            href={lenke.url}
+                            label={lenke.label}
+                            className={style.lenke}
+                            component={'link-list'}
+                            linkGroup={tittel}
+                            withChevron={listType === 'chevron'}
+                        >
+                            {lenke.text}
+                        </LenkeStandalone>
+                    </LIWrapper>
+                ))}
+            </ULWrapper>
         </nav>
     );
 };

--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -11,11 +11,11 @@ import style from './Lenkeliste.module.scss';
 type Props = {
     lenker: LinkProps[];
     tittel?: string;
-    listType?: ListType;
     className?: string;
+    listType: ListType;
 };
 
-const ULWrapper = ({
+const WrapUL = ({
     showAsList,
     children,
 }: {
@@ -24,7 +24,7 @@ const ULWrapper = ({
 }) =>
     showAsList ? <ul className={style.liste}>{children}</ul> : <>{children}</>;
 
-const LIWrapper = ({
+const WrapLI = ({
     showAsList,
     children,
 }: {
@@ -32,12 +32,7 @@ const LIWrapper = ({
     children: React.ReactNode;
 }) => (showAsList ? <li>{children}</li> : <>{children}</>);
 
-export const Lenkeliste = ({
-    tittel,
-    lenker,
-    listType = 'default',
-    className,
-}: Props) => {
+export const Lenkeliste = ({ tittel, lenker, listType, className }: Props) => {
     const headingId = `heading-linklist-${useId()}`;
 
     if (!lenker || lenker.length === 0) {
@@ -59,12 +54,9 @@ export const Lenkeliste = ({
                     {tittel}
                 </Heading>
             )}
-            <ULWrapper showAsList={listType === 'bulletlist'}>
+            <WrapUL showAsList={listType === 'bulletlist'}>
                 {lenker.map((lenke, index) => (
-                    <LIWrapper
-                        showAsList={listType === 'bulletlist'}
-                        key={index}
-                    >
+                    <WrapLI showAsList={listType === 'bulletlist'} key={index}>
                         <LenkeStandalone
                             href={lenke.url}
                             label={lenke.label}
@@ -75,9 +67,9 @@ export const Lenkeliste = ({
                         >
                             {lenke.text}
                         </LenkeStandalone>
-                    </LIWrapper>
+                    </WrapLI>
                 ))}
-            </ULWrapper>
+            </WrapUL>
         </nav>
     );
 };

--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -22,7 +22,11 @@ const WrapUL = ({
     showAsList: boolean;
     children: React.ReactNode;
 }) =>
-    showAsList ? <ul className={style.liste}>{children}</ul> : <>{children}</>;
+    showAsList ? (
+        <ul className={style.ulListe}>{children}</ul>
+    ) : (
+        <>{children}</>
+    );
 
 const WrapLI = ({
     showAsList,

--- a/src/components/parts/_legacy/link-lists/LinkLists.tsx
+++ b/src/components/parts/_legacy/link-lists/LinkLists.tsx
@@ -25,7 +25,7 @@ const LinkLists = (props: SectionPageProps) => {
                     {ntkContents && (
                         <ContentList
                             content={ntkContents}
-                            withChevron={true}
+                            listType={'chevron'}
                             className={style.column}
                         />
                     )}
@@ -35,7 +35,7 @@ const LinkLists = (props: SectionPageProps) => {
                                 <ContentList
                                     content={newsContents}
                                     showDateLabel={true}
-                                    withChevron={true}
+                                    listType={'chevron'}
                                 />
                                 {newsUrlAbsolute && (
                                     <LenkeStandalone
@@ -53,7 +53,7 @@ const LinkLists = (props: SectionPageProps) => {
                     {scContents && (
                         <ContentList
                             content={scContents}
-                            withChevron={true}
+                            listType={'chevron'}
                             className={style.column}
                         />
                     )}

--- a/src/components/parts/link-list/LinkListPart.tsx
+++ b/src/components/parts/link-list/LinkListPart.tsx
@@ -9,7 +9,7 @@ import { EditorHelp } from '../../_editor-only/editor-help/EditorHelp';
 import style from './LinkList.module.scss';
 
 const getListComponent = (config: DynamicLinkListProps['config']) => {
-    const { title, list, chevron, hideTitle } = config;
+    const { title, list, listType, hideTitle } = config;
     const { _selected } = list;
 
     if (_selected === 'contentList') {
@@ -19,7 +19,7 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
                 content={contentList?.target}
                 title={title}
                 hideTitle={hideTitle}
-                withChevron={chevron}
+                listType={listType}
             />
         );
     }
@@ -31,7 +31,7 @@ const getListComponent = (config: DynamicLinkListProps['config']) => {
             <Lenkeliste
                 tittel={!hideTitle ? title : undefined}
                 lenker={links}
-                withChevron={chevron}
+                listType={listType}
             />
         );
     }

--- a/src/components/parts/news-list/NewsListPart.tsx
+++ b/src/components/parts/news-list/NewsListPart.tsx
@@ -22,7 +22,7 @@ export const NewsListPart = ({ config }: DynamicNewsListProps) => {
                     content={contentList.target}
                     title={title}
                     hideTitle={hideTitle}
-                    withChevron={true}
+                    listType={'chevron'}
                 />
                 {moreNews && (
                     <LenkeStandalone

--- a/src/types/component-props/parts/link-list.ts
+++ b/src/types/component-props/parts/link-list.ts
@@ -8,12 +8,14 @@ import {
 } from '../_mixins';
 import { OptionSetSingle } from '../../util-types';
 
+export type ListType = 'default' | 'chevron' | 'bulletlist';
+
 export interface DynamicLinkListProps extends PartComponentProps {
     descriptor: PartType.LinkList;
     config: {
         title?: string;
         hideTitle?: boolean;
-        chevron?: boolean;
+        listType: ListType;
         list: OptionSetSingle<{
             contentList: ContentListMixin;
             linkList: {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Lenkeliste må ha tre type visninger: vanlig, chevron og punktliste (ny). Denne PR'en fjerner "Lenker med chevron" og lar redaktøren velge samme visning via en dropdown.

Det er 3-4 sider som faktisk har Lenkeliste hvor Lenker med chevron er slått på, så vi kan gå inn i etterkant av deploy og korrigere dette slik at disse sidene fortsatt viser lenkeliste med chevron.

## Testing
Testes i dev