### PR TITLE
Gjeninnfører FallbackPage som innholdstype for initiell context

### DIFF
--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -4,7 +4,6 @@ import { PageWrapper } from './PageWrapper';
 import { ContentMapper } from './ContentMapper';
 import { makeErrorProps } from 'utils/make-error-props';
 import { PageContextProvider } from 'store/pageContext';
-import { FallbackPage } from './pages/fallback-page/FallbackPage';
 
 export type PageProps = {
     content: ContentProps;
@@ -15,10 +14,6 @@ export const PageBase = (props: PageProps) => {
     const content =
         props?.content ||
         makeErrorProps('www.nav.no', 'Ukjent feil - kunne ikke laste innhold');
-
-    if (!content) {
-        return <FallbackPage />;
-    }
 
     return (
         <PageContextProvider content={content}>

--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -4,6 +4,7 @@ import { PageWrapper } from './PageWrapper';
 import { ContentMapper } from './ContentMapper';
 import { makeErrorProps } from 'utils/make-error-props';
 import { PageContextProvider } from 'store/pageContext';
+import { FallbackPage } from './pages/fallback-page/FallbackPage';
 
 export type PageProps = {
     content: ContentProps;
@@ -14,6 +15,10 @@ export const PageBase = (props: PageProps) => {
     const content =
         props?.content ||
         makeErrorProps('www.nav.no', 'Ukjent feil - kunne ikke laste innhold');
+
+    if (!content) {
+        return <FallbackPage />;
+    }
 
     return (
         <PageContextProvider content={content}>

--- a/src/components/pages/fallback-page/FallbackPage.module.scss
+++ b/src/components/pages/fallback-page/FallbackPage.module.scss
@@ -1,0 +1,6 @@
+.fallbackPage {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 2rem;
+}

--- a/src/components/pages/fallback-page/FallbackPage.tsx
+++ b/src/components/pages/fallback-page/FallbackPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Heading, Loader } from '@navikt/ds-react';
+
+import style from './FallbackPage.module.scss';
+
+export const FallbackPage = () => {
+    return (
+        <div className={style.fallbackPage}>
+            <Loader size={'2xlarge'} />
+            <Heading level="1" size="medium">
+                {'Laster side-innhold...'}
+            </Heading>
+        </div>
+    );
+};

--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext } from 'react';
 import { ContentProps } from 'types/content-props/_content-common';
-import { makeErrorProps } from 'utils/make-error-props';
 
 const PageContext = createContext<ContentProps>(null);
 

--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -1,7 +1,16 @@
 import React, { createContext, useContext } from 'react';
-import { ContentProps } from 'types/content-props/_content-common';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 
-const PageContext = createContext<ContentProps>(null);
+const PageContext = createContext<ContentProps>({
+    type: ContentType.FallbackPage,
+    _id: '',
+    _path: '',
+    createdTime: '',
+    modifiedTime: '',
+    displayName: 'Laster innhold...',
+    language: 'no',
+    data: {},
+});
 
 const PageContextProvider: React.FC<any> = ({ children, content }) => {
     return (

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -53,7 +53,6 @@ import { FormDetailsPageProps } from './form-details';
 import { FormIntermediateStepPageProps } from './form-intermediate-step';
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
 import { OverviewPageProps } from 'types/content-props/overview-props';
-import { FallbackPage } from 'components/pages/fallback-page/FallbackPage';
 import { FallbackPageProps } from './fallback-page-props';
 
 export enum ContentType {

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -53,6 +53,8 @@ import { FormDetailsPageProps } from './form-details';
 import { FormIntermediateStepPageProps } from './form-intermediate-step';
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
 import { OverviewPageProps } from 'types/content-props/overview-props';
+import { FallbackPage } from 'components/pages/fallback-page/FallbackPage';
+import { FallbackPageProps } from './fallback-page-props';
 
 export enum ContentType {
     Error = 'error',
@@ -101,6 +103,7 @@ export enum ContentType {
     UserTestsConfig = 'no.nav.navno:user-tests-config',
     Video = 'no.nav.navno:video',
     AlertInContext = 'no.nav.navno:alert-in-context',
+    FallbackPage = 'no.nav.navno:fallback-page',
 }
 
 export type ContentAndMediaCommonProps = {
@@ -200,7 +203,8 @@ type SpecificContentProps =
     | PressLandingPageProps
     | FormDetailsPageProps
     | FormIntermediateStepPageProps
-    | FormsOverviewProps;
+    | FormsOverviewProps
+    | FallbackPageProps;
 
 export type ContentProps<Type extends ContentType = ContentType> =
     ContentCommonProps<Type> & SpecificContentProps;

--- a/src/types/content-props/fallback-page-props.ts
+++ b/src/types/content-props/fallback-page-props.ts
@@ -1,0 +1,6 @@
+import { ContentType, ContentCommonProps } from './_content-common';
+
+export type FallbackPageProps = ContentCommonProps & {
+    type: ContentType.FallbackPage;
+    data: {};
+};


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Gjeninnfører FallbackPage slik at den setter som initiell verdi i kontekst. I hovedsak blir den umiddelbart overskrevet av korrekt innholdstype, men den er nødvendig for å unngå en feil som kastes i redigeringsmodus i Content Studio.

## Testing
Testes i dev