### PR TITLE
Aktuelle målgrupper: Kunne sette egen label for aandre samarbeidspartnere

### DIFF
--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import {
     AlternativeAudience as AlternativeAudienceType,
     Audience,
+    ProviderAudience,
 } from 'types/component-props/_mixins';
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
@@ -94,6 +95,9 @@ const buildAudienceLinks = (
     if (provider?.providerList) {
         provider.providerList.forEach((singleProvider) => {
             const providerLabels = singleProvider.providerAudience.map((audience) => {
+                if (typeof audience === 'string') {
+                    return getProviderAudienceLabel(audience as ProviderAudience);
+                }
                 if (audience.overrideLabel) return audience.overrideLabel;
                 return getProviderAudienceLabel(audience.name);
             });

--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -46,16 +46,10 @@ export const AlternativeAudience = ({
             )}
         >
             <BodyShort>
-                {getRelatedString('relatedAudience').replace(
-                    '{name}',
-                    name.toLowerCase()
-                )}{' '}
+                {getRelatedString('relatedAudience').replace('{name}', name.toLowerCase())}{' '}
                 {audienceLinks.map((link, index) => (
                     <Fragment key={index}>
-                        <LenkeInline
-                            href={link.url}
-                            analyticsLabel={'Aktuell målgruppe'}
-                        >
+                        <LenkeInline href={link.url} analyticsLabel={'Aktuell målgruppe'}>
                             {link.title}
                         </LenkeInline>
                         {getConjunction({
@@ -99,9 +93,10 @@ const buildAudienceLinks = (
     // with 'person' and 'arbeidsgiver'.
     if (provider?.providerList) {
         provider.providerList.forEach((singleProvider) => {
-            const providerLabels = singleProvider.providerAudience.map(
-                (audience) => getProviderAudienceLabel(audience)
-            );
+            const providerLabels = singleProvider.providerAudience.map((audience) => {
+                if (audience.overrideLabel) return audience.overrideLabel;
+                return getProviderAudienceLabel(audience.name);
+            });
             links.push({
                 title: joinWithConjunction(providerLabels, language),
                 url: stripXpPathPrefix(singleProvider.targetPage._path),

--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -7,7 +7,7 @@ import {
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { Language, translator } from 'translations';
-import { BodyShort } from '@navikt/ds-react';
+import { BodyLong } from '@navikt/ds-react';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { stripXpPathPrefix } from 'utils/urls';
 import { getConjunction, joinWithConjunction } from 'utils/string';
@@ -46,7 +46,7 @@ export const AlternativeAudience = ({
                 editorView === 'edit' && style.noMargin
             )}
         >
-            <BodyShort>
+            <BodyLong>
                 {getRelatedString('relatedAudience').replace('{name}', name.toLowerCase())}{' '}
                 {audienceLinks.map((link, index) => (
                     <Fragment key={index}>
@@ -60,7 +60,7 @@ export const AlternativeAudience = ({
                         })}
                     </Fragment>
                 ))}
-            </BodyShort>
+            </BodyLong>
         </div>
     );
 };

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -38,9 +38,7 @@ export type AudienceOptions = OptionSetSingle<{
 type AudienceProps = AudienceOptions | Audience | Audience[];
 
 export function getAudience(audience: AudienceProps): Audience;
-export function getAudience(
-    audience: AudienceProps | undefined | null
-): Audience | null;
+export function getAudience(audience: AudienceProps | undefined | null): Audience | null;
 export function getAudience(audience: AudienceProps | undefined | null) {
     if (!audience) {
         return null;
@@ -52,9 +50,7 @@ export function getAudience(audience: AudienceProps | undefined | null) {
 
     // Always prioritize person audience if it is present
     if (Array.isArray(audience)) {
-        return audience.includes(Audience.PERSON)
-            ? Audience.PERSON
-            : audience[0];
+        return audience.includes(Audience.PERSON) ? Audience.PERSON : audience[0];
     }
 
     return audience._selected;
@@ -81,7 +77,10 @@ export type AlternativeAudience = OptionSetMulti<{
     employer: { targetPage: ContentProps };
     provider: {
         providerList: {
-            providerAudience: ProviderAudience[];
+            providerAudience: {
+                name: ProviderAudience;
+                overrideLabel?: string;
+            }[];
             targetPage: ContentProps;
         }[];
     };

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -77,10 +77,13 @@ export type AlternativeAudience = OptionSetMulti<{
     employer: { targetPage: ContentProps };
     provider: {
         providerList: {
-            providerAudience: {
-                name: ProviderAudience;
-                overrideLabel?: string;
-            }[];
+            providerAudience: (
+                | {
+                      name: ProviderAudience;
+                      overrideLabel?: string;
+                  }
+                | string
+            )[];
             targetPage: ContentProps;
         }[];
     };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Man må kunne sette en egen label/navn hvis man har valgt "andre samarbeidspartnere" som aktuell målgruppe.
Denne PR'en gjør at frontend håndterer både string og objekt for valgt samarbeidspartner. String-støtte fjernes når backend er rullet ut.

## Testing
Testes i dev2.