### PR TITLE
Sjekke for visning av RelatedSituations og AlternativeAudience i ComponentPreview og DynamicPage 

### DIFF
--- a/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
+++ b/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
@@ -6,7 +6,6 @@ import { ContentType } from 'types/content-props/_content-common';
 import { createTypeGuard } from 'types/_type-guards';
 
 const isValidContentType = createTypeGuard([
-    ContentType.DynamicPage,
     ContentType.ProductPage,
     ContentType.ThemedArticlePage,
     ContentType.GuidePage,
@@ -15,21 +14,21 @@ const isValidContentType = createTypeGuard([
 export const AlternativeAudiencePart = ({ config, pageProps }: AlternativeAudienceProps) => {
     const { data, type, _id, displayName } = pageProps;
 
-    if (!isValidContentType(type)) {
-        return <EditorHelp text={`Ugyldig content-type ${type}`} />;
-    }
-
     // If the page is in preview mode, audience from the page props will be empty,
     // so display a note about 'mark as ready' to the editor, as we can't actually
     // display the audience until the page has been refreshed.
     const isComponentPreviewMode = _id === '';
-    if (isComponentPreviewMode) {
+    if (isComponentPreviewMode || type === ContentType.DynamicPage) {
         return (
             <EditorHelp
                 type={'info'}
                 text={'Aktuelle målgrupper vises her når du klikker "marker som klar".'}
             />
         );
+    }
+
+    if (!isValidContentType(type)) {
+        return <EditorHelp text={`Ugyldig content-type ${type}`} />;
     }
 
     const { alternativeAudience, title } = data;

--- a/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
+++ b/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
@@ -6,6 +6,7 @@ import { ContentType } from 'types/content-props/_content-common';
 import { createTypeGuard } from 'types/_type-guards';
 
 const isValidContentType = createTypeGuard([
+    ContentType.DynamicPage,
     ContentType.ProductPage,
     ContentType.ThemedArticlePage,
     ContentType.GuidePage,

--- a/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
+++ b/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
@@ -18,6 +18,9 @@ export const AlternativeAudiencePart = ({ config, pageProps }: AlternativeAudien
     // so display a note about 'mark as ready' to the editor, as we can't actually
     // display the audience until the page has been refreshed.
     const isComponentPreviewMode = _id === '';
+    // Note (02.04.24): The type guard for DynamicPage needs to be in place until ComponentPreview
+    // receives the actual content type from the actual page props. Described in task:
+    // https://github.com/navikt/nav-enonicxp/issues/2081
     if (isComponentPreviewMode || type === ContentType.DynamicPage) {
         return (
             <EditorHelp

--- a/src/components/parts/related-situations/RelatedSituationsPart.tsx
+++ b/src/components/parts/related-situations/RelatedSituationsPart.tsx
@@ -6,7 +6,6 @@ import { ContentType } from 'types/content-props/_content-common';
 import { createTypeGuard } from 'types/_type-guards';
 
 const isValidContentType = createTypeGuard([
-    ContentType.DynamicPage,
     ContentType.ProductPage,
     ContentType.ThemedArticlePage,
     ContentType.GuidePage,
@@ -15,21 +14,21 @@ const isValidContentType = createTypeGuard([
 export const RelatedSituationsPart = ({ config, pageProps }: RelatedSituationsProps) => {
     const { type, data, _id } = pageProps;
 
-    if (!isValidContentType(type)) {
-        return <EditorHelp text={`Ugyldig content-type ${type}`} />;
-    }
-
     // If the page is in preview mode, related situations from the page props will be empty,
     // so display a note about 'mark as ready' to the editor, as we can't actually
     // display the situations until the page has been refreshed.
     const isComponentPreviewMode = _id === '';
-    if (isComponentPreviewMode) {
+    if (isComponentPreviewMode || type === ContentType.DynamicPage) {
         return (
             <EditorHelp
                 type={'info'}
                 text={'Aktuelle situasjoner vises her når du klikker "marker som klar".'}
             />
         );
+    }
+
+    if (!isValidContentType(type)) {
+        return <EditorHelp text={`Ugyldig content-type ${type}`} />;
     }
 
     const { relatedSituations } = data;

--- a/src/components/parts/related-situations/RelatedSituationsPart.tsx
+++ b/src/components/parts/related-situations/RelatedSituationsPart.tsx
@@ -17,6 +17,9 @@ export const RelatedSituationsPart = ({ config, pageProps }: RelatedSituationsPr
     // If the page is in preview mode, related situations from the page props will be empty,
     // so display a note about 'mark as ready' to the editor, as we can't actually
     // display the situations until the page has been refreshed.
+    // Note (02.04.24): The type guard for DynamicPage needs to be in place until ComponentPreview
+    // receives the actual content type from the actual page props. Described in task:
+    // https://github.com/navikt/nav-enonicxp/issues/2081
     const isComponentPreviewMode = _id === '';
     if (isComponentPreviewMode || type === ContentType.DynamicPage) {
         return (

--- a/src/components/parts/related-situations/RelatedSituationsPart.tsx
+++ b/src/components/parts/related-situations/RelatedSituationsPart.tsx
@@ -6,6 +6,7 @@ import { ContentType } from 'types/content-props/_content-common';
 import { createTypeGuard } from 'types/_type-guards';
 
 const isValidContentType = createTypeGuard([
+    ContentType.DynamicPage,
     ContentType.ProductPage,
     ContentType.ThemedArticlePage,
     ContentType.GuidePage,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Flytter sjekk av componentPreview ovenfor typeguard for gyldig bruk av komponenten.
Dette er en midlertidig fiks til vi kan få inn korrekte pageProps (og dermed innholdstype) i ComponentPreview.

Type guard for DynamicPage kan fjernes når denne oppgaven er løst:
https://github.com/navikt/nav-enonicxp/issues/2081

## Testing
Testes i dev