### PR TITLE
Forbedrer håndtering av manglende context

### DIFF
--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -6,9 +6,7 @@ const PageContext = createContext<ContentProps | {}>({});
 
 const PageContextProvider: React.FC<any> = ({ children, content }) => {
     return (
-        <PageContext.Provider value={content || {}}>
-            {children}
-        </PageContext.Provider>
+        <PageContext.Provider value={content}>{children}</PageContext.Provider>
     );
 };
 

--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -2,22 +2,24 @@ import React, { createContext, useContext } from 'react';
 import { ContentProps } from 'types/content-props/_content-common';
 import { logger } from 'srcCommon/logger';
 
-const PageContext = createContext<ContentProps>(null);
+const PageContext = createContext<ContentProps | {}>({});
 
 const PageContextProvider: React.FC<any> = ({ children, content }) => {
     return (
-        <PageContext.Provider value={content}>{children}</PageContext.Provider>
+        <PageContext.Provider value={content || {}}>
+            {children}
+        </PageContext.Provider>
     );
 };
 
-const usePageContentProps = () => {
-    const context = useContext(PageContext);
+const usePageContentProps = (): ContentProps => {
+    const context = useContext(PageContext) as ContentProps;
 
     if (!context) {
         logger.error('Could not get page context from useContext');
     }
 
-    return context || {};
+    return context;
 };
 
 export { PageContextProvider, usePageContentProps };

--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext } from 'react';
 import { ContentProps } from 'types/content-props/_content-common';
-import { makeErrorProps } from 'utils/make-error-props';
+import { logger } from 'srcCommon/logger';
 
 const PageContext = createContext<ContentProps>(null);
 
@@ -14,12 +14,10 @@ const usePageContentProps = () => {
     const context = useContext(PageContext);
 
     if (!context) {
-        throw new Error(
-            'usePageContentProps must be used within a PageContextProvider'
-        );
+        logger.error('Could not get page context from useContext');
     }
 
-    return context;
+    return context || {};
 };
 
 export { PageContextProvider, usePageContentProps };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Når frontend kjøres lokalt, så feiler siden når den lastes inn i edit-mode. Fungerer i preview. Mulig det handler om at hook'en kjører før context er klart fra Provider? Det stabiliserer seg ved ny render, men siden krasjer hvis man kaster en feil.

## Testing
Testes i dev
