### PR TITLE
Legger til import order linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
                 ],
                 "pathGroups": [
                     {
-                        "pattern": "./**/*.scss",
+                        "pattern": "./**/*.module.scss",
                         "group": "sibling",
                         "position": "after"
                     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,24 @@
                 "camelCase": true
             }
         ],
+        "import/order": [
+            "warn",
+            {
+                "groups": [
+                    ["builtin", "external"],
+                    ["internal", "parent", "index", "object", "unknown", "type"],
+                    "sibling"
+                ],
+                "pathGroups": [
+                    {
+                        "pattern": "./**/*.scss",
+                        "group": "sibling",
+                        "position": "after"
+                    }
+                ],
+                "newlines-between": "always"
+            }
+        ],
         "no-console": "warn",
         "no-relative-import-paths/no-relative-import-paths": [
             "warn",

--- a/server/src/cache/image-cache-handler.test.ts
+++ b/server/src/cache/image-cache-handler.test.ts
@@ -2,9 +2,11 @@ import NextNodeServer from 'next/dist/server/next-server';
 import mockFs from 'mock-fs';
 import fs from 'fs';
 import { ImageOptimizerCache } from 'next/dist/server/image-optimizer';
-import { injectNextImageCacheDir } from './image-cache-handler';
+
 import { __getNextTestApp } from '../../__test-utils/utils';
 import { getNextServer } from '../next-utils';
+
+import { injectNextImageCacheDir } from './image-cache-handler';
 
 describe('Set next.js image cache dir', () => {
     const nextApp = __getNextTestApp();

--- a/server/src/cache/image-cache-handler.ts
+++ b/server/src/cache/image-cache-handler.ts
@@ -27,10 +27,7 @@ class ImageCacheWithCustomCacheDir extends ResponseCache {
     }
 }
 
-export const injectNextImageCacheDir = async (
-    nextServer: NextNodeServer,
-    cacheDir: string
-) => {
+export const injectNextImageCacheDir = async (nextServer: NextNodeServer, cacheDir: string) => {
     const responseCache = new ImageCacheWithCustomCacheDir(false, cacheDir);
 
     try {

--- a/server/src/cache/revalidator-proxy-heartbeat.test.ts
+++ b/server/src/cache/revalidator-proxy-heartbeat.test.ts
@@ -10,17 +10,13 @@ describe('Revalidator proxy heartbeat', () => {
     process.env.ENV = 'localhost';
 
     test('Should call revalidator proxy', async () => {
-        const { initRevalidatorProxyHeartbeat } = await import(
-            './revalidator-proxy-heartbeat'
-        );
+        const { initRevalidatorProxyHeartbeat } = await import('./revalidator-proxy-heartbeat');
 
         fetchMock.mockResponse('Hello!');
 
         initRevalidatorProxyHeartbeat('dummy-build-id');
 
         expect(fetchMock.mock.calls.length).toEqual(1);
-        expect(fetchMock.mock.calls[0][0]).toMatch(
-            new RegExp(`^${revalidatorProxyOrigin}`)
-        );
+        expect(fetchMock.mock.calls[0][0]).toMatch(new RegExp(`^${revalidatorProxyOrigin}`));
     });
 });

--- a/server/src/cache/revalidator-proxy-heartbeat.ts
+++ b/server/src/cache/revalidator-proxy-heartbeat.ts
@@ -3,19 +3,11 @@
 // See: https://github.com/navikt/nav-enonicxp-frontend-revalidator-proxy
 import { networkInterfaces } from 'os';
 import { logger } from 'srcCommon/logger';
-import {
-    getRenderCacheKeyPrefix,
-    getResponseCacheKeyPrefix,
-} from 'srcCommon/redis';
+import { getRenderCacheKeyPrefix, getResponseCacheKeyPrefix } from 'srcCommon/redis';
 import { objectToQueryString } from 'srcCommon/fetch-utils';
 
-const {
-    ENV,
-    NODE_ENV,
-    DOCKER_HOST_ADDRESS,
-    REVALIDATOR_PROXY_ORIGIN,
-    SERVICE_SECRET,
-} = process.env;
+const { ENV, NODE_ENV, DOCKER_HOST_ADDRESS, REVALIDATOR_PROXY_ORIGIN, SERVICE_SECRET } =
+    process.env;
 
 const HEARTBEAT_PERIOD_MS = 5000;
 
@@ -45,10 +37,9 @@ const getProxyLivenessUrl = (buildId: string) => {
     return podAddress
         ? `${REVALIDATOR_PROXY_ORIGIN}/liveness${objectToQueryString({
               address: podAddress,
-              redisPrefixes: [
-                  getRenderCacheKeyPrefix(buildId),
-                  getResponseCacheKeyPrefix(),
-              ].join(','),
+              redisPrefixes: [getRenderCacheKeyPrefix(buildId), getResponseCacheKeyPrefix()].join(
+                  ','
+              ),
           })}`
         : null;
 };

--- a/server/src/next-utils.test.ts
+++ b/server/src/next-utils.test.ts
@@ -1,6 +1,8 @@
-import { getNextBuildId, getNextServer } from './next-utils';
 import NextNodeServer from 'next/dist/server/next-server';
+
 import { __getNextTestApp } from '../__test-utils/utils';
+
+import { getNextBuildId, getNextServer } from './next-utils';
 
 describe('Next.js server private accessors', () => {
     const nextApp = __getNextTestApp();

--- a/server/src/next-utils.ts
+++ b/server/src/next-utils.ts
@@ -6,9 +6,7 @@ import { NextServer } from 'next/dist/server/next';
 // Note: there are additional worker instances of the next server,
 // used for handling requests.
 // This function only returns the top level instance
-export const getNextServer = async (
-    nextApp: NextServer
-): Promise<NextNodeServer> => {
+export const getNextServer = async (nextApp: NextServer): Promise<NextNodeServer> => {
     return nextApp['getServer']();
 };
 

--- a/server/src/req-handlers/pending-responses.ts
+++ b/server/src/req-handlers/pending-responses.ts
@@ -19,9 +19,5 @@ export const handleGetPendingResponses =
 
         return pending
             ? res.status(200).send(pending)
-            : res
-                  .status(500)
-                  .send(
-                      'Failed to retrieve pending responses - see logs for details'
-                  );
+            : res.status(500).send('Failed to retrieve pending responses - see logs for details');
     };

--- a/server/src/req-handlers/set-cache-key.test.ts
+++ b/server/src/req-handlers/set-cache-key.test.ts
@@ -11,11 +11,7 @@ describe('Set cache key middleware', () => {
         const { setCacheKey } = await import('./set-cache-key');
         const cacheKey = 'myCacheKey';
 
-        setCacheKey(
-            { headers: { cache_key: cacheKey, cache_ts: '1' } } as any,
-            res,
-            next
-        );
+        setCacheKey({ headers: { cache_key: cacheKey, cache_ts: '1' } } as any, res, next);
 
         expect(global.cacheKey).toEqual(cacheKey);
     });
@@ -37,11 +33,7 @@ describe('Set cache key middleware', () => {
 
         const cacheKey = 'myCacheKey';
 
-        setCacheKey(
-            { headers: { cache_key: cacheKey, cache_ts: '1' } } as any,
-            res,
-            next
-        );
+        setCacheKey({ headers: { cache_key: cacheKey, cache_ts: '1' } } as any, res, next);
         setCacheKey({ headers: {} } as any, res, next);
 
         expect(global.cacheKey).toEqual(cacheKey);

--- a/server/src/req-handlers/set-cache-key.ts
+++ b/server/src/req-handlers/set-cache-key.ts
@@ -9,9 +9,7 @@ export const setCacheKey: RequestHandler = (req, res, next) => {
     if (typeof cache_key === 'string') {
         const newCacheTimestamp = Number(cache_ts);
         if (newCacheTimestamp > currentCacheTimestamp) {
-            logger.info(
-                `Setting new cache key ${cache_key} with timestamp ${cache_ts}`
-            );
+            logger.info(`Setting new cache key ${cache_key} with timestamp ${cache_ts}`);
             global.cacheKey = cache_key;
             currentCacheTimestamp = newCacheTimestamp;
         } else {

--- a/server/src/req-handlers/validate-secret.test.ts
+++ b/server/src/req-handlers/validate-secret.test.ts
@@ -19,22 +19,14 @@ describe('Validate secret header middleware', () => {
     });
 
     test('Next function should be called on valid secrets', () => {
-        validateSecretMiddleware(
-            { headers: { secret: mySecret } },
-            resObject,
-            nextFunction
-        );
+        validateSecretMiddleware({ headers: { secret: mySecret } }, resObject, nextFunction);
 
         expect(nextFunction).toBeCalledTimes(1);
         expect(nextAppMock.renderError).toBeCalledTimes(0);
     });
 
     test('renderError should be called on invalid secrets', () => {
-        validateSecretMiddleware(
-            { headers: { secret: 'notMySecret' } },
-            resObject,
-            nextFunction
-        );
+        validateSecretMiddleware({ headers: { secret: 'notMySecret' } }, resObject, nextFunction);
 
         validateSecretMiddleware({ headers: {} }, resObject, nextFunction);
 

--- a/server/src/req-handlers/validate-secret.test.ts
+++ b/server/src/req-handlers/validate-secret.test.ts
@@ -1,4 +1,5 @@
 import { NextFunction } from 'express';
+
 import { validateSecret } from './validate-secret';
 
 const mySecret = 'mySecret';

--- a/server/src/server-setup/server-setup-dev.ts
+++ b/server/src/server-setup/server-setup-dev.ts
@@ -9,8 +9,7 @@ const LEGACY_DEV_HOSTNAME = 'www.intern.dev.nav.no';
 
 // 155.55.* is NAVs public IP range. Also includes the private IP range used by our
 // internal network (10.*), and localhost. Takes the IPv6 prefix ::ffff: into account.
-const isNavIp = (ip?: string) =>
-    ip && /^(::ffff:)?(155\.55\.|10\.|127\.)/.test(ip);
+const isNavIp = (ip?: string) => ip && /^(::ffff:)?(155\.55\.|10\.|127\.)/.test(ip);
 
 // Applies certain restrictions for the app in dev environments. This is not intended
 // as a security measure, but rather to ensure (to some degree) that the public does
@@ -42,9 +41,7 @@ export const serverSetupDev = (expressApp: Express, nextApp: NextServer) => {
 
     // Sets a cookie which will bypass the IP restriction
     expressApp.get('/login', (req, res) => {
-        return res
-            .cookie(LOGIN_COOKIE, true, { maxAge: 1000 * 3600 * 24 })
-            .redirect(302, '/');
+        return res.cookie(LOGIN_COOKIE, true, { maxAge: 1000 * 3600 * 24 }).redirect(302, '/');
     });
 
     expressApp.all('*', cookieParser(), (req, res, next) => {
@@ -52,9 +49,7 @@ export const serverSetupDev = (expressApp: Express, nextApp: NextServer) => {
             return next();
         }
 
-        logger.info(
-            `Non-authorized client ips: ${req.ip} ${JSON.stringify(req.ips)}`
-        );
+        logger.info(`Non-authorized client ips: ${req.ip} ${JSON.stringify(req.ips)}`);
 
         return res
             .status(401)

--- a/server/src/server-setup/server-setup-failover.ts
+++ b/server/src/server-setup/server-setup-failover.ts
@@ -1,10 +1,7 @@
 import { Express } from 'express';
 import { NextServer } from 'next/dist/server/next';
 
-export const serverSetupFailover = (
-    expressApp: Express,
-    nextApp: NextServer
-) => {
+export const serverSetupFailover = (expressApp: Express, nextApp: NextServer) => {
     const nextRequestHandler = nextApp.getRequestHandler();
 
     // Assets from /_next and internal apis should be served as normal

--- a/server/src/server-setup/server-setup.ts
+++ b/server/src/server-setup/server-setup.ts
@@ -52,18 +52,12 @@ export const serverSetup = async (expressApp: Express, nextApp: NextServer) => {
         handleInvalidateAllReq
     );
 
-    expressApp.get(
-        '/api/pending',
-        validateSecretMiddleware,
-        handleGetPendingResponses(nextServer)
-    );
+    expressApp.get('/api/pending', validateSecretMiddleware, handleGetPendingResponses(nextServer));
 
     expressApp.get('/_next/data/:buildId/*.json', (req, res) => {
         const { buildId } = req.params;
         if (buildId !== currentBuildId) {
-            logger.info(
-                `Expected build-id ${currentBuildId}, got ${buildId} on ${req.path}`
-            );
+            logger.info(`Expected build-id ${currentBuildId}, got ${buildId} on ${req.path}`);
             req.url = req.url.replace(buildId, currentBuildId);
         }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,9 +20,7 @@ const promMiddleware = promBundle({
 });
 
 const nextApp = next({
-    dev:
-        process.env.NODE_ENV === 'development' &&
-        process.env.ENV === 'localhost',
+    dev: process.env.NODE_ENV === 'development' && process.env.ENV === 'localhost',
     quiet: process.env.ENV === 'prod',
     dir: path.join(__dirname, '..', '..'),
 });

--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import {
-    ComponentProps,
-    ComponentType,
-} from 'types/component-props/_component-common';
+
+import { ComponentProps, ComponentType } from 'types/component-props/_component-common';
+import { ContentProps } from 'types/content-props/_content-common';
+
 import { TextComponentXp } from './parts/_text/TextComponentXp';
 import { ImageComponentXp } from './parts/_image/ImageComponent';
 import { PartsMapper } from './parts/PartsMapper';
-import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutMapper } from './layouts/LayoutMapper';
 import { FragmentComponent } from './FragmentComponent';
 import { AuthDependantRender } from './_common/auth-dependant-render/AuthDependantRender';
@@ -31,56 +30,27 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
 
     switch (componentProps.type) {
         case ComponentType.Text:
-            return (
-                <TextComponentXp
-                    textProps={componentProps}
-                    editMode={!!pageProps.editorView}
-                />
-            );
+            return <TextComponentXp textProps={componentProps} editMode={!!pageProps.editorView} />;
         case ComponentType.Image:
             return (
-                <ImageComponentXp
-                    imageProps={componentProps}
-                    editMode={!!pageProps.editorView}
-                />
+                <ImageComponentXp imageProps={componentProps} editMode={!!pageProps.editorView} />
             );
         case ComponentType.Layout:
         case ComponentType.Page:
-            return (
-                <LayoutMapper
-                    layoutProps={componentProps}
-                    pageProps={pageProps}
-                />
-            );
+            return <LayoutMapper layoutProps={componentProps} pageProps={pageProps} />;
         case ComponentType.Part:
-            return (
-                <PartsMapper partProps={componentProps} pageProps={pageProps} />
-            );
+            return <PartsMapper partProps={componentProps} pageProps={pageProps} />;
         case ComponentType.Fragment:
-            return (
-                <FragmentComponent
-                    componentProps={componentProps}
-                    pageProps={pageProps}
-                />
-            );
+            return <FragmentComponent componentProps={componentProps} pageProps={pageProps} />;
         default:
-            return (
-                <div>{`Unimplemented component type: ${
-                    (componentProps as any).type
-                }`}</div>
-            );
+            return <div>{`Unimplemented component type: ${(componentProps as any).type}`}</div>;
     }
 };
 
 export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
     return (
-        <AuthDependantRender
-            renderOn={componentProps?.config?.renderOnAuthState}
-        >
-            <ComponentToRender
-                componentProps={componentProps}
-                pageProps={pageProps}
-            />
+        <AuthDependantRender renderOn={componentProps?.config?.renderOnAuthState}>
+            <ComponentToRender componentProps={componentProps} pageProps={pageProps} />
         </AuthDependantRender>
     );
 };

--- a/src/components/ContentMapper.tsx
+++ b/src/components/ContentMapper.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
+
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
+import { ContentTypeNotSupportedPage } from 'components/pages/contenttype-not-supported-page/ContentTypeNotSupportedPage';
+import { FormDetailsPreviewPage } from 'components/pages/form-details-preview-page/FormDetailsPreviewPage';
+import { FormsOverviewPage } from 'components/pages/forms-overview-page/FormsOverviewPage';
+import { VideoPreviewPage } from 'components/pages/video-preview-page/VideoPreviewPage';
+import { UserTestsConfigPreviewPage } from 'components/pages/user-tests-config-preview-page/UserTestsConfigPreviewPage';
+
 import { ErrorPage } from './pages/error-page/ErrorPage';
 import { DynamicPage } from './pages/dynamic-page/DynamicPage';
 import { FragmentPage } from './pages/fragment-page/FragmentPage';
@@ -22,13 +29,8 @@ import { GenericPage } from './pages/generic-page/GenericPage';
 import { CurrentTopicPage } from './pages/current-topic-page/CurrentTopicPage';
 import { PressLandingPage } from './pages/press-landing-page/PressLandingPage';
 import { PublishingCalendarEntryPage } from './parts/_legacy/publishing-calendar/PublishingCalendarEntryPage';
-import { ContentTypeNotSupportedPage } from 'components/pages/contenttype-not-supported-page/ContentTypeNotSupportedPage';
 import { FormIntermediateStepPage } from './pages/form-intermediate-step-page/FormIntermediateStepPage';
-import { FormDetailsPreviewPage } from 'components/pages/form-details-preview-page/FormDetailsPreviewPage';
-import { FormsOverviewPage } from 'components/pages/forms-overview-page/FormsOverviewPage';
-import { VideoPreviewPage } from 'components/pages/video-preview-page/VideoPreviewPage';
 import { CalculatorPage } from './pages/calculator-page/CalculatorPage';
-import { UserTestsConfigPreviewPage } from 'components/pages/user-tests-config-preview-page/UserTestsConfigPreviewPage';
 import { AlertInContextPage } from './pages/alert-in-context-page/AlertInContextPage';
 
 const contentToReactComponent: {
@@ -92,8 +94,7 @@ type Props = {
 };
 
 export const ContentMapper = ({ content }: Props) => {
-    const Component =
-        contentToReactComponent[content.type] || ContentTypeNotSupportedPage;
+    const Component = contentToReactComponent[content.type] || ContentTypeNotSupportedPage;
 
     // @ts-ignore
     return <Component {...content} />;

--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import {
-    ComponentType,
-    FragmentComponentProps,
-} from 'types/component-props/_component-common';
+
+import { ComponentType, FragmentComponentProps } from 'types/component-props/_component-common';
 import { ContentProps } from 'types/content-props/_content-common';
-import { ComponentMapper } from './ComponentMapper';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+
+import { ComponentMapper } from './ComponentMapper';
 
 type Props = {
     componentProps: FragmentComponentProps;
@@ -23,12 +22,7 @@ const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
         );
     }
 
-    return (
-        <ComponentMapper
-            pageProps={pageProps}
-            componentProps={componentProps.fragment}
-        />
-    );
+    return <ComponentMapper pageProps={pageProps} componentProps={componentProps.fragment} />;
 };
 
 export const FragmentComponent = ({ componentProps, pageProps }: Props) => {
@@ -40,18 +34,10 @@ export const FragmentComponent = ({ componentProps, pageProps }: Props) => {
 
         return (
             <div {...editorProps}>
-                <_FragmentComponent
-                    pageProps={pageProps}
-                    componentProps={componentProps}
-                />
+                <_FragmentComponent pageProps={pageProps} componentProps={componentProps} />
             </div>
         );
     }
 
-    return (
-        <_FragmentComponent
-            pageProps={pageProps}
-            componentProps={componentProps}
-        />
-    );
+    return <_FragmentComponent pageProps={pageProps} componentProps={componentProps} />;
 };

--- a/src/components/PageBase.tsx
+++ b/src/components/PageBase.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
-import { PageWrapper } from './PageWrapper';
-import { ContentMapper } from './ContentMapper';
 import { makeErrorProps } from 'utils/make-error-props';
 import { PageContextProvider } from 'store/pageContext';
+
+import { PageWrapper } from './PageWrapper';
+import { ContentMapper } from './ContentMapper';
 
 export type PageProps = {
     content: ContentProps;
@@ -12,8 +14,7 @@ export type PageProps = {
 
 export const PageBase = (props: PageProps) => {
     const content =
-        props?.content ||
-        makeErrorProps('www.nav.no', 'Ukjent feil - kunne ikke laste innhold');
+        props?.content || makeErrorProps('www.nav.no', 'Ukjent feil - kunne ikke laste innhold');
 
     return (
         <PageContextProvider content={content}>

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -1,22 +1,24 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/compat/router';
 import { onBreadcrumbClick, onLanguageSelect, setParams } from '@navikt/nav-dekoratoren-moduler';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { hookAndInterceptInternalLink, prefetchOnMouseover } from 'utils/links';
 import { hasWhiteHeader, hasWhitePage, shouldPushUpwards } from 'utils/appearance';
-import { PageWarnings } from './_page-warnings/PageWarnings';
-import { HeadWithMetatags } from './_common/metatags/HeadWithMetatags';
 import { getDecoratorParams } from 'utils/decorator/decorator-utils';
-import { DocumentParameterMetatags } from './_common/metatags/DocumentParameterMetatags';
 import { getInternalRelativePath } from 'utils/urls';
 import { store } from 'store/store';
 import { fetchAndSetInnloggingsstatus } from 'utils/fetch/fetch-innloggingsstatus';
 import { setAuthStateAction } from 'store/slices/authState';
 import { fetchAndSetMeldekortStatus } from 'utils/fetch/fetch-meldekort-status';
-import { LegacyPageChatbot } from './_common/chatbot/LegacyPageChatbot';
 import { classNames } from 'utils/classnames';
-import { EditorWidgets } from './_editor-only/EditorWidgets';
 import { isLegacyContentType } from 'utils/content-types';
+
+import { LegacyPageChatbot } from './_common/chatbot/LegacyPageChatbot';
+import { EditorWidgets } from './_editor-only/EditorWidgets';
+import { DocumentParameterMetatags } from './_common/metatags/DocumentParameterMetatags';
+import { HeadWithMetatags } from './_common/metatags/HeadWithMetatags';
+import { PageWarnings } from './_page-warnings/PageWarnings';
 
 import styles from './PageWrapper.module.scss';
 

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -1,14 +1,14 @@
 import { Accordion as DSAccordion } from '@navikt/ds-react';
+import { useState } from 'react';
+
 import { AccordionPartProps } from 'types/component-props/parts/accordion';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
-
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
+import { usePageContentProps } from 'store/pageContext';
 
 import styles from './Accordion.module.scss';
-import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
-import { useState } from 'react';
-import { usePageContentProps } from 'store/pageContext';
 
 type AccordionProps = AccordionPartProps['config'];
 type PanelItem = AccordionProps['accordion'][0];
@@ -23,31 +23,23 @@ export const Accordion = ({ accordion }: AccordionProps) => {
 
     useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
 
-    const openChangeHandler = (
-        isOpen: boolean,
-        title: string,
-        index: number
-    ) => {
+    const openChangeHandler = (isOpen: boolean, title: string, index: number) => {
         if (isOpen) {
             setOpenAccordions([...openAccordions, index]);
         } else {
             setOpenAccordions(openAccordions.filter((i) => i !== index));
         }
-        logAmplitudeEvent(
-            isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
-            {
-                tittel: title,
-                opprinnelse: 'trekkspill',
-            }
-        );
+        logAmplitudeEvent(isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND, {
+            tittel: title,
+            opprinnelse: 'trekkspill',
+        });
     };
 
     const validatePanel = (item: PanelItem) => !!(item.title && item.html);
 
     // Show all panels in edit mode, but only valid panels in view mode
     const validAccordion = accordion.filter(validatePanel);
-    const relevantAccordion =
-        editorView === 'edit' ? accordion : validAccordion;
+    const relevantAccordion = editorView === 'edit' ? accordion : validAccordion;
 
     return (
         <DSAccordion className={styles.accordion}>
@@ -58,9 +50,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                         key={index}
                         className={styles.item}
                         open={openAccordions.includes(index)}
-                        onOpenChange={(open) =>
-                            openChangeHandler(open, item.title, index)
-                        }
+                        onOpenChange={(open) => openChangeHandler(open, item.title, index)}
                     >
                         <DSAccordion.Header className={styles.header}>
                             {!isValid && (
@@ -70,11 +60,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                                     }
                                 />
                             )}
-                            {isValid && (
-                                <div className={styles.headerTitle}>
-                                    {item.title}
-                                </div>
-                            )}
+                            {isValid && <div className={styles.headerTitle}>{item.title}</div>}
                         </DSAccordion.Header>
                         <DSAccordion.Content className={styles.content}>
                             <ParsedHtml htmlProps={item.html} />

--- a/src/components/_common/alert-box/AlertBox.tsx
+++ b/src/components/_common/alert-box/AlertBox.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Alert, AlertProps } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
+
 import style from './AlertBox.module.scss';
 
 type Props = {
@@ -15,17 +17,10 @@ const role = {
     success: 'status',
     warning: 'status',
     info: undefined,
-    error: 'alert'
+    error: 'alert',
 };
 
-export const AlertBox = ({
-    variant,
-    size,
-    inline,
-    className,
-    children,
-    ...rest
-}: Props) => {
+export const AlertBox = ({ variant, size, inline, className, children, ...rest }: Props) => {
     return (
         <Alert
             {...rest}

--- a/src/components/_common/alert-in-context/AlertInContext.tsx
+++ b/src/components/_common/alert-in-context/AlertInContext.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { AlertData } from 'types/content-props/alerts';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 

--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -1,4 +1,6 @@
 import { Fragment } from 'react';
+import { BodyLong } from '@navikt/ds-react';
+
 import {
     AlternativeAudience as AlternativeAudienceType,
     Audience,
@@ -7,7 +9,6 @@ import {
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { Language, translator } from 'translations';
-import { BodyLong } from '@navikt/ds-react';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { stripXpPathPrefix } from 'utils/urls';
 import { getConjunction, joinWithConjunction } from 'utils/string';

--- a/src/components/_common/area-card/AreaCard.tsx
+++ b/src/components/_common/area-card/AreaCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { LinkPanel } from '@navikt/ds-react';
+
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { classNames } from 'utils/classnames';
-import { AreaCardGraphics } from './graphics/AreaCardGraphics';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
+
+import { AreaCardGraphics } from './graphics/AreaCardGraphics';
 
 import style from './AreaCard.module.scss';
 import graphicsStyle from './graphics/AreaCardGraphicsCommon.module.scss';
@@ -16,14 +18,7 @@ type Props = {
     className?: string;
 } & Omit<React.ComponentProps<typeof LinkPanel>, 'as'>;
 
-export const AreaCard = ({
-    path,
-    title,
-    area,
-    linkGroup,
-    className,
-    ...rest
-}: Props) => {
+export const AreaCard = ({ path, title, area, linkGroup, className, ...rest }: Props) => {
     if (!area) {
         return <EditorHelp text={'Velg en grafikk for kortet'} />;
     }
@@ -36,11 +31,7 @@ export const AreaCard = ({
             analyticsLabel={title}
             analyticsComponent={'Områdekort'}
             analyticsLinkGroup={linkGroup}
-            className={classNames(
-                style.linkPanel,
-                graphicsStyle.expandOnHover,
-                className
-            )}
+            className={classNames(style.linkPanel, graphicsStyle.expandOnHover, className)}
             as={LenkeBase}
         >
             <div

--- a/src/components/_common/area-card/graphics/AreaCardGraphics.tsx
+++ b/src/components/_common/area-card/graphics/AreaCardGraphics.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
+
 import { AreaCardGraphicsType } from 'types/component-props/parts/area-card';
+import { classNames } from 'utils/classnames';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+
 import { CasesAnimation } from './logged-in/cases/CasesAnimation';
 import { EmploymentStatusFormAnimation } from './logged-in/employment-status-form/EmploymentStatusFormAnimation';
 import { PaymentsAnimation } from './logged-in/payments/PaymentsAnimation';
@@ -9,8 +13,6 @@ import { HealthAnimation } from './open-pages/health/HealthAnimation';
 import { PensionAnimation } from './open-pages/pension/PensionAnimation';
 import { SocialCounsellingAnimation } from './open-pages/social-counselling/SocialCounsellingAnimation';
 import { WorkAnimation } from './open-pages/work/WorkAnimation';
-import { classNames } from 'utils/classnames';
-import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 import style from './AreaCardGraphics.module.scss';
 
@@ -39,17 +41,8 @@ export const AreaCardGraphics = ({ type, insideCard }: Props) => {
     const GraphicComponent = areaTypeComponentMap[type];
 
     return (
-        <div
-            className={classNames(
-                style.graphics,
-                insideCard ? style.insideCard : ''
-            )}
-        >
-            {GraphicComponent ? (
-                <GraphicComponent />
-            ) : (
-                <DefaultComponent type={type} />
-            )}
+        <div className={classNames(style.graphics, insideCard ? style.insideCard : '')}>
+            {GraphicComponent ? <GraphicComponent /> : <DefaultComponent type={type} />}
         </div>
     );
 };

--- a/src/components/_common/area-card/graphics/logged-in/cases/CasesAnimation.tsx
+++ b/src/components/_common/area-card/graphics/logged-in/cases/CasesAnimation.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
+import letterS from 'components/_common/area-card/graphics/open-pages/social-counselling/gfx/letterS.svg';
 
 import shapes from './gfx/shapes.svg';
-import letterS from 'components/_common/area-card/graphics/open-pages/social-counselling/gfx/letterS.svg';
 import document from './gfx/document.svg';
 
 import style from './CasesAnimation.module.scss';
@@ -13,11 +14,7 @@ export const CasesAnimation = () => {
             <StaticImage imageData={shapes} className={style.shapes} alt="" />
             <StaticImage imageData={letterS} className={style.letterS} alt="" />
             <div className={style.mask} />
-            <StaticImage
-                imageData={document}
-                className={style.document}
-                alt=""
-            />
+            <StaticImage imageData={document} className={style.document} alt="" />
         </>
     );
 };

--- a/src/components/_common/area-card/graphics/logged-in/employment-status-form/EmploymentStatusFormAnimation.tsx
+++ b/src/components/_common/area-card/graphics/logged-in/employment-status-form/EmploymentStatusFormAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import shapes from './gfx/shapes.svg';

--- a/src/components/_common/area-card/graphics/logged-in/payments/PaymentsAnimation.tsx
+++ b/src/components/_common/area-card/graphics/logged-in/payments/PaymentsAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import shapes from './gfx/shapes.svg';

--- a/src/components/_common/area-card/graphics/open-pages/accessibility/AccessibilityAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/accessibility/AccessibilityAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import arrow from './gfx/arrow.svg';

--- a/src/components/_common/area-card/graphics/open-pages/family/FamilyAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/family/FamilyAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import house from './gfx/house.svg';
@@ -13,11 +14,7 @@ export const FamilyAnimation = () => {
             <div className={style.letterPartOrange} />
             <div className={style.letterPartBlue} />
             <div className={style.mask} />
-            <StaticImage
-                imageData={stroller}
-                className={style.stroller}
-                alt=""
-            />
+            <StaticImage imageData={stroller} className={style.stroller} alt="" />
         </>
     );
 };

--- a/src/components/_common/area-card/graphics/open-pages/health/HealthAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/health/HealthAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import pill from './gfx/pill.svg';
@@ -13,11 +14,7 @@ export const HealthAnimation = () => {
             <div className={style.letterPartOrange} />
             <div className={style.letterPartBlue} />
             <div className={style.mask} />
-            <StaticImage
-                imageData={stethoscope}
-                className={style.stethoscope}
-                alt=""
-            />
+            <StaticImage imageData={stethoscope} className={style.stethoscope} alt="" />
         </>
     );
 };

--- a/src/components/_common/area-card/graphics/open-pages/pension/PensionAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/pension/PensionAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import shapes from './gfx/shapes.svg';
@@ -11,17 +12,9 @@ export const PensionAnimation = () => {
     return (
         <>
             <StaticImage imageData={shapes} className={style.shapes} alt="" />
-            <StaticImage
-                imageData={letterPartBlue}
-                className={style.letterPartBlue}
-                alt=""
-            />
+            <StaticImage imageData={letterPartBlue} className={style.letterPartBlue} alt="" />
             <div className={style.mask} />
-            <StaticImage
-                imageData={piggyBank}
-                className={style.piggyBank}
-                alt=""
-            />
+            <StaticImage imageData={piggyBank} className={style.piggyBank} alt="" />
             <div className={style.coin} />
         </>
     );

--- a/src/components/_common/area-card/graphics/open-pages/social-counselling/SocialCounsellingAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/social-counselling/SocialCounsellingAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import compass from './gfx/compass.svg';

--- a/src/components/_common/area-card/graphics/open-pages/work/WorkAnimation.tsx
+++ b/src/components/_common/area-card/graphics/open-pages/work/WorkAnimation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
 import { classNames } from 'utils/classnames';
 
@@ -10,19 +11,11 @@ import style from './WorkAnimation.module.scss';
 export const WorkAnimation = () => {
     return (
         <>
-            <StaticImage
-                imageData={shapes}
-                className={classNames(style.shapes)}
-                alt=""
-            />
+            <StaticImage imageData={shapes} className={classNames(style.shapes)} alt="" />
             <div className={classNames(style.letterPartOrange)} />
             <div className={classNames(style.letterPartBlue)} />
             <div className={classNames(style.mask)} />
-            <StaticImage
-                imageData={briefcase}
-                className={classNames(style.briefcase)}
-                alt=""
-            />
+            <StaticImage imageData={briefcase} className={classNames(style.briefcase)} alt="" />
         </>
     );
 };

--- a/src/components/_common/auth-dependant-render/AuthDependantRender.tsx
+++ b/src/components/_common/auth-dependant-render/AuthDependantRender.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { useAuthState } from 'store/hooks/useAuthState';
 import { AuthStateType } from 'store/slices/authState';
 import { usePageContentProps } from 'store/pageContext';
@@ -8,18 +9,14 @@ import { useLayoutEffectClientSide } from 'utils/react';
 // eslint-disable-next-line css-modules/no-unused-class
 import style from './AuthDependantRender.module.scss';
 
-export const editorAuthstateClassname = (authState: AuthStateType) =>
-    style[authState];
+export const editorAuthstateClassname = (authState: AuthStateType) => style[authState];
 
 type Props = {
     renderOn: AuthStateType | 'always';
     children: React.ReactNode;
 };
 
-export const AuthDependantRender = ({
-    children,
-    renderOn = 'always',
-}: Props) => {
+export const AuthDependantRender = ({ children, renderOn = 'always' }: Props) => {
     const { editorView } = usePageContentProps();
     const { authState } = useAuthState();
     const [shouldRender, setShouldRender] = useState(renderOn !== 'loggedIn');

--- a/src/components/_common/button/Button.tsx
+++ b/src/components/_common/button/Button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Button as DsButton, ButtonProps } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { XpImageProps } from 'types/media';
 import { XpImage } from 'components/_common/image/XpImage';
-import { Button as DsButton, ButtonProps } from '@navikt/ds-react';
 
 import style from './Button.module.scss';
 
@@ -40,11 +41,7 @@ export const Button = ({
         <DsButton
             as={LenkeBase}
             href={href || '#'}
-            className={classNames(
-                style.button,
-                fullWidth && style.buttonFullWidth,
-                className
-            )}
+            className={classNames(style.button, fullWidth && style.buttonFullWidth, className)}
             onClick={(e) => {
                 if (!href) {
                     e.preventDefault();

--- a/src/components/_common/calculator/Calculator.tsx
+++ b/src/components/_common/calculator/Calculator.tsx
@@ -1,19 +1,19 @@
 import React, { FormEvent, useState } from 'react';
 import { Heading } from '@navikt/ds-react';
-import { Button } from 'components/_common/button/Button';
 import { CalculatorIcon } from '@navikt/aksel-icons';
+
+import { Button } from 'components/_common/button/Button';
 import { translator } from 'translations';
 import { CalculatorField } from 'components/_common/calculator/CalculatorField';
-import { CalculatorResult } from './CalculatorResult';
-import {
-    CalculatorData,
-    CalculatorFieldData,
-} from 'types/component-props/parts/calculator';
+import { CalculatorData, CalculatorFieldData } from 'types/component-props/parts/calculator';
 import { usePageContentProps } from 'store/pageContext';
+
+import { CalculatorResult } from './CalculatorResult';
+
+import style from './Calculator.module.scss';
 
 // TODO: Add better data validation and enforce input on the backend
 // for fields which should not be optional
-import style from './Calculator.module.scss';
 
 type FieldRecord = Record<string, number | null>;
 
@@ -75,9 +75,7 @@ export const Calculator = ({ header, calculatorData }: Props) => {
 
     const { language } = usePageContentProps();
 
-    const [fieldValues, setFieldValues] = useState<FieldRecord>(
-        populateDefaultValues(fields)
-    );
+    const [fieldValues, setFieldValues] = useState<FieldRecord>(populateDefaultValues(fields));
     const [calculatedValue, setCalculatedValue] = useState(null);
     const [errorMessage, setErrorMessage] = useState('');
 
@@ -112,9 +110,7 @@ export const Calculator = ({ header, calculatorData }: Props) => {
 
         // Make sure that calculator script from Enonic only returns numbers.
         try {
-            const calculated = calculationFactory(variableNames)(
-                ...variableValues
-            );
+            const calculated = calculationFactory(variableNames)(...variableValues);
             setCalculatedValue(calculated);
         } catch (error: any) {
             setErrorMessage(`${error.name}: ${error.message}`);
@@ -145,8 +141,7 @@ export const Calculator = ({ header, calculatorData }: Props) => {
                     {fields
                         .filter((field) => !field.globalValue)
                         .map((field) => {
-                            const fieldKey = (field.dropdownField
-                                ?.variableName ||
+                            const fieldKey = (field.dropdownField?.variableName ||
                                 field.inputField?.variableName) as string;
 
                             return (
@@ -165,10 +160,7 @@ export const Calculator = ({ header, calculatorData }: Props) => {
                     onClick={handleCalculateButtonClick}
                     className={style.calculateButton}
                     dsIcon={
-                        <CalculatorIcon
-                            title={'Kalkulator-ikon'}
-                            className={style.calculateIcon}
-                        />
+                        <CalculatorIcon title={'Kalkulator-ikon'} className={style.calculateIcon} />
                     }
                 >
                     <span>{getLabel('calculate')}</span>

--- a/src/components/_common/calculator/CalculatorField.tsx
+++ b/src/components/_common/calculator/CalculatorField.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Select, TextField } from '@navikt/ds-react';
+
 import { CalculatorFieldData } from 'types/component-props/parts/calculator';
 
 import style from './Field.module.scss';
@@ -34,12 +35,7 @@ export const CalculatorField = (props: Props) => {
                     label={field.inputField.label}
                     type="number"
                     value={value?.toString() || ''}
-                    onChange={(e) =>
-                        onChange(
-                            field.inputField.variableName,
-                            e.currentTarget.value
-                        )
-                    }
+                    onChange={(e) => onChange(field.inputField.variableName, e.currentTarget.value)}
                     autoComplete={autoComplete ? 'on' : 'off'}
                 />
             )}
@@ -48,10 +44,7 @@ export const CalculatorField = (props: Props) => {
                     label={field.dropdownField.label}
                     name={field.dropdownField.variableName}
                     onChange={(e) =>
-                        onChange(
-                            field.dropdownField.variableName,
-                            e.currentTarget.value
-                        )
+                        onChange(field.dropdownField.variableName, e.currentTarget.value)
                     }
                     value={value || ''}
                     autoComplete={autoComplete ? 'on' : 'off'}

--- a/src/components/_common/calculator/CalculatorResult.tsx
+++ b/src/components/_common/calculator/CalculatorResult.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Panel } from '@navikt/ds-react';
+
 import { translator } from 'translations';
 import { insertHTMLBreaks, numberToFormattedValue } from 'utils/string';
 import { usePageContentProps } from 'store/pageContext';

--- a/src/components/_common/card/LargeCard.tsx
+++ b/src/components/_common/card/LargeCard.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import { BodyLong, BodyShort } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { CardSize, CardType } from 'types/card';
-import { BodyLong, BodyShort } from '@navikt/ds-react';
 import { Illustration } from 'components/_common/illustration/Illustration';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { LinkProps } from 'types/link-props';
-import { useCard } from './useCard';
 import { usePageContentProps } from 'store/pageContext';
+
+import { useCard } from './useCard';
 
 import style from './LargeCard.module.scss';
 import sharedStyle from './Card.module.scss';
@@ -34,14 +36,7 @@ type Props = {
 };
 
 export const LargeCard = (props: Props) => {
-    const {
-        link,
-        description,
-        type,
-        category,
-        illustration,
-        preferStaticIllustration,
-    } = props;
+    const { link, description, type, category, illustration, preferStaticIllustration } = props;
     const { text } = link;
 
     const hasIllustration = illustration && cardTypesWithIllustration.has(type);
@@ -55,9 +50,7 @@ export const LargeCard = (props: Props) => {
     const { editorView } = usePageContentProps();
 
     const layoutVariation =
-        type === CardType.Situation
-            ? LayoutVariation.SITUATION
-            : LayoutVariation.DEFAULT;
+        type === CardType.Situation ? LayoutVariation.SITUATION : LayoutVariation.DEFAULT;
 
     return (
         <div {...userEventProps} className={classNames(sharedStyle.card)}>
@@ -74,28 +67,20 @@ export const LargeCard = (props: Props) => {
                             className={style.illustration}
                             isHovering={isHovering}
                             preferStaticIllustration={
-                                editorView === 'edit' ||
-                                preferStaticIllustration
+                                editorView === 'edit' || preferStaticIllustration
                             }
                         />
                     )}
                     <LenkeBase
                         href={link.url}
                         {...analyticsProps}
-                        className={classNames(
-                            style.title,
-                            sharedStyle.lenkeBaseOverride
-                        )}
+                        className={classNames(style.title, sharedStyle.lenkeBaseOverride)}
                     >
                         {text}
                     </LenkeBase>
                     <div className={style.textContainer}>
-                        <BodyLong className={style.description}>
-                            {description}
-                        </BodyLong>
-                        <BodyShort className={style.category}>
-                            {category}
-                        </BodyShort>
+                        <BodyLong className={style.description}>{description}</BodyLong>
+                        <BodyShort className={style.category}>{category}</BodyShort>
                     </div>
                 </div>
             </div>

--- a/src/components/_common/card/MicroCard.tsx
+++ b/src/components/_common/card/MicroCard.tsx
@@ -1,25 +1,21 @@
 import React from 'react';
+import { BodyShort } from '@navikt/ds-react';
+
 import { LinkProps } from 'types/link-props';
 import { CardSize, CardType } from 'types/card';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { useCard } from './useCard';
 import { classNames } from 'utils/classnames';
 import { TargetPage } from 'types/component-props/parts/product-card';
 import { CardProps, getCardProps } from 'components/_common/card/card-utils';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { BodyShort } from '@navikt/ds-react';
 import { usePageContentProps } from 'store/pageContext';
+
+import { useCard } from './useCard';
 
 import sharedStyle from './Card.module.scss';
 import style from './MicroCard.module.scss';
 
-export const MicroCard = ({
-    link,
-    type,
-}: {
-    link: LinkProps;
-    type: CardType;
-}) => {
+export const MicroCard = ({ link, type }: { link: LinkProps; type: CardType }) => {
     const { analyticsProps } = useCard({ type, size: CardSize.Micro, link });
     return (
         <LenkeBase
@@ -27,9 +23,7 @@ export const MicroCard = ({
             {...analyticsProps}
             className={classNames(sharedStyle.card, sharedStyle.inline)}
         >
-            <div className={classNames(sharedStyle.bed, style.micro, type)}>
-                {link.text}
-            </div>
+            <div className={classNames(sharedStyle.bed, style.micro, type)}>{link.text}</div>
         </LenkeBase>
     );
 };
@@ -52,11 +46,7 @@ export const MicroCards = ({ header, card_list }: Props) => {
     }, []);
 
     if (cardProps.length === 0) {
-        return (
-            <EditorHelp
-                text={'Velg minst én lenke for å aktivere mikrokortene'}
-            />
-        );
+        return <EditorHelp text={'Velg minst én lenke for å aktivere mikrokortene'} />;
     }
 
     return (

--- a/src/components/_common/card/MiniCard.tsx
+++ b/src/components/_common/card/MiniCard.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { BodyShort } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { CardSize, CardType } from 'types/card';
 import { Illustration } from 'components/_common/illustration/Illustration';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { LinkProps } from 'types/link-props';
-import { useCard } from './useCard';
 import { usePageContentProps } from 'store/pageContext';
+
+import { useCard } from './useCard';
 
 import sharedStyle from './Card.module.scss';
 import style from './MiniCard.module.scss';
@@ -48,25 +50,17 @@ export const MiniCard = (props: MiniKortProps) => {
                     {header}
                 </BodyShort>
             )}
-            <div
-                {...userEventProps}
-                className={classNames(sharedStyle.card, className)}
-            >
+            <div {...userEventProps} className={classNames(sharedStyle.card, className)}>
                 <div className={classNames(sharedStyle.bed, style.mini, type)}>
                     <Illustration
                         className={style.illustration}
                         illustration={illustration}
                         isHovering={isHovering}
-                        preferStaticIllustration={
-                            preferStaticIllustration || editorView === 'edit'
-                        }
+                        preferStaticIllustration={preferStaticIllustration || editorView === 'edit'}
                         withFallbackIllustration={withFallbackIllustration}
                     />
                     <LenkeBase
-                        className={classNames(
-                            sharedStyle.lenkeBaseOverride,
-                            style.title
-                        )}
+                        className={classNames(sharedStyle.lenkeBaseOverride, style.title)}
                         href={link.url}
                         {...analyticsProps}
                     >

--- a/src/components/_common/card/card-utils.ts
+++ b/src/components/_common/card/card-utils.ts
@@ -32,10 +32,7 @@ export const cardTypeMap = {
     [ContentType.GenericPage]: CardType.Generic,
 };
 
-const getCardCategory = (
-    content: CardTargetProps,
-    language: Language
-): string[] => {
+const getCardCategory = (content: CardTargetProps, language: Language): string[] => {
     const { data } = content;
     const { taxonomy = [], customCategory, audience } = data;
     const selectedAudience = audience && getAudience(audience);

--- a/src/components/_common/card/overview-microcard/OverviewMicroCards.tsx
+++ b/src/components/_common/card/overview-microcard/OverviewMicroCards.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BodyShort } from '@navikt/ds-react';
+
 import { MicroCard } from 'components/_common/card/MicroCard';
 import { cardTypeMap } from 'components/_common/card/card-utils';
 import { Language, translator } from 'translations';
@@ -44,11 +45,7 @@ const CardsHeader = ({ text }: { text: string }) => (
     <BodyShort weight={'semibold'}>{text}</BodyShort>
 );
 
-const CardsList = ({
-    productLinks,
-}: {
-    productLinks: OverviewPageProductLink[];
-}) =>
+const CardsList = ({ productLinks }: { productLinks: OverviewPageProductLink[] }) =>
     productLinks.map((productLink) => (
         <MicroCard
             type={cardTypeMap[productLink.type]}
@@ -71,8 +68,10 @@ export const OverviewMicroCards = ({ productLinks, className }: Props) => {
 
     const headingText = translator('overview', pageLanguage)('more');
 
-    const { withStandardReadMore, withEnglishWarningReadMore } =
-        splitByHeaderType(productLinks, pageLanguage);
+    const { withStandardReadMore, withEnglishWarningReadMore } = splitByHeaderType(
+        productLinks,
+        pageLanguage
+    );
 
     return (
         <div className={className}>

--- a/src/components/_common/card/useCard.tsx
+++ b/src/components/_common/card/useCard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { useState } from 'react';
 import { useRouter } from 'next/compat/router';
+
+import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { CardSize, CardType } from 'types/card';
 import { Interaction } from 'types/interaction';
 import { LinkProps } from 'types/link-props';

--- a/src/components/_common/chatbot/ChatbotLinkPanel.tsx
+++ b/src/components/_common/chatbot/ChatbotLinkPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { LinkPanelNavno } from 'components/_common/linkpanel/LinkPanelNavno';
 import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
+
+import { LinkPanelNavno } from 'components/_common/linkpanel/LinkPanelNavno';
 import { FrontpageContactAlert } from 'components/parts/frontpage-contact/FrontpageContactAlert';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 
@@ -13,12 +14,7 @@ type Props = {
     ingress: string;
 };
 
-export const ChatbotLinkPanel = ({
-    analyticsGroup,
-    linkText,
-    alertText,
-    ingress,
-}: Props) => {
+export const ChatbotLinkPanel = ({ analyticsGroup, linkText, alertText, ingress }: Props) => {
     return (
         <LinkPanelNavno
             className={style.chat}

--- a/src/components/_common/chatbot/LegacyPageChatbot.tsx
+++ b/src/components/_common/chatbot/LegacyPageChatbot.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { ChatbotLinkPanel } from './ChatbotLinkPanel';
+
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { Language, translator } from 'translations';
+
+import { ChatbotLinkPanel } from './ChatbotLinkPanel';
 
 import style from './LegacyPageChatbot.module.scss';
 

--- a/src/components/_common/chevron/Chevron.tsx
+++ b/src/components/_common/chevron/Chevron.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { ChevronRightIcon, ChevronDownIcon, ChevronLeftIcon, ChevronUpIcon } from '@navikt/aksel-icons';
+import {
+    ChevronRightIcon,
+    ChevronDownIcon,
+    ChevronLeftIcon,
+    ChevronUpIcon,
+} from '@navikt/aksel-icons';
 
 type Props = {
     direction?: 'Up' | 'Right' | 'Down' | 'Left';
@@ -14,7 +19,5 @@ const ChevronIcon = {
 
 export const Chevron = ({ direction = 'Right', className }: Props) => {
     const Icon = ChevronIcon[direction];
-    return (
-        <Icon className={className}  aria-hidden="true" />
-    );
+    return <Icon className={className} aria-hidden="true" />;
 };

--- a/src/components/_common/chevron/FancyChevron.tsx
+++ b/src/components/_common/chevron/FancyChevron.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+
 import { classNames } from 'utils/classnames';
 import { StaticImage } from 'components/_common/image/StaticImage';
 
-import style from './FancyChevron.module.scss';
-
 import chevron from './chevron_icon.svg';
+
+import style from './FancyChevron.module.scss';
 
 type Props = {
     color: 'white' | 'blue';
@@ -16,30 +17,17 @@ export const FancyChevron = ({ color, scale, className }: Props) => {
     return (
         <div
             className={classNames(className, style.scaleWrapper)}
-            style={
-                scale
-                    ? ({ '--scale': scale } as React.CSSProperties)
-                    : undefined
-            }
+            style={scale ? ({ '--scale': scale } as React.CSSProperties) : undefined}
             aria-hidden={true}
         >
-            <div
-                className={classNames(
-                    style.outer,
-                    color === 'blue' && style.blue
-                )}
-            >
+            <div className={classNames(style.outer, color === 'blue' && style.blue)}>
                 <div className={classNames(style.line1, style.colorLine)} />
                 <div className={style.line2} />
                 <div className={style.line3} />
                 <div className={style.line5} />
                 <div className={classNames(style.line6, style.colorLine)} />
                 <div className={style.circle} />
-                <StaticImage
-                    imageData={chevron}
-                    alt={''}
-                    className={style.chevron}
-                />
+                <StaticImage imageData={chevron} alt={''} className={style.chevron} />
             </div>
         </div>
     );

--- a/src/components/_common/contact-option/CallOption.tsx
+++ b/src/components/_common/contact-option/CallOption.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { translator } from 'translations';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+
+import { translator } from 'translations';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { TelephoneData } from 'types/component-props/parts/contact-option';
 import { AnalyticsEvents } from 'utils/amplitude';
@@ -10,10 +11,8 @@ import { OpeningInfo } from 'components/_common/contact-option/opening-info/Open
 import { Audience, getAudience } from 'types/component-props/_mixins';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { usePageContentProps } from 'store/pageContext';
-import {
-    hoverFocusIcon,
-    useHoverAndFocus,
-} from './opening-info/helpers/iconUtils';
+
+import { hoverFocusIcon, useHoverAndFocus } from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 
@@ -57,9 +56,7 @@ export const CallOption = ({
     const sharedTranslations = getContactTranslations('shared');
 
     const getContactUrl = () => {
-        const audienceUrls = audience
-            ? contactURLs[getAudience(audience)]
-            : null;
+        const audienceUrls = audience ? contactURLs[getAudience(audience)] : null;
         if (!audienceUrls) {
             return contactURLs.person.no;
         }
@@ -100,12 +97,7 @@ export const CallOption = ({
             )}
             <BodyLong className={style.text}>
                 <ParsedHtml
-                    htmlProps={
-                        overrideText ||
-                        ingress ||
-                        text ||
-                        callTranslations.ingress
-                    }
+                    htmlProps={overrideText || ingress || text || callTranslations.ingress}
                 />
             </BodyLong>
             {!alertText && regularOpeningHours && specialOpeningHours && (

--- a/src/components/_common/contact-option/ChatOption.tsx
+++ b/src/components/_common/contact-option/ChatOption.tsx
@@ -1,30 +1,23 @@
 import React from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
+
 import { ChatData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { AnalyticsEvents } from 'utils/amplitude';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
-import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import TextWithIndicator from 'components/_common/text-with-indicator/TextWithIndicator';
+
 import { OpeningInfo } from './opening-info/OpeningInfo';
-import {
-    hoverFocusIcon,
-    useHoverAndFocus,
-} from './opening-info/helpers/iconUtils';
+import { hoverFocusIcon, useHoverAndFocus } from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 
 export const ChatOption = (props: ChatData) => {
-    const {
-        ingress,
-        title,
-        alertText,
-        regularOpeningHours,
-        specialOpeningHours,
-    } = props;
+    const { ingress, title, alertText, regularOpeningHours, specialOpeningHours } = props;
     const overrideText = specialOpeningHours?.overrideText;
 
     const { language } = usePageContentProps();
@@ -66,9 +59,7 @@ export const ChatOption = (props: ChatData) => {
                 </Alert>
             )}
             <BodyLong as="div" className={style.text}>
-                <ParsedHtml
-                    htmlProps={overrideText || ingress || translations.ingress}
-                />
+                <ParsedHtml htmlProps={overrideText || ingress || translations.ingress} />
             </BodyLong>
             {!alertText && (
                 <TextWithIndicator

--- a/src/components/_common/contact-option/DefaultOption.tsx
+++ b/src/components/_common/contact-option/DefaultOption.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import { BodyLong, Heading } from '@navikt/ds-react';
-import {
-    ChannelType,
-    DefaultContactData,
-} from 'types/component-props/parts/contact-option';
+import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
+
+import { ChannelType, DefaultContactData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { AnalyticsEvents } from 'utils/amplitude';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
-import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import Config from 'config';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import {
-    hoverFocusIcon,
-    useHoverAndFocus,
-} from './opening-info/helpers/iconUtils';
+
+import { hoverFocusIcon, useHoverAndFocus } from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 
@@ -88,12 +84,10 @@ export const DefaultOption = (props: Props) => {
         return { href: '#' };
     };
 
-    const titleActual =
-        title || (channel !== 'custom' ? getTranslations(channel).title : null);
+    const titleActual = title || (channel !== 'custom' ? getTranslations(channel).title : null);
 
     const ingressActual =
-        ingress ||
-        (channel !== 'custom' ? getTranslations(channel).ingress : null);
+        ingress || (channel !== 'custom' ? getTranslations(channel).ingress : null);
 
     const iconName = icon || 'place';
     const iconElement = hoverFocusIcon({

--- a/src/components/_common/contact-option/WriteOption.tsx
+++ b/src/components/_common/contact-option/WriteOption.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+
 import { WriteData } from 'types/component-props/parts/contact-option';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
@@ -7,10 +8,8 @@ import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import Config from 'config';
-import {
-    hoverFocusIcon,
-    useHoverAndFocus,
-} from './opening-info/helpers/iconUtils';
+
+import { hoverFocusIcon, useHoverAndFocus } from './opening-info/helpers/iconUtils';
 
 import style from './ContactOption.module.scss';
 

--- a/src/components/_common/contact-option/opening-info/OpeningInfo.tsx
+++ b/src/components/_common/contact-option/opening-info/OpeningInfo.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { Loader } from '@navikt/ds-react';
+
 import { getCurrentOpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoUtils';
 import { usePageContentProps } from 'store/pageContext';
 import { OpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoTypes';
 import { getOpeningInfoText } from 'components/_common/contact-option/opening-info/helpers/openingInfoText';
 import { processOpeningHours } from 'components/_common/contact-option/opening-info/helpers/processOpeningHours';
-import { Loader } from '@navikt/ds-react';
 import {
     RegularOpeningHours,
     SpecialOpeningHours,
@@ -17,15 +18,10 @@ type Props = {
     textPrefix?: string;
 };
 
-export const OpeningInfo = ({
-    regularOpeningHours,
-    specialOpeningHours,
-    textPrefix,
-}: Props) => {
+export const OpeningInfo = ({ regularOpeningHours, specialOpeningHours, textPrefix }: Props) => {
     const { language } = usePageContentProps();
 
-    const [currentOpeningHours, setCurrentOpeningHours] =
-        useState<OpeningHours | null>(null);
+    const [currentOpeningHours, setCurrentOpeningHours] = useState<OpeningHours | null>(null);
     const [openingInfoText, setOpeningInfoText] = useState('');
 
     useEffect(() => {

--- a/src/components/_common/contact-option/opening-info/helpers/openingInfo.test.ts
+++ b/src/components/_common/contact-option/opening-info/helpers/openingInfo.test.ts
@@ -70,19 +70,13 @@ const specialOpeningHours: OpeningHourSpecialRaw[] = [
 ];
 
 const getOpeningInfo = () => {
-    const openingHours = processOpeningHours(
-        regularOpeningHours,
-        specialOpeningHours
-    );
+    const openingHours = processOpeningHours(regularOpeningHours, specialOpeningHours);
 
     return getCurrentOpeningHours(openingHours);
 };
 
 const getInfoText = () => {
-    const allOpeningInfo = processOpeningHours(
-        regularOpeningHours,
-        specialOpeningHours
-    );
+    const allOpeningInfo = processOpeningHours(regularOpeningHours, specialOpeningHours);
 
     const currentOpeningInfo = getCurrentOpeningHours(allOpeningInfo);
 
@@ -189,9 +183,7 @@ describe('Opening information text', () => {
 
         const text = getInfoText();
 
-        const expectedText = translator('contactPoint', 'no')('shared')[
-            'openNow'
-        ];
+        const expectedText = translator('contactPoint', 'no')('shared')['openNow'];
 
         expect(text).toBe(expectedText);
     });
@@ -201,9 +193,7 @@ describe('Opening information text', () => {
 
         const text = getInfoText();
 
-        const expectedText = translator('contactPoint', 'no')('shared')[
-            'closedNow'
-        ];
+        const expectedText = translator('contactPoint', 'no')('shared')['closedNow'];
 
         expect(text).toContain(expectedText);
     });
@@ -213,12 +203,8 @@ describe('Opening information text', () => {
 
         const text = getInfoText();
 
-        const expectedText1 = translator('contactPoint', 'no')('shared')[
-            'closedNow'
-        ];
-        const expectedText2 = translator('dateTime', 'no')('relatives')[
-            'tomorrow'
-        ];
+        const expectedText1 = translator('contactPoint', 'no')('shared')['closedNow'];
+        const expectedText2 = translator('dateTime', 'no')('relatives')['tomorrow'];
 
         expect(text).toContain(expectedText1);
         expect(text).toContain(expectedText2);
@@ -229,17 +215,12 @@ describe('Opening information text', () => {
 
         const text = getInfoText();
 
-        const expectedText1 = translator('contactPoint', 'no')('shared')[
-            'closedNow'
-        ];
+        const expectedText1 = translator('contactPoint', 'no')('shared')['closedNow'];
         const expectedText2 = translator('contactPoint', 'no')('shared')
             ['opensAt'].replace('{$date}', '(.*)')
             .replace('{$time}', '(.*)');
 
-        const expectedTextPattern = new RegExp(
-            `${expectedText1}(.*)${expectedText2}`,
-            'i'
-        );
+        const expectedTextPattern = new RegExp(`${expectedText1}(.*)${expectedText2}`, 'i');
 
         expect(text).toMatch(expectedTextPattern);
     });

--- a/src/components/_common/contact-option/opening-info/helpers/openingInfoText.ts
+++ b/src/components/_common/contact-option/opening-info/helpers/openingInfoText.ts
@@ -1,4 +1,7 @@
 import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
 import {
     OpeningHours,
     OpeningHoursOpen,
@@ -10,24 +13,17 @@ import {
     openingHourDateFormat,
     openingHourTimeFormat,
 } from 'components/_common/contact-option/opening-info/helpers/openingInfoUtils';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
 const MAX_FUTURE_DAYS_TO_CHECK = 7;
 
-const getNextOpenOpeningHour = (
-    openingHours: OpeningHours[]
-): OpeningHoursOpen | null => {
+const getNextOpenOpeningHour = (openingHours: OpeningHours[]): OpeningHoursOpen | null => {
     const tomorrow = dayjs().add(1, 'day');
 
     for (let i = 0; i < MAX_FUTURE_DAYS_TO_CHECK; i++) {
-        const found = getOpeningHoursForDateTime(
-            openingHours,
-            tomorrow.add(i, 'day')
-        );
+        const found = getOpeningHoursForDateTime(openingHours, tomorrow.add(i, 'day'));
 
         if (found?.status !== 'CLOSED') {
             return found;
@@ -52,10 +48,7 @@ const getDayOfWeek = (dayJs: Dayjs, language: Language) => {
     return language === 'en' ? dayOfWeek : dayOfWeek.toLowerCase();
 };
 
-const buildFutureOpenString = (
-    { date, from }: OpeningHoursOpen,
-    language: Language
-) => {
+const buildFutureOpenString = ({ date, from }: OpeningHoursOpen, language: Language) => {
     const relatives = translator('dateTime', language)('relatives');
     const sharedTranslations = translator('contactPoint', language)('shared');
 

--- a/src/components/_common/contact-option/opening-info/helpers/openingInfoUtils.ts
+++ b/src/components/_common/contact-option/opening-info/helpers/openingInfoUtils.ts
@@ -1,9 +1,10 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { OpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoTypes';
-import { daysNameArray, norwayTz } from 'utils/datetime';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+
+import { daysNameArray, norwayTz } from 'utils/datetime';
+import { OpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoTypes';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -16,17 +17,13 @@ export const getOpeningHoursForDateTime = (
     openingHours: OpeningHours[],
     dateTime: Dayjs
 ): OpeningHours =>
-    openingHours.find((openingHour) =>
-        dateTime.isSame(openingHour.date, 'day')
-    ) || {
+    openingHours.find((openingHour) => dateTime.isSame(openingHour.date, 'day')) || {
         status: 'CLOSED',
         dayName: daysNameArray[dateTime.day()],
         date: dateTime.format(openingHourDateFormat),
     };
 
-export const getCurrentOpeningHours = (
-    openingHours: OpeningHours[]
-): OpeningHours => {
+export const getCurrentOpeningHours = (openingHours: OpeningHours[]): OpeningHours => {
     const now = dayjs();
     const openingHour = getOpeningHoursForDateTime(openingHours, now);
 

--- a/src/components/_common/contact-option/opening-info/helpers/processOpeningHours.ts
+++ b/src/components/_common/contact-option/opening-info/helpers/processOpeningHours.ts
@@ -1,11 +1,12 @@
-import { OpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoTypes';
 import dayjs, { Dayjs } from 'dayjs';
-import { dayNameToIndex, daysNameArray } from 'utils/datetime';
-import { openingHourDateFormat } from 'components/_common/contact-option/opening-info/helpers/openingInfoUtils';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+
+import { openingHourDateFormat } from 'components/_common/contact-option/opening-info/helpers/openingInfoUtils';
+import { dayNameToIndex, daysNameArray } from 'utils/datetime';
+import { OpeningHours } from 'components/_common/contact-option/opening-info/helpers/openingInfoTypes';
 import {
     OpeningHourRaw,
     OpeningHourRegularRaw,
@@ -41,21 +42,11 @@ const transformOpeningHour = ({
     return { ...commonProps, status: 'OPEN', from, to };
 };
 
-const getSpecialOpeningHour = (
-    specialOpeningHours: OpeningHourSpecialRaw[],
-    day: Dayjs
-) =>
-    specialOpeningHours.find((openingHour) =>
-        day.isSame(openingHour.date, 'day')
-    );
+const getSpecialOpeningHour = (specialOpeningHours: OpeningHourSpecialRaw[], day: Dayjs) =>
+    specialOpeningHours.find((openingHour) => day.isSame(openingHour.date, 'day'));
 
-const getRegularOpeningHour = (
-    regularOpeningHours: OpeningHourRegularRaw[],
-    day: Dayjs
-) =>
-    regularOpeningHours.find(
-        (openingHour) => day.day() === dayNameToIndex[openingHour.dayName]
-    );
+const getRegularOpeningHour = (regularOpeningHours: OpeningHourRegularRaw[], day: Dayjs) =>
+    regularOpeningHours.find((openingHour) => day.day() === dayNameToIndex[openingHour.dayName]);
 
 export const processOpeningHours = (
     regularOpeningHours: OpeningHourRegularRaw[] = [],
@@ -74,9 +65,7 @@ export const processOpeningHours = (
             getSpecialOpeningHour(specialOpeningHours, dayToCheck) ||
             getRegularOpeningHour(regularOpeningHours, dayToCheck);
 
-        openingHours.push(
-            transformOpeningHour({ openingHour, day: dayToCheck })
-        );
+        openingHours.push(transformOpeningHour({ openingHour, day: dayToCheck }));
     }
 
     return openingHours;

--- a/src/components/_common/content-list/ContentList.tsx
+++ b/src/components/_common/content-list/ContentList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentListProps } from 'types/content-props/content-list-props';
 import { LinkProps } from 'types/link-props';
 import { Lenkeliste } from 'components/_common/lenkeliste/Lenkeliste';
@@ -11,12 +12,9 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ListType } from 'types/component-props/parts/link-list';
 
 const getDate = (content: ContentProps, dateLabelKey?: DateTimeKey): string => {
-    const dateLabel =
-        dateLabelKey && getNestedValueFromKeyString(content, dateLabelKey);
+    const dateLabel = dateLabelKey && getNestedValueFromKeyString(content, dateLabelKey);
 
-    return typeof dateLabel === 'string'
-        ? dateLabel
-        : getPublishedDateTime(content);
+    return typeof dateLabel === 'string' ? dateLabel : getPublishedDateTime(content);
 };
 
 type Props = {

--- a/src/components/_common/copyLink/copyLink.tsx
+++ b/src/components/_common/copyLink/copyLink.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
+import { LinkIcon } from '@navikt/aksel-icons';
+
 import { translator } from 'translations';
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
-import { LinkIcon } from '@navikt/aksel-icons';
 
 import style from './copyLink.module.scss';
 
@@ -17,12 +18,7 @@ type CopyLinkProps = {
 
 const linkCopiedDisplayTimeMs = 2500;
 
-export const CopyLink = ({
-    anchor,
-    heading,
-    label,
-    className,
-}: CopyLinkProps) => {
+export const CopyLink = ({ anchor, heading, label, className }: CopyLinkProps) => {
     const [showCopyTooltip, setShowCopyTooltip] = useState(false);
     const { language } = usePageContentProps();
     const { layoutConfig } = useLayoutConfig();
@@ -36,16 +32,11 @@ export const CopyLink = ({
         e.preventDefault();
 
         if (navigator?.clipboard?.writeText) {
-            const baseUrl = (e.target as HTMLAnchorElement)?.baseURI?.split(
-                '#'
-            )[0];
+            const baseUrl = (e.target as HTMLAnchorElement)?.baseURI?.split('#')[0];
             if (baseUrl) {
                 navigator?.clipboard?.writeText(`${baseUrl}${anchor}`);
                 setShowCopyTooltip(true);
-                setTimeout(
-                    () => setShowCopyTooltip(false),
-                    linkCopiedDisplayTimeMs
-                );
+                setTimeout(() => setShowCopyTooltip(false), linkCopiedDisplayTimeMs);
             }
             logAmplitudeEvent(AnalyticsEvents.COPY_LINK, {
                 seksjon: layoutConfig.title,

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Accordion } from '@navikt/ds-react';
+
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
@@ -15,13 +16,7 @@ type Props = {
     children: React.ReactNode;
 };
 
-export const Expandable = ({
-    title,
-    anchorId,
-    analyticsOriginTag,
-    children,
-    className,
-}: Props) => {
+export const Expandable = ({ title, anchorId, analyticsOriginTag, children, className }: Props) => {
     const [isOpen, setIsOpen] = useState(false);
     const accordionRef = useRef<HTMLDivElement | null>(null);
 
@@ -33,13 +28,10 @@ export const Expandable = ({
     });
 
     const toggleExpandCollapse = () => {
-        logAmplitudeEvent(
-            isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
-            {
-                tittel: title,
-                opprinnelse: analyticsOriginTag,
-            }
-        );
+        logAmplitudeEvent(isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND, {
+            tittel: title,
+            opprinnelse: analyticsOriginTag,
+        });
         setIsOpen(!isOpen);
     };
 
@@ -91,9 +83,7 @@ export const Expandable = ({
             ref={accordionRef}
         >
             <Accordion.Item open={isOpen} className={style.expandable}>
-                <Accordion.Header onClick={toggleExpandCollapse}>
-                    {title}
-                </Accordion.Header>
+                <Accordion.Header onClick={toggleExpandCollapse}>{title}</Accordion.Header>
                 <Accordion.Content>{children}</Accordion.Content>
             </Accordion.Item>
         </Accordion>

--- a/src/components/_common/expandable/ExpandableComponentWrapper.tsx
+++ b/src/components/_common/expandable/ExpandableComponentWrapper.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { ExpandableMixin } from 'types/component-props/_mixins';
+
 import { Expandable } from './Expandable';
 
 type Props = {

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { translator } from 'translations';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 import { usePageContentProps } from 'store/pageContext';
 import { FilterCheckbox } from 'components/parts/filters-menu/FilterCheckbox';
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
-import { FilterExplanation } from './FilterExplanation';
 import { useScrollPosition } from 'utils/useStickyScroll';
 import { Category, Filter } from 'types/component-props/parts/filter-menu';
+
+import { FilterExplanation } from './FilterExplanation';
 
 import style from './FilterBar.module.scss';
 

--- a/src/components/_common/filter-bar/FilterExplanation.tsx
+++ b/src/components/_common/filter-bar/FilterExplanation.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect, useRef, useId } from 'react';
+import { InformationSquareIcon, InformationSquareFillIcon } from '@navikt/aksel-icons';
+
 import { classNames } from 'utils/classnames';
-import {
-    InformationSquareIcon,
-    InformationSquareFillIcon,
-} from '@navikt/aksel-icons';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 
@@ -24,9 +22,7 @@ export const FilterExplanation = ({
 
     const { language } = usePageContentProps();
 
-    const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-        null
-    );
+    const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const relevantSelectedFilters = selectedFilters.filter((filterId) =>
         availableFilters.includes(filterId)
     );

--- a/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/src/components/_common/filtered-content/FilteredContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FilterSelection } from 'types/component-props/_mixins';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 
@@ -7,10 +8,8 @@ type Props = {
     children: React.ReactNode;
 };
 
-const checkForFilterMatch = (
-    filters: string[],
-    selectedFilters: FilterSelection
-) => filters.some((filter) => selectedFilters.includes(filter));
+const checkForFilterMatch = (filters: string[], selectedFilters: FilterSelection) =>
+    filters.some((filter) => selectedFilters.includes(filter));
 
 export const FilteredContent = ({ filters, children }: Props) => {
     const { selectedFilters, availableFilters } = useFilterState();
@@ -34,9 +33,7 @@ export const FilteredContent = ({ filters, children }: Props) => {
     });
 
     const isAffectedByFiltering = relevantCategories.some((category) => {
-        return category.filters.some((filter) =>
-            selectedFilters.includes(filter.id)
-        );
+        return category.filters.some((filter) => selectedFilters.includes(filter.id));
     });
 
     const isFilterMatch = checkForFilterMatch(filters, selectedFilters);

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -1,11 +1,13 @@
 import React, { Fragment } from 'react';
 import { Detail, Heading } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
-import { FormDetailsButton } from './FormDetailsButton';
 import { InfoBox } from 'components/_common/info-box/InfoBox';
 import { AlertInContext } from 'components/_common/alert-in-context/AlertInContext';
+
+import { FormDetailsButton } from './FormDetailsButton';
 
 import style from './FormDetails.module.scss';
 
@@ -40,14 +42,7 @@ export const FormDetails = ({
         showTitleAsLevel4 = false, // Temporary solution until all product pages have been re-organized.
     } = displayConfig;
 
-    const {
-        formNumbers,
-        formType,
-        languageDisclaimer,
-        ingress,
-        title,
-        alerts,
-    } = formDetails;
+    const { formNumbers, formType, languageDisclaimer, ingress, title, alerts } = formDetails;
 
     const variations = formType.reduce<Variation[]>((acc, cur) => {
         const { _selected } = cur;
@@ -71,9 +66,7 @@ export const FormDetails = ({
 
     const formNumberToHighlight =
         formNumberSelected &&
-        formNumbers?.find((formNumber) =>
-            formNumber.toLowerCase().endsWith(formNumberSelected)
-        );
+        formNumbers?.find((formNumber) => formNumber.toLowerCase().endsWith(formNumberSelected));
 
     const hasVisibleTitle = showTitle && title;
     const hasVisibleIngress = showIngress && ingress;
@@ -95,10 +88,7 @@ export const FormDetails = ({
                     {formNumbers.map((formNumber, index) => (
                         <Fragment key={formNumber}>
                             {index > 0 && (
-                                <span
-                                    aria-hidden={true}
-                                    className={style.separator}
-                                >
+                                <span aria-hidden={true} className={style.separator}>
                                     {'|'}
                                 </span>
                             )}
@@ -122,10 +112,7 @@ export const FormDetails = ({
                 </div>
             )}
             {languageDisclaimer && <InfoBox>{languageDisclaimer}</InfoBox>}
-            {alerts &&
-                alerts.map((alert, index) => (
-                    <AlertInContext key={index} alert={alert} />
-                ))}
+            {alerts && alerts.map((alert, index) => <AlertInContext key={index} alert={alert} />)}
             {variations.length > 0 && (
                 <div className={style.variation}>
                     {variations.map((variation, index) => (

--- a/src/components/_common/headers/Header.tsx
+++ b/src/components/_common/headers/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { onlyText } from 'utils/react-children';
 import { classNames } from 'utils/classnames';
 import { Level, levelToSize, Size } from 'types/typo-style';
@@ -30,30 +31,20 @@ export const Header = ({
     setId = true,
     className,
 }: Props) => {
-    const anchor = anchorId
-        ? anchorId.startsWith('#')
-            ? anchorId
-            : `#${anchorId}`
-        : undefined;
+    const anchor = anchorId ? (anchorId.startsWith('#') ? anchorId : `#${anchorId}`) : undefined;
 
     const fallbackSizeByLevel = levelToSize[level] || 'large';
 
     return (
         <div
-            className={classNames(
-                style.header,
-                justify && style[`header__${justify}`],
-                className
-            )}
+            className={classNames(style.header, justify && style[`header__${justify}`], className)}
             id={setId ? anchorId : undefined}
             tabIndex={-1}
         >
             <Heading size={size || fallbackSizeByLevel} level={level}>
                 {children}
             </Heading>
-            {anchor && !hideCopyButton && (
-                <CopyLink heading={onlyText(children)} anchor={anchor} />
-            )}
+            {anchor && !hideCopyButton && <CopyLink heading={onlyText(children)} anchor={anchor} />}
         </div>
     );
 };

--- a/src/components/_common/headers/featured-header/DateLine.tsx
+++ b/src/components/_common/headers/featured-header/DateLine.tsx
@@ -1,4 +1,5 @@
 import { Detail } from '@navikt/ds-react';
+
 import { Language, translator } from 'translations';
 import { formatDate } from 'utils/datetime';
 
@@ -10,11 +11,7 @@ type DateLineProps = {
     language: Language;
 };
 
-export const DateLine = ({
-    createdTime,
-    modifiedTime,
-    language,
-}: DateLineProps) => {
+export const DateLine = ({ createdTime, modifiedTime, language }: DateLineProps) => {
     const getDatesLabel = translator('dates', language);
 
     const createdDate = createdTime.split('T')[0];
@@ -33,15 +30,9 @@ export const DateLine = ({
         })}`;
     };
 
-    const publishedString = buildDateString(
-        getDatesLabel('published'),
-        createdTime
-    );
+    const publishedString = buildDateString(getDatesLabel('published'), createdTime);
 
-    const lastChangedString = buildDateString(
-        getDatesLabel('lastChanged'),
-        modifiedTime
-    );
+    const lastChangedString = buildDateString(getDatesLabel('lastChanged'), modifiedTime);
 
     const dateString = wasChangedAfterPublish
         ? `${publishedString} | ${lastChangedString}`

--- a/src/components/_common/headers/featured-header/FeaturedHeader.tsx
+++ b/src/components/_common/headers/featured-header/FeaturedHeader.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 import { CurrentTopicPageProps } from 'types/content-props/dynamic-page-props';
+
 import { DateLine } from './DateLine';
 import { TagLine } from './TagLine';
 
@@ -31,11 +33,7 @@ export const NewsHeader = ({ contentProps }: Props) => {
                     {pageTitle}
                 </Heading>
             </header>
-            <DateLine
-                createdTime={createdTime}
-                modifiedTime={modifiedTime}
-                language={language}
-            />
+            <DateLine createdTime={createdTime} modifiedTime={modifiedTime} language={language} />
         </>
     );
 };

--- a/src/components/_common/headers/featured-header/TagLine.tsx
+++ b/src/components/_common/headers/featured-header/TagLine.tsx
@@ -1,5 +1,7 @@
 import { Detail } from '@navikt/ds-react';
+
 import { StaticImage } from 'components/_common/image/StaticImage';
+
 import pinIcon from '/public/gfx/pin-icon.svg';
 
 import styles from './TagLine.module.scss';
@@ -8,11 +10,7 @@ export const TagLine = ({ children }: { children: React.ReactNode }) => {
     return (
         <div className={styles.tagLine}>
             <div className={styles.wrapper}>
-                <StaticImage
-                    imageData={pinIcon}
-                    alt={''}
-                    className={styles.tagIcon}
-                />
+                <StaticImage imageData={pinIcon} alt={''} className={styles.tagIcon} />
                 <Detail className={styles.tagLabel}>{children}</Detail>
             </div>
         </div>

--- a/src/components/_common/headers/page-header/PageHeader.tsx
+++ b/src/components/_common/headers/page-header/PageHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Header } from 'components/_common/headers/Header';
 import { HeaderCommonConfig } from 'types/component-props/_mixins';
 import { Level, Size } from 'types/typo-style';
@@ -14,13 +15,7 @@ type Props = {
     children: string;
 };
 
-export const PageHeader = ({
-    justify,
-    children,
-    level,
-    size,
-    className,
-}: Props) => {
+export const PageHeader = ({ justify, children, level, size, className }: Props) => {
     return children ? (
         <Header
             level={level || '1'}

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { BodyShort, Detail } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { PageHeader } from 'components/_common/headers/page-header/PageHeader';
 import { formatDate } from 'utils/datetime';
-import { BodyShort, Detail } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { Illustration } from 'components/_common/illustration/Illustration';
+
 import {
     ContentPropsForThemedPageHeader,
     themedPageHeaderGetSubtitle,
@@ -19,10 +21,7 @@ type Props = {
     showTimeStamp?: boolean;
 };
 
-export const ThemedPageHeader = ({
-    contentProps,
-    showTimeStamp = true,
-}: Props) => {
+export const ThemedPageHeader = ({ contentProps, showTimeStamp = true }: Props) => {
     const { type, displayName, modifiedTime, language, data } = contentProps;
     const { title, illustration } = data;
 
@@ -41,25 +40,14 @@ export const ThemedPageHeader = ({
         })}`;
 
     return (
-        <div
-            className={classNames(
-                style.themedPageHeader,
-                typeSpecificClassName
-            )}
-        >
-            <Illustration
-                illustration={illustration}
-                className={style.illustration}
-            />
+        <div className={classNames(style.themedPageHeader, typeSpecificClassName)}>
+            <Illustration illustration={illustration} className={style.illustration} />
             <div className={style.text}>
                 <PageHeader justify={'left'}>{title || displayName}</PageHeader>
                 {(subTitle || modified) && (
                     <div className={style.taglineWrapper}>
                         {subTitle && (
-                            <BodyShort
-                                size="small"
-                                className={style.taglineLabel}
-                            >
+                            <BodyShort size="small" className={style.taglineLabel}>
                                 {subTitle.toUpperCase()}
                             </BodyShort>
                         )}

--- a/src/components/_common/headers/themed-page-header/themedPageHeaderUtils.ts
+++ b/src/components/_common/headers/themed-page-header/themedPageHeaderUtils.ts
@@ -42,20 +42,13 @@ export const themedPageHeaderGetSubtitle = ({
     const currentAudience = getAudience(audience);
     const subAudience = getSubAudience(audience);
 
-    if (
-        currentAudience === Audience.PROVIDER &&
-        subAudience &&
-        subAudience.length > 0
-    ) {
+    if (currentAudience === Audience.PROVIDER && subAudience && subAudience.length > 0) {
         const getStringParts = translator('stringParts', language);
         const getSubAudienceLabel = translator('providerAudience', language);
         const subAudienceLabels = subAudience.map((audience) =>
             getSubAudienceLabel(audience).toLowerCase()
         );
-        return `${getStringParts('for')} ${joinWithConjunction(
-            subAudienceLabels,
-            language
-        )}`;
+        return `${getStringParts('for')} ${joinWithConjunction(subAudienceLabels, language)}`;
     }
 
     if (type === ContentType.SituationPage) {
@@ -73,22 +66,16 @@ export const themedPageHeaderGetSubtitle = ({
         return getTaxonomyLabel('any');
     }
 
-    if (
-        type === ContentType.ThemedArticlePage ||
-        type === ContentType.FormIntermediateStepPage
-    ) {
+    if (type === ContentType.ThemedArticlePage || type === ContentType.FormIntermediateStepPage) {
         const taxonomyArray = getTranslatedTaxonomies(taxonomy, language);
-        const allCategories = customCategory
-            ? [...taxonomyArray, customCategory]
-            : taxonomyArray;
+        const allCategories = customCategory ? [...taxonomyArray, customCategory] : taxonomyArray;
 
         return joinWithConjunction(allCategories, language);
     }
 
     if (
         type === ContentType.ProductPage &&
-        (currentAudience === Audience.EMPLOYER ||
-            currentAudience === Audience.PROVIDER) // Will catch unlikely events where no sub audience for provider was set
+        (currentAudience === Audience.EMPLOYER || currentAudience === Audience.PROVIDER) // Will catch unlikely events where no sub audience for provider was set
     ) {
         const getTaxonomyLabel = translator('products', language);
         return getTaxonomyLabel(currentAudience);

--- a/src/components/_common/illustration/Illustration.tsx
+++ b/src/components/_common/illustration/Illustration.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
+
 import { IllustrationStatic } from './static/IllustrationStatic';
 import { IllustrationAnimated } from './animated/IllustrationAnimated';
 import { FallbackChevron } from './static/FallbackChevron';
@@ -20,19 +22,12 @@ export const Illustration = ({
     withFallbackIllustration,
 }: Props) => {
     if (!illustration) {
-        return withFallbackIllustration ? (
-            <FallbackChevron className={className} />
-        ) : null;
+        return withFallbackIllustration ? <FallbackChevron className={className} /> : null;
     }
 
     const animationDataUrl = illustration.data.lottieHover?.mediaUrl;
     if (!animationDataUrl || preferStaticIllustration) {
-        return (
-            <IllustrationStatic
-                illustration={illustration}
-                className={className}
-            />
-        );
+        return <IllustrationStatic illustration={illustration} className={className} />;
     }
 
     return (

--- a/src/components/_common/illustration/animated/IllustrationAnimated.tsx
+++ b/src/components/_common/illustration/animated/IllustrationAnimated.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useId } from 'react';
+
 import { classNames } from 'utils/classnames';
 import { fetchJson } from 'srcCommon/fetch-utils';
 import { useSWRImmutableOnScrollIntoView } from 'utils/fetch/useSWRImmutableOnScrollIntoView';
 import type { AnimationItem } from 'lottie-web';
-
 import styleCommon from 'components/_common/illustration/Illustration.module.scss';
+
 import styleAnimated from './IllustrationAnimated.module.scss';
 
 const fetchJsonData = (url: string) =>
@@ -16,11 +17,7 @@ type Props = {
     className?: string;
 };
 
-export const IllustrationAnimated = ({
-    dataUrl,
-    isHovering,
-    className,
-}: Props) => {
+export const IllustrationAnimated = ({ dataUrl, isHovering, className }: Props) => {
     const lottieContainer = useRef<HTMLDivElement | null>(null);
     const lottiePlayer = useRef<AnimationItem | null>(null);
 
@@ -53,9 +50,7 @@ export const IllustrationAnimated = ({
                 return;
             }
 
-            const lottie = (
-                await import('lottie-web/build/player/lottie_light')
-            ).default;
+            const lottie = (await import('lottie-web/build/player/lottie_light')).default;
 
             if (container.innerHTML) {
                 container.innerHTML = '';
@@ -84,10 +79,7 @@ export const IllustrationAnimated = ({
             aria-hidden={'true'}
             id={elementId}
         >
-            <div
-                ref={lottieContainer}
-                className={styleAnimated.lottieContainer}
-            />
+            <div ref={lottieContainer} className={styleAnimated.lottieContainer} />
         </div>
     );
 };

--- a/src/components/_common/illustration/static/FallbackChevron.tsx
+++ b/src/components/_common/illustration/static/FallbackChevron.tsx
@@ -1,4 +1,5 @@
 import { classNames } from 'utils/classnames';
+
 import styles from './FallbackChevron.module.scss';
 
 type FallbackChevronProps = {

--- a/src/components/_common/illustration/static/IllustrationStatic.tsx
+++ b/src/components/_common/illustration/static/IllustrationStatic.tsx
@@ -1,19 +1,14 @@
 import React, { useId } from 'react';
-import {
-    AnimatedIcon,
-    AnimatedIconsProps,
-} from 'types/content-props/animated-icons';
+
+import { AnimatedIcon, AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { getMediaUrl } from 'utils/urls';
 import { classNames } from 'utils/classnames';
-import {
-    buildImageCacheUrl,
-    NextImageProps,
-} from 'components/_common/image/NextImage';
+import { buildImageCacheUrl, NextImageProps } from 'components/_common/image/NextImage';
 import { usePageContentProps } from 'store/pageContext';
 import { XpImage } from 'components/_common/image/XpImage';
 import { useSWRImmutableOnScrollIntoView } from 'utils/fetch/useSWRImmutableOnScrollIntoView';
-
 import styleCommon from 'components/_common/illustration/Illustration.module.scss';
+
 import styleStatic from './IllustrationStatic.module.scss';
 
 type DefinedIcon = Required<NonNullable<AnimatedIcon['icon']>>;
@@ -25,8 +20,7 @@ type StaticIconProps = {
     className?: string;
 };
 
-const isValidIcon = (icon?: AnimatedIcon['icon']): icon is ValidIcon =>
-    !!icon?.mediaUrl;
+const isValidIcon = (icon?: AnimatedIcon['icon']): icon is ValidIcon => !!icon?.mediaUrl;
 
 const nextImageProps: NextImageProps = {
     maxWidth: 96,
@@ -97,23 +91,12 @@ export const IllustrationStatic = ({ illustration, className }: Props) => {
     const [icon1, icon2] = icons;
 
     return (
-        <span
-            className={classNames(styleCommon.image, className)}
-            aria-hidden={'true'}
-        >
+        <span className={classNames(styleCommon.image, className)} aria-hidden={'true'}>
             {isValidIcon(icon1?.icon) && (
-                <StaticIcon
-                    icon={icon1.icon}
-                    isEditorView={!!editorView}
-                    className={'back'}
-                />
+                <StaticIcon icon={icon1.icon} isEditorView={!!editorView} className={'back'} />
             )}
             {isValidIcon(icon2?.icon) && (
-                <StaticIcon
-                    icon={icon2.icon}
-                    isEditorView={!!editorView}
-                    className={'front'}
-                />
+                <StaticIcon icon={icon2.icon} isEditorView={!!editorView} className={'front'} />
             )}
         </span>
     );

--- a/src/components/_common/image/NextImage.tsx
+++ b/src/components/_common/image/NextImage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { usePageContentProps } from 'store/pageContext';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
-import { isValidImageUrl } from 'utils/urls';
 import dynamic from 'next/dynamic';
+
+import { usePageContentProps } from 'store/pageContext';
+import { isValidImageUrl } from 'utils/urls';
 
 // These types should match what's specified in next.config
 type DeviceSize = 480 | 768 | 1024 | 1440;
@@ -24,8 +25,7 @@ const maxWidthDefault: DeviceSize = 1440;
 const qualityDefault = 90;
 
 const origin =
-    typeof process.env !== 'undefined' &&
-    process.env.IS_FAILOVER_INSTANCE === 'true'
+    typeof process.env !== 'undefined' && process.env.IS_FAILOVER_INSTANCE === 'true'
         ? process.env.FAILOVER_ORIGIN
         : process.env.APP_ORIGIN;
 
@@ -53,13 +53,7 @@ export const buildImageCacheUrl = ({
 };
 
 const NextImageRunTime = (props: ImageProps) => {
-    const {
-        src,
-        alt,
-        maxWidth = maxWidthDefault,
-        quality = qualityDefault,
-        ...imgAttribs
-    } = props;
+    const { src, alt, maxWidth = maxWidthDefault, quality = qualityDefault, ...imgAttribs } = props;
 
     const { editorView } = usePageContentProps();
 
@@ -82,8 +76,7 @@ const NextImageRunTime = (props: ImageProps) => {
 };
 
 export const NextImage =
-    typeof process.env !== 'undefined' &&
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+    typeof process.env !== 'undefined' && process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
         ? dynamic(
               import('./NextImageBuildTime').then((module) => {
                   const { NextImageBuildTime } = module;

--- a/src/components/_common/image/NextImageBuildTime.tsx
+++ b/src/components/_common/image/NextImageBuildTime.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { updateImageManifest } from 'utils/fetch/fetch-images';
+
 import { buildImageCacheUrl, ImageProps } from './NextImage';
 
 export const NextImageBuildTime = (props: ImageProps) => {

--- a/src/components/_common/image/StaticImage.tsx
+++ b/src/components/_common/image/StaticImage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { NextImage } from './NextImage';
 import { StaticImageData } from 'next/image';
+
+import { NextImage } from './NextImage';
 
 type Props = {
     imageData: StaticImageData;
@@ -10,12 +11,5 @@ type Props = {
 export const StaticImage = (props: Props) => {
     const { imageData, alt, ...imgAttribs } = props;
 
-    return (
-        <NextImage
-            {...imgAttribs}
-            src={imageData.src}
-            alt={alt}
-            role={imgAttribs.role}
-        />
-    );
+    return <NextImage {...imgAttribs} src={imageData.src} alt={alt} role={imgAttribs.role} />;
 };

--- a/src/components/_common/image/XpImage.tsx
+++ b/src/components/_common/image/XpImage.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import { XpImageProps } from 'types/media';
 import { getMediaUrl } from 'utils/urls';
-import { NextImage, NextImageProps } from './NextImage';
 import { usePageContentProps } from 'store/pageContext';
+
+import { NextImage, NextImageProps } from './NextImage';
 
 type Props = {
     imageProps: XpImageProps;

--- a/src/components/_common/info-box/InfoBox.tsx
+++ b/src/components/_common/info-box/InfoBox.tsx
@@ -1,4 +1,5 @@
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
+
 import styles from './InfoBox.module.scss';
 
 type InfoBoxProps = {
@@ -7,12 +8,7 @@ type InfoBoxProps = {
 
 export const InfoBox = ({ children }: InfoBoxProps) => {
     return (
-        <AlertBox
-            variant="info"
-            size="small"
-            inline={true}
-            className={styles.infoBox}
-        >
+        <AlertBox variant="info" size="small" inline={true} className={styles.infoBox}>
             {children}
         </AlertBox>
     );

--- a/src/components/_common/lenke/LenkeBase.tsx
+++ b/src/components/_common/lenke/LenkeBase.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import Link from 'next/link';
+
 import { adminOrigin, isNofollowUrl, xpDraftPathPrefix } from 'utils/urls';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { onlyText } from 'utils/react-children';
@@ -65,9 +66,7 @@ export const LenkeBase = ({
 
     // Setting prefetch=true on next/link is deprecated, hence this strange thing (true is default)
     const shouldPrefetch =
-        canRouteClientSide && (prefetch === false || editorView)
-            ? false
-            : undefined;
+        canRouteClientSide && (prefetch === false || editorView) ? false : undefined;
 
     return (
         <WrapperComponent>
@@ -75,10 +74,7 @@ export const LenkeBase = ({
                 {...rest}
                 href={url}
                 onClick={(e) => {
-                    logAmplitudeEvent(
-                        analyticsEvent || AnalyticsEvents.NAVIGATION,
-                        analyticsData
-                    );
+                    logAmplitudeEvent(analyticsEvent || AnalyticsEvents.NAVIGATION, analyticsData);
                     onClick?.(e);
                 }}
                 rel={isNofollowUrl(url) ? 'nofollow' : undefined}

--- a/src/components/_common/lenke/LenkeInline.tsx
+++ b/src/components/_common/lenke/LenkeInline.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { LenkeBase } from './LenkeBase';
+
 import { classNames } from 'utils/classnames';
+
+import { LenkeBase } from './LenkeBase';
+
 import style from './LenkeInline.module.scss';
 
 type Props = React.ComponentProps<typeof LenkeBase>;

--- a/src/components/_common/lenke/LenkeStandalone.tsx
+++ b/src/components/_common/lenke/LenkeStandalone.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { BodyLong, BodyShort } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
-import { LenkeBase } from './LenkeBase';
 import { Chevron } from 'components/_common/chevron/Chevron';
+
+import { LenkeBase } from './LenkeBase';
 
 import style from './LenkeStandalone.module.scss';
 
@@ -32,17 +34,10 @@ export const LenkeStandalone = ({
         <LenkeBase
             {...rest}
             href={href}
-            className={classNames(
-                style.navnoLenke,
-                withChevron && style.withChevron,
-                className
-            )}
+            className={classNames(style.navnoLenke, withChevron && style.withChevron, className)}
             analyticsComponent={component}
             analyticsLinkGroup={linkGroup}
-            analyticsLabel={
-                analyticsLabel ||
-                (typeof children === 'string' ? children : undefined)
-            }
+            analyticsLabel={analyticsLabel || (typeof children === 'string' ? children : undefined)}
         >
             <BodyShort className={style.lenketekst} as={'span'}>
                 {withChevron && (

--- a/src/components/_common/lenkeliste/Lenkeliste.tsx
+++ b/src/components/_common/lenkeliste/Lenkeliste.tsx
@@ -1,5 +1,6 @@
 import React, { useId } from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { LinkProps } from 'types/link-props';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -15,26 +16,11 @@ type Props = {
     listType: ListType;
 };
 
-const WrapUL = ({
-    showAsList,
-    children,
-}: {
-    showAsList: boolean;
-    children: React.ReactNode;
-}) =>
-    showAsList ? (
-        <ul className={style.ulListe}>{children}</ul>
-    ) : (
-        <>{children}</>
-    );
+const WrapUL = ({ showAsList, children }: { showAsList: boolean; children: React.ReactNode }) =>
+    showAsList ? <ul className={style.ulListe}>{children}</ul> : <>{children}</>;
 
-const WrapLI = ({
-    showAsList,
-    children,
-}: {
-    showAsList: boolean;
-    children: React.ReactNode;
-}) => (showAsList ? <li>{children}</li> : <>{children}</>);
+const WrapLI = ({ showAsList, children }: { showAsList: boolean; children: React.ReactNode }) =>
+    showAsList ? <li>{children}</li> : <>{children}</>;
 
 export const Lenkeliste = ({ tittel, lenker, listType, className }: Props) => {
     const headingId = `heading-linklist-${useId()}`;
@@ -44,17 +30,9 @@ export const Lenkeliste = ({ tittel, lenker, listType, className }: Props) => {
     }
 
     return (
-        <nav
-            className={classNames(className, style.lenker)}
-            aria-labelledby={headingId}
-        >
+        <nav className={classNames(className, style.lenker)} aria-labelledby={headingId}>
             {tittel && (
-                <Heading
-                    className={style.tittel}
-                    id={headingId}
-                    size="small"
-                    level="2"
-                >
+                <Heading className={style.tittel} id={headingId} size="small" level="2">
                     {tittel}
                 </Heading>
             )}

--- a/src/components/_common/lenkepanel-legacy/LenkepanelNavNo.tsx
+++ b/src/components/_common/lenkepanel-legacy/LenkepanelNavNo.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Heading, LinkPanel } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
+
 import style from './LenkepanelNavNo.module.scss';
 
 type Props = {
@@ -35,20 +37,12 @@ const LenkepanelNavNo = ({
             analyticsComponent={component}
             analyticsLinkGroup={linkGroup}
             analyticsLabel={tittel}
-            className={classNames(
-                style.lenkepanelNavno,
-                vertikal && style.vertikal,
-                className
-            )}
+            className={classNames(style.lenkepanelNavno, vertikal && style.vertikal, className)}
             as={LenkeBase}
         >
             {ikon && <div className={style.ikon}>{ikon}</div>}
             <div className={style.innhold}>
-                <Heading
-                    level="2"
-                    size="small"
-                    className={'navds-link-panel__title'}
-                >
+                <Heading level="2" size="small" className={'navds-link-panel__title'}>
                     {tittel}
                 </Heading>
                 {separator && <hr className={style.separator} />}

--- a/src/components/_common/lenkepanel-liste/LenkepanelListe.tsx
+++ b/src/components/_common/lenkepanel-liste/LenkepanelListe.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { LinkPanel } from 'types/link-panel';
 import { BodyLong, Heading, Ingress } from '@navikt/ds-react';
+
+import { LinkPanel } from 'types/link-panel';
 import LenkepanelNavNo from 'components/_common/lenkepanel-legacy/LenkepanelNavNo';
 import { getUrlFromContent } from 'utils/links-from-content';
 
@@ -44,9 +45,7 @@ export const LenkepanelListe = ({ title, ingress, items }: Props) => {
                                 linkGroup={title}
                                 key={item.title}
                             >
-                                {item.ingress && (
-                                    <BodyLong>{item.ingress}</BodyLong>
-                                )}
+                                {item.ingress && <BodyLong>{item.ingress}</BodyLong>}
                             </LenkepanelNavNo>
                         );
                     })}

--- a/src/components/_common/linkpanel/LinkPanelNavno.tsx
+++ b/src/components/_common/linkpanel/LinkPanelNavno.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { classNames } from 'utils/classnames';
 import { Heading } from '@navikt/ds-react';
+
+import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 
 import styles from './LinkPanelNavno.module.scss';
@@ -60,11 +61,7 @@ export const LinkPanelNavno = ({
                         {linkText}
                     </LenkeBase>
                 </span>
-                {children && (
-                    <div className={styles.linkPanelNavnoIngress}>
-                        {children}
-                    </div>
-                )}
+                {children && <div className={styles.linkPanelNavnoIngress}>{children}</div>}
             </div>
         </div>
     );

--- a/src/components/_common/linkpanel/LinkPanelNavnoSimple.tsx
+++ b/src/components/_common/linkpanel/LinkPanelNavnoSimple.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Heading } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { Heading } from '@navikt/ds-react';
 
 import style from './LinkPanelNavnoSimple.module.scss';
 
@@ -33,21 +34,12 @@ export const LinkPanelNavnoSimple = ({
         <LenkeBase
             {...rest}
             href={href}
-            className={classNames(
-                style.linkPanel,
-                icon && style.withIcon,
-                className
-            )}
+            className={classNames(style.linkPanel, icon && style.withIcon, className)}
             analyticsComponent={'Lenkepanel navno enkel'}
             analyticsLinkGroup={analyticsLinkGroup}
         >
             {icon && <div className={style.icon}>{icon}</div>}
-            <div
-                className={classNames(
-                    'navds-heading',
-                    `navds-heading--${linkTextSize}`
-                )}
-            >
+            <div className={classNames('navds-heading', `navds-heading--${linkTextSize}`)}>
                 <span className={style.text}>{children}</span>
             </div>
         </LenkeBase>

--- a/src/components/_common/metatags/DocumentParameterMetatags.tsx
+++ b/src/components/_common/metatags/DocumentParameterMetatags.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ContentProps } from 'types/content-props/_content-common';
 import Head from 'next/head';
+
+import { ContentProps } from 'types/content-props/_content-common';
 import { getDecoratorParams } from 'utils/decorator/decorator-utils';
 import { isLegacyContentType } from 'utils/content-types';
 
@@ -29,19 +30,10 @@ export const DocumentParameterMetatags = ({ content }: Props) => {
 
     return (
         <Head>
-            <meta
-                name={DocumentParameter.DecoratorParams}
-                content={decoratorParams}
-            />
-            <meta
-                name={DocumentParameter.HtmlLang}
-                content={content.language}
-            />
+            <meta name={DocumentParameter.DecoratorParams} content={decoratorParams} />
+            <meta name={DocumentParameter.HtmlLang} content={content.language} />
             {editorView === 'edit' && isLegacyContentType(type) && (
-                <meta
-                    name={DocumentParameter.LegacyContentType}
-                    content={'true'}
-                />
+                <meta name={DocumentParameter.LegacyContentType} content={'true'} />
             )}
         </Head>
     );

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import Head from 'next/head';
+
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import {
     hasCanonicalUrl,
     hasDescription,
@@ -35,9 +36,7 @@ const getDescription = (content: ContentProps) => {
 };
 
 const shouldNotIndex = (content: ContentProps) =>
-    content.isPagePreview ||
-    content.type === ContentType.Error ||
-    content.data?.noindex;
+    content.isPagePreview || content.type === ContentType.Error || content.data?.noindex;
 
 const shouldNotSnippet = (content: ContentProps) => content.data?.nosnippet;
 
@@ -96,29 +95,13 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
             <meta name={'twitter:image:src'} content={imageUrl} />
             <meta name={'description'} content={description} />
             <meta name={'contentId'} content={content._id} />
-            {content.contentLayer && (
-                <meta name={'contentLayer'} content={content.contentLayer} />
-            )}
+            {content.contentLayer && <meta name={'contentLayer'} content={content.contentLayer} />}
             <meta name={'msapplication-TileColor'} content={'#ffffff'} />
             <meta name={'theme-color'} content={'#ffffff'} />
-            <link
-                rel={'icon'}
-                href={`${decoratorUrl}/media/favicon.ico`}
-                sizes="any"
-            />
-            <link
-                rel={'icon'}
-                href={`${decoratorUrl}/media/favicon.svg`}
-                type={'image/svg+xml'}
-            />
-            <link
-                rel={'apple-touch-icon'}
-                href={`${decoratorUrl}/media/apple-touch-icon.png`}
-            />
-            <link
-                rel={'manifest'}
-                href={`${decoratorUrl}/media/site.webmanifest`}
-            />
+            <link rel={'icon'} href={`${decoratorUrl}/media/favicon.ico`} sizes="any" />
+            <link rel={'icon'} href={`${decoratorUrl}/media/favicon.svg`} type={'image/svg+xml'} />
+            <link rel={'apple-touch-icon'} href={`${decoratorUrl}/media/apple-touch-icon.png`} />
+            <link rel={'manifest'} href={`${decoratorUrl}/media/site.webmanifest`} />
             {children}
         </Head>
     );

--- a/src/components/_common/moreLink/MoreLink.tsx
+++ b/src/components/_common/moreLink/MoreLink.tsx
@@ -1,7 +1,8 @@
+import { ArrowRightIcon } from '@navikt/aksel-icons';
+
 import { LinkSelectable } from 'types/component-props/_mixins';
 import { getSelectableLinkProps } from 'utils/links-from-content';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
-import { ArrowRightIcon } from '@navikt/aksel-icons';
 
 import styles from './MoreLink.module.scss';
 
@@ -13,11 +14,7 @@ export const MoreLink = ({ link }: { link?: LinkSelectable }) => {
     const { text, url } = getSelectableLinkProps(link);
 
     return (
-        <LenkeStandalone
-            href={url}
-            className={styles.moreLink}
-            withChevron={false}
-        >
+        <LenkeStandalone href={url} className={styles.moreLink} withChevron={false}>
             <ArrowRightIcon aria-hidden={true} className={styles.arrow} />
             {text}
         </LenkeStandalone>

--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -1,16 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { FunnelIcon } from '@navikt/aksel-icons';
+import { Heading, Button } from '@navikt/ds-react';
+
 import { OverviewAreaFilter } from 'components/_common/overview-filters/area-filter/OverviewAreaFilter';
 import { OverviewTaxonomyFilter } from 'components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter';
 import { OverviewTextFilter } from 'components/_common/overview-filters/text-filter/OverviewTextFilter';
-import {
-    OverviewFilterableItem,
-    useOverviewFilters,
-} from 'store/hooks/useOverviewFilters';
+import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { classNames } from 'utils/classnames';
-import { FunnelIcon } from '@navikt/aksel-icons';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
-import { Heading, Button } from '@navikt/ds-react';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 
 import style from './OverviewFilters.module.scss';
@@ -53,8 +51,7 @@ const MobileView = ({
                                     e.preventDefault();
                                     setIsOpen(!isOpen);
                                     logAmplitudeEvent(AnalyticsEvents.FILTER, {
-                                        opprinnelse:
-                                            'oversiktsside filter mobil',
+                                        opprinnelse: 'oversiktsside filter mobil',
                                     });
                                 }}
                                 className={style.mobileFilterButton}
@@ -75,12 +72,8 @@ const MobileView = ({
                     )}
                     ref={filtersRef}
                 >
-                    {showAreaFilter && (
-                        <OverviewAreaFilter items={filterableItems} />
-                    )}
-                    {showTaxonomyFilter && (
-                        <OverviewTaxonomyFilter items={filterableItems} />
-                    )}
+                    {showAreaFilter && <OverviewAreaFilter items={filterableItems} />}
+                    {showTaxonomyFilter && <OverviewTaxonomyFilter items={filterableItems} />}
                 </div>
             )}
         </div>
@@ -101,9 +94,7 @@ const DesktopView = ({
                 {searchLabel}
             </Heading>
             {showAreaFilter && <OverviewAreaFilter items={filterableItems} />}
-            {showTaxonomyFilter && (
-                <OverviewTaxonomyFilter items={filterableItems} />
-            )}
+            {showTaxonomyFilter && <OverviewTaxonomyFilter items={filterableItems} />}
             {showTextInputFilter && <OverviewTextFilter hideLabel={false} />}
         </div>
     );

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
+
 import { Area } from 'types/areas';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { OverviewFilterBase } from 'components/_common/overview-filters/filter-base/OverviewFilterBase';
-import {
-    OverviewFilterableItem,
-    useOverviewFilters,
-} from 'store/hooks/useOverviewFilters';
+import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
 const orderedAreas: Area[] = [
     Area.WORK,

--- a/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
+++ b/src/components/_common/overview-filters/filter-base/OverviewFilterBase.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Chips, Heading } from '@navikt/ds-react';
+
 import { Area } from 'types/areas';
 import { Taxonomy } from 'types/taxonomies';
 import { translator } from 'translations';
@@ -31,9 +32,7 @@ export const OverviewFilterBase = <Type extends FilterOptions>({
     const { language } = usePageContentProps();
 
     const translations = translator('overview', language)(type);
-    const optionsTranslations = translator(type, language) as (
-        key: Type
-    ) => string;
+    const optionsTranslations = translator(type, language) as (key: Type) => string;
 
     return (
         <div className={styles.overviewFilter}>

--- a/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
+++ b/src/components/_common/overview-filters/summary/OverviewFiltersSummary.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { BodyLong, Chips, Heading } from '@navikt/ds-react';
+
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
-import { BodyLong, Chips, Heading } from '@navikt/ds-react';
 import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
 
@@ -14,11 +15,7 @@ type Props = {
     showResetChips: boolean;
 };
 
-export const OverviewFiltersSummary = ({
-    numMatches,
-    numTotal,
-    showResetChips,
-}: Props) => {
+export const OverviewFiltersSummary = ({ numMatches, numTotal, showResetChips }: Props) => {
     const { language } = usePageContentProps();
 
     const {
@@ -45,18 +42,12 @@ export const OverviewFiltersSummary = ({
                 {showResetChips && !hasDefaultFilters && (
                     <Chips className={style.chips}>
                         {areaFilter !== Area.ALL && (
-                            <Chips.Removable
-                                onClick={() => setAreaFilter(Area.ALL)}
-                            >
+                            <Chips.Removable onClick={() => setAreaFilter(Area.ALL)}>
                                 {areaTranslations(areaFilter)}
                             </Chips.Removable>
                         )}
                         {taxonomyFilter !== ProductTaxonomy.ALL && (
-                            <Chips.Removable
-                                onClick={() =>
-                                    setTaxonomyFilter(ProductTaxonomy.ALL)
-                                }
-                            >
+                            <Chips.Removable onClick={() => setTaxonomyFilter(ProductTaxonomy.ALL)}>
                                 {taxonomyTranslations(taxonomyFilter)}
                             </Chips.Removable>
                         )}
@@ -71,9 +62,7 @@ export const OverviewFiltersSummary = ({
                 )}
             </div>
             {numMatches === 0 && (
-                <BodyLong className={style.nohits}>
-                    {overviewTranslations('noHits')}
-                </BodyLong>
+                <BodyLong className={style.nohits}>{overviewTranslations('noHits')}</BodyLong>
             )}
         </>
     );

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
+
 import { ProductTaxonomy } from 'types/taxonomies';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { OverviewFilterBase } from 'components/_common/overview-filters/filter-base/OverviewFilterBase';
-import {
-    OverviewFilterableItem,
-    useOverviewFilters,
-} from 'store/hooks/useOverviewFilters';
+import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
 const orderedTaxonomies: ProductTaxonomy[] = [
     ProductTaxonomy.BENEFITS,
@@ -35,14 +33,10 @@ export const OverviewTaxonomyFilter = ({ items }: Props) => {
     };
 
     const taxonomiesPresent = orderedTaxonomies.filter((taxonomy) =>
-        items.some((item) =>
-            item.taxonomy.some((itemTaxonomy) => itemTaxonomy === taxonomy)
-        )
+        items.some((item) => item.taxonomy.some((itemTaxonomy) => itemTaxonomy === taxonomy))
     );
 
-    const listHasGuidePage = items.some(
-        (product) => product.type === 'no.nav.navno:guide-page'
-    );
+    const listHasGuidePage = items.some((product) => product.type === 'no.nav.navno:guide-page');
 
     if (listHasGuidePage) {
         taxonomiesPresent.push(ProductTaxonomy.OTHER);

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useId, useState } from 'react';
 import { Search } from '@navikt/ds-react';
 import debounce from 'lodash.debounce';
+
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
@@ -45,24 +46,16 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
     };
 
     useEffect(() => {
-        const handleInputFromEvent = (
-            e: CustomEvent<OverviewFiltersTextInputEventDetail>
-        ) => {
+        const handleInputFromEvent = (e: CustomEvent<OverviewFiltersTextInputEventDetail>) => {
             const { value, id: senderId } = e.detail;
             if (senderId !== inputId) {
                 setTextInput(value);
             }
         };
 
-        window.addEventListener(
-            OVERVIEW_FILTERS_TEXT_INPUT_EVENT,
-            handleInputFromEvent
-        );
+        window.addEventListener(OVERVIEW_FILTERS_TEXT_INPUT_EVENT, handleInputFromEvent);
         return () => {
-            window.removeEventListener(
-                OVERVIEW_FILTERS_TEXT_INPUT_EVENT,
-                handleInputFromEvent
-            );
+            window.removeEventListener(OVERVIEW_FILTERS_TEXT_INPUT_EVENT, handleInputFromEvent);
         };
     }, [inputId]);
 
@@ -84,9 +77,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                 // with onscreen keyboard input.
                 // (Closing the onscreen keyboard interrupts scrolling)
                 setTimeout(() => {
-                    const top =
-                        targetElement.getBoundingClientRect().top +
-                        window.scrollY;
+                    const top = targetElement.getBoundingClientRect().top + window.scrollY;
                     windowScrollTo(top - 16);
                 }, 100);
             }}

--- a/src/components/_common/page-navigation-menu/PageNavigationDupeLinkWarning.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationDupeLinkWarning.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { AnchorLink } from 'types/component-props/parts/page-navigation-menu';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { usePageContentProps } from 'store/pageContext';

--- a/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationLink.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { BodyShort } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { PageNavViewStyle } from 'types/component-props/parts/page-navigation-menu';
-import { PageNavScrollDirection } from './PageNavigationMenu';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 import Config from 'config';
+
+import { PageNavScrollDirection } from './PageNavigationMenu';
 
 import style from './PageNavigationLink.module.scss';
 import sidebarStyle from './views/PageNavigationSidebar.module.scss';
@@ -23,24 +25,14 @@ type Props = {
 };
 
 export const PageNavigationLink = React.memo(
-    ({
-        targetId,
-        linkId,
-        isCurrent,
-        scrollDirection,
-        viewStyle,
-        children,
-    }: Props) => {
-        const setLocationHashAndScrollToTarget = (
-            e: React.MouseEvent<HTMLAnchorElement>
-        ) => {
+    ({ targetId, linkId, isCurrent, scrollDirection, viewStyle, children }: Props) => {
+        const setLocationHashAndScrollToTarget = (e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault();
             window.history.pushState(window.history.state, '', `#${targetId}`);
             smoothScrollToTarget(targetId, ANCHOR_OFFSET_PX);
         };
 
-        const currentViewStyle =
-            viewStyle === 'sidebar' ? sidebarStyle : inContentStyle;
+        const currentViewStyle = viewStyle === 'sidebar' ? sidebarStyle : inContentStyle;
 
         return (
             <LenkeBase
@@ -57,10 +49,7 @@ export const PageNavigationLink = React.memo(
                 id={linkId}
             >
                 {viewStyle === 'sidebar' && (
-                    <span
-                        className={currentViewStyle.decor}
-                        aria-hidden={true}
-                    />
+                    <span className={currentViewStyle.decor} aria-hidden={true} />
                 )}
                 <BodyShort className={style.linkText}>{children}</BodyShort>
             </LenkeBase>

--- a/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-import {
-    AnchorLink,
-    PageNavViewStyle,
-} from 'types/component-props/parts/page-navigation-menu';
 import debounce from 'lodash.debounce';
+
+import { AnchorLink, PageNavViewStyle } from 'types/component-props/parts/page-navigation-menu';
+import Config from 'config';
+
 import { PageNavigationSidebar } from './views/PageNavigationSidebar';
 import { PageNavigationInContent } from './views/PageNavigationInContent';
-import Config from 'config';
 import { PageNavigationDupeLinkWarning } from './PageNavigationDupeLinkWarning';
 
 const MENU_UPDATE_RATE = 1000 / 30;
@@ -55,27 +54,21 @@ export const PageNavigationMenu = ({
     }, [currentIndex, links, currentLinkCallback]);
 
     useEffect(() => {
-        const elementsSortedByVerticalPosition = links.reduce<HTMLElement[]>(
-            (acc, link) => {
-                const element = document.getElementById(link.anchorId);
-                if (element) {
-                    acc.push(element);
-                }
-                return acc;
-            },
-            []
-        );
+        const elementsSortedByVerticalPosition = links.reduce<HTMLElement[]>((acc, link) => {
+            const element = document.getElementById(link.anchorId);
+            if (element) {
+                acc.push(element);
+            }
+            return acc;
+        }, []);
 
         const currentScrollPositionHandler = debounce(
             () => {
-                const index = getCurrentLinkIndex(
-                    elementsSortedByVerticalPosition
-                );
+                const index = getCurrentLinkIndex(elementsSortedByVerticalPosition);
 
                 const scrollPos = window.scrollY;
 
-                scrollDir.current =
-                    scrollPos > prevScrollPos.current ? 'down' : 'up';
+                scrollDir.current = scrollPos > prevScrollPos.current ? 'down' : 'up';
                 prevScrollPos.current = scrollPos;
 
                 setCurrentIndex(index);
@@ -87,8 +80,7 @@ export const PageNavigationMenu = ({
         currentScrollPositionHandler();
 
         window.addEventListener('scroll', currentScrollPositionHandler);
-        return () =>
-            window.removeEventListener('scroll', currentScrollPositionHandler);
+        return () => window.removeEventListener('scroll', currentScrollPositionHandler);
     }, [links]);
 
     if (links.length === 0) {
@@ -96,9 +88,7 @@ export const PageNavigationMenu = ({
     }
 
     const PageNavigationComponent =
-        viewStyle === 'sidebar'
-            ? PageNavigationSidebar
-            : PageNavigationInContent;
+        viewStyle === 'sidebar' ? PageNavigationSidebar : PageNavigationInContent;
 
     const props = {
         currentIndex,
@@ -120,17 +110,14 @@ export const getPageNavigationLinkId = (anchorId: string) => `${anchorId}-a`;
 const getCurrentLinkIndex = (targetElements: HTMLElement[]) => {
     const scrollTarget = window.scrollY + Config.vars.dekoratorenHeight;
 
-    const scrolledToTop = !!(
-        targetElements?.length && targetElements[0].offsetTop > scrollTarget
-    );
+    const scrolledToTop = !!(targetElements?.length && targetElements[0].offsetTop > scrollTarget);
 
     if (scrolledToTop) {
         return -1;
     }
 
     const scrolledToBottom =
-        window.scrollY + window.innerHeight >=
-        document.documentElement.scrollHeight;
+        window.scrollY + window.innerHeight >= document.documentElement.scrollHeight;
 
     if (scrolledToBottom) {
         return targetElements.length - 1;
@@ -148,6 +135,4 @@ const getCurrentLinkIndex = (targetElements: HTMLElement[]) => {
 };
 
 const getValidLinks = (anchorLinks: AnchorLink[]): AnchorLink[] =>
-    anchorLinks.filter(
-        (link) => link.anchorId && link.linkText && !link.isDupe
-    );
+    anchorLinks.filter((link) => link.anchorId && link.linkText && !link.isDupe);

--- a/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationInContent.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import { Header } from 'components/_common/headers/Header';
 import { PageNavigationLink } from 'components/_common/page-navigation-menu/PageNavigationLink';
 import { AnchorLink } from 'types/component-props/parts/page-navigation-menu';
 import { getPageNavigationLinkId } from 'components/_common/page-navigation-menu/PageNavigationMenu';
+
 import style from './PageNavigationInContent.module.scss';
 
 type Props = {
@@ -14,12 +16,7 @@ export const PageNavigationInContent = ({ title, links }: Props) => {
     return (
         <div className={style.pageNavInContent}>
             {title && (
-                <Header
-                    level="2"
-                    className={style.title}
-                    justify={'left'}
-                    size="medium"
-                >
+                <Header level="2" className={style.title} justify={'left'} size="medium">
                     {title}
                 </Header>
             )}
@@ -29,9 +26,7 @@ export const PageNavigationInContent = ({ title, links }: Props) => {
                         <li key={anchorLink.anchorId}>
                             <PageNavigationLink
                                 targetId={anchorLink.anchorId}
-                                linkId={getPageNavigationLinkId(
-                                    anchorLink.anchorId
-                                )}
+                                linkId={getPageNavigationLinkId(anchorLink.anchorId)}
                                 viewStyle={'inContent'}
                             >
                                 {anchorLink.linkText}

--- a/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
+++ b/src/components/_common/page-navigation-menu/views/PageNavigationSidebar.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { PageNavigationLink } from 'components/_common/page-navigation-menu/PageNavigationLink';
 import { AnchorLink } from 'types/component-props/parts/page-navigation-menu';
 import {
     getPageNavigationLinkId,
     PageNavScrollDirection,
 } from 'components/_common/page-navigation-menu/PageNavigationMenu';
+
 import style from './PageNavigationSidebar.module.scss';
 
 type Props = {
@@ -15,12 +17,7 @@ type Props = {
     scrollDirection: PageNavScrollDirection;
 };
 
-export const PageNavigationSidebar = ({
-    title,
-    links,
-    currentIndex,
-    scrollDirection,
-}: Props) => {
+export const PageNavigationSidebar = ({ title, links, currentIndex, scrollDirection }: Props) => {
     return (
         <div className={style.pageNavSidebar}>
             {title && (
@@ -34,9 +31,7 @@ export const PageNavigationSidebar = ({
                         <li key={anchorLink.anchorId}>
                             <PageNavigationLink
                                 targetId={anchorLink.anchorId}
-                                linkId={getPageNavigationLinkId(
-                                    anchorLink.anchorId
-                                )}
+                                linkId={getPageNavigationLinkId(anchorLink.anchorId)}
                                 isCurrent={currentIndex === index}
                                 scrollDirection={scrollDirection}
                                 viewStyle={'sidebar'}

--- a/src/components/_common/parsed-html/ParsedHtml.tsx
+++ b/src/components/_common/parsed-html/ParsedHtml.tsx
@@ -1,10 +1,7 @@
 import React, { Fragment } from 'react';
 import { Provider } from 'react-redux';
-import { store } from 'store/store';
 import ReactDOMServer from 'react-dom/server';
 import { isTag, isText } from 'domhandler';
-import { usePageContentProps } from 'store/pageContext';
-import { NextImage } from 'components/_common/image/NextImage';
 import htmlReactParser, {
     Element,
     domToReact,
@@ -12,18 +9,19 @@ import htmlReactParser, {
     DOMNode,
     HTMLReactParserOptions,
 } from 'html-react-parser';
+import { BodyLong, Heading } from '@navikt/ds-react';
+
+import { store } from 'store/store';
+import { usePageContentProps } from 'store/pageContext';
+import { NextImage } from 'components/_common/image/NextImage';
 import { getMediaUrl } from 'utils/urls';
-import {
-    processedHtmlMacroTag,
-    ProcessedHtmlProps,
-} from 'types/processed-html-props';
+import { processedHtmlMacroTag, ProcessedHtmlProps } from 'types/processed-html-props';
 import { headingToLevel, headingToSize, isHeadingTag } from 'types/typo-style';
 import { MacroType } from 'types/macro-props/_macros-common';
 import { MacroMapper } from 'components/macros/MacroMapper';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { Table } from 'components/_common/table/Table';
-import { BodyLong, Heading } from '@navikt/ds-react';
 
 const blockLevelMacros: ReadonlySet<string> = new Set([
     MacroType.AlertBox,
@@ -88,9 +86,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
     }
 
     const { processedHtml, macros } =
-        typeof htmlProps === 'string'
-            ? { processedHtml: htmlProps, macros: [] }
-            : htmlProps;
+        typeof htmlProps === 'string' ? { processedHtml: htmlProps, macros: [] } : htmlProps;
 
     if (!processedHtml) {
         return null;
@@ -115,12 +111,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
             // Handle macros
             if (tag === processedHtmlMacroTag) {
-                return (
-                    <MacroMapper
-                        macros={macros}
-                        macroRef={attribs?.['data-macro-ref']}
-                    />
-                );
+                return <MacroMapper macros={macros} macroRef={attribs?.['data-macro-ref']} />;
             }
 
             // Remove img without src
@@ -227,9 +218,7 @@ export const ParsedHtml = ({ htmlProps }: Props) => {
 
             // Table class fix, excluding large-table (statistics pages)
             if (tag === 'table' && attribs?.class !== 'statTab') {
-                return (
-                    <Table>{domToReact(validChildren, parserOptions)}</Table>
-                );
+                return <Table>{domToReact(validChildren, parserOptions)}</Table>;
             }
 
             // Replace empty rows with stylable element

--- a/src/components/_common/payout-dates/PayoutDates.tsx
+++ b/src/components/_common/payout-dates/PayoutDates.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PayoutDatesData } from 'types/content-props/payout-dates';
 import { Table } from 'components/_common/table/Table';
 import { formatDate } from 'utils/datetime';

--- a/src/components/_common/press-landing/PressNews.tsx
+++ b/src/components/_common/press-landing/PressNews.tsx
@@ -1,7 +1,9 @@
-import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
-import { translator } from 'translations';
 import { Heading, Link } from '@navikt/ds-react';
 import { ChevronRightIcon } from '@navikt/aksel-icons';
+
+import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
+import { translator } from 'translations';
+
 import { PressNewsItem } from './PressNewsItem';
 
 import styles from './PressNews.module.scss';
@@ -16,10 +18,7 @@ export const PressNews = (props: PressNewsProps) => {
 
     const getTranslations = translator('pressLanding', language);
 
-    if (
-        !pressNews?.data?.sectionContents ||
-        pressNews?.data?.sectionContents?.length === 0
-    ) {
+    if (!pressNews?.data?.sectionContents || pressNews?.data?.sectionContents?.length === 0) {
         return null;
     }
 
@@ -31,10 +30,7 @@ export const PressNews = (props: PressNewsProps) => {
                 </Heading>
                 <ul className={styles.newsList}>
                     {pressNews.data.sectionContents.map((newsItem) => (
-                        <PressNewsItem
-                            newsItem={newsItem}
-                            key={newsItem._path}
-                        />
+                        <PressNewsItem newsItem={newsItem} key={newsItem._path} />
                     ))}
                 </ul>
                 {moreNewsUrl && (

--- a/src/components/_common/press-landing/PressNewsItem.tsx
+++ b/src/components/_common/press-landing/PressNewsItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { translator } from 'translations';
 import { Detail, Heading } from '@navikt/ds-react';
+
+import { translator } from 'translations';
 import { shortenText } from 'utils/string';
 import { StaticImage } from 'components/_common/image/StaticImage';
 import { getPublicPathname } from 'utils/urls';
@@ -41,9 +42,7 @@ export const PressNewsItem = ({ newsItem }: Props) => {
                 </Heading>
             </LenkeBase>
             {newsItem.data?.ingress && (
-                <div className={style.ingress}>
-                    {shortenText(newsItem.data.ingress, 240, 30)}
-                </div>
+                <div className={style.ingress}>{shortenText(newsItem.data.ingress, 240, 30)}</div>
             )}
             <div className={style.newsTagline}>
                 {icon && <StaticImage imageData={icon} alt={''} />}

--- a/src/components/_common/press-landing/PressShortcuts.tsx
+++ b/src/components/_common/press-landing/PressShortcuts.tsx
@@ -1,6 +1,7 @@
+import { Heading, LinkPanel } from '@navikt/ds-react';
+
 import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
 import { translator } from 'translations';
-import { Heading, LinkPanel } from '@navikt/ds-react';
 import { getPublicPathname } from 'utils/urls';
 
 import styles from './PressShortcuts.module.scss';
@@ -15,10 +16,7 @@ export const PressShortcuts = (props: PressShortcutsProps) => {
 
     const shortcuts = props.page.data?.shortcuts;
 
-    if (
-        !shortcuts?.data?.sectionContents ||
-        shortcuts.data.sectionContents.length === 0
-    ) {
+    if (!shortcuts?.data?.sectionContents || shortcuts.data.sectionContents.length === 0) {
         return null;
     }
 

--- a/src/components/_common/press-landing/PressTopSection.tsx
+++ b/src/components/_common/press-landing/PressTopSection.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@navikt/ds-react';
+
 import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 

--- a/src/components/_common/product-panel/ProductPanelExpandable.tsx
+++ b/src/components/_common/product-panel/ProductPanelExpandable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { BodyShort, ExpansionCard, Loader } from '@navikt/ds-react';
+
 import { IllustrationStatic } from 'components/_common/illustration/static/IllustrationStatic';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
@@ -64,40 +65,27 @@ export const ProductPanelExpandable = ({
     }, []);
 
     const handleClick = () => {
-        logAmplitudeEvent(
-            isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
-            {
-                tittel: header,
-                ...analyticsData,
-            }
-        );
+        logAmplitudeEvent(isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND, {
+            tittel: header,
+            ...analyticsData,
+        });
 
         setIsOpen(!isOpen);
         contentLoaderCallback?.();
     };
 
     return (
-        <ExpansionCard
-            open={isOpen}
-            className={style.expandable}
-            id={anchorId}
-            aria-label={header}
-        >
+        <ExpansionCard open={isOpen} className={style.expandable} id={anchorId} aria-label={header}>
             <ExpansionCard.Header
                 onClick={handleClick}
                 onMouseOver={contentLoaderCallback}
                 onFocus={contentLoaderCallback}
                 className={style.expandableHeader}
             >
-                <IllustrationStatic
-                    className={style.illustration}
-                    illustration={illustration}
-                />
+                <IllustrationStatic className={style.illustration} illustration={illustration} />
                 <span className={style.panelHeader}>
                     <span>{header}</span>
-                    {subHeader && (
-                        <span className={style.subHeader}>{subHeader}</span>
-                    )}
+                    {subHeader && <span className={style.subHeader}>{subHeader}</span>}
                 </span>
             </ExpansionCard.Header>
             <ExpansionCard.Content className={style.expandableContent}>

--- a/src/components/_common/qbrick-video/QbrickVideo.tsx
+++ b/src/components/_common/qbrick-video/QbrickVideo.tsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useId } from 'react';
 import { Button, Detail, Label, Loader } from '@navikt/ds-react';
-import { getMediaUrl } from 'utils/urls';
-import { getTimestampFromDuration } from './utils/videoHelpers';
-import { translator } from 'translations';
 import Script from 'next/script';
+
+import { translator } from 'translations';
+import { getMediaUrl } from 'utils/urls';
 import { classNames } from 'utils/classnames';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
-import { useQbrickPlayerState } from './useQbrickPlayerState';
 import { logger } from 'srcCommon/logger';
 import { NextImage } from 'components/_common/image/NextImage';
-import { QbrickVideoProps } from './utils/videoProps';
 import { usePageContentProps } from 'store/pageContext';
+
+import { QbrickVideoProps } from './utils/videoProps';
+import { getTimestampFromDuration } from './utils/videoHelpers';
+import { useQbrickPlayerState } from './useQbrickPlayerState';
 
 import style from './QbrickVideo.module.scss';
 

--- a/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
+++ b/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useId, useState } from 'react';
+
 import { logger } from 'srcCommon/logger';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+
 import { QbrickVideoProps } from './utils/videoProps';
 
 type PlayerState = 'loading' | 'ready' | 'error' | 'stopped';
@@ -13,10 +15,7 @@ type Props = {
     videoContainerId: string;
 };
 
-export const useQbrickPlayerState = ({
-    videoProps,
-    videoContainerId,
-}: Props) => {
+export const useQbrickPlayerState = ({ videoProps, videoContainerId }: Props) => {
     const [playerState, setPlayerState] = useState<PlayerState>('stopped');
     const widgetId = useId();
 
@@ -27,9 +26,7 @@ export const useQbrickPlayerState = ({
 
         const videoContainer = document.getElementById(videoContainerId);
         if (!videoContainer) {
-            logger.error(
-                `Element not found for video container ${videoContainerId}`
-            );
+            logger.error(`Element not found for video container ${videoContainerId}`);
             return;
         }
 

--- a/src/components/_common/qbrick-video/utils/videoHelpers.ts
+++ b/src/components/_common/qbrick-video/utils/videoHelpers.ts
@@ -1,5 +1,6 @@
 import { QbrickMeta } from 'types/qbrickMeta';
 import { fetchJson } from 'srcCommon/fetch-utils';
+
 import { QbrickVideoProps } from './videoProps';
 
 const findImageUrlFromVideoMeta = (qbrickMediaData: QbrickMeta) => {
@@ -10,8 +11,7 @@ const findImageUrlFromVideoMeta = (qbrickMediaData: QbrickMeta) => {
 
     const images = resources.filter((resource) => resource.type === 'image');
 
-    const qBrickPickedThumbnail =
-        qbrickMediaData.thumbnails && qbrickMediaData.thumbnails[0]?.id;
+    const qBrickPickedThumbnail = qbrickMediaData.thumbnails && qbrickMediaData.thumbnails[0]?.id;
 
     // If the specified thumbnail is not found, pick the first image
     const selectedImage =
@@ -34,11 +34,8 @@ const findVideoDurationFromMeta = (qbrickMediaData: QbrickMeta) => {
         return 0;
     }
 
-    const firstFoundResource = resources.find(
-        (resource) => resource.type === 'video'
-    );
-    const firstFoundVideo =
-        firstFoundResource && firstFoundResource.renditions[0]?.videos;
+    const firstFoundResource = resources.find((resource) => resource.type === 'video');
+    const firstFoundVideo = firstFoundResource && firstFoundResource.renditions[0]?.videos;
     const duration = firstFoundVideo && firstFoundVideo[0]?.duration;
 
     return duration || 0;

--- a/src/components/_common/qbrick-video/utils/videoProps.ts
+++ b/src/components/_common/qbrick-video/utils/videoProps.ts
@@ -1,5 +1,6 @@
-import { VideoData } from 'types/content-props/video';
 import { parse } from 'querystring';
+
+import { VideoData } from 'types/content-props/video';
 
 export type QbrickVideoProps = {
     accountId: string;
@@ -10,12 +11,8 @@ export type QbrickVideoProps = {
     language?: string;
 };
 
-export const buildQbrickVideoProps = (
-    videoData: VideoData,
-    language: string
-): QbrickVideoProps => {
-    const { accountId, mediaId, poster, duration, title, subtitles } =
-        videoData;
+export const buildQbrickVideoProps = (videoData: VideoData, language: string): QbrickVideoProps => {
+    const { accountId, mediaId, poster, duration, title, subtitles } = videoData;
 
     return {
         accountId,
@@ -55,21 +52,15 @@ export const buildQbrickVideoPropsLegacy = (
     };
 };
 
-const getSubtitlesLanguage = (
-    language: string,
-    subtitles: VideoData['subtitles']
-) => {
+const getSubtitlesLanguage = (language: string, subtitles: VideoData['subtitles']) => {
     if (!subtitles) {
         return undefined;
     }
 
     const selectedLanguage = transformLanguage(language);
 
-    return subtitles.find(
-        (language) => transformLanguage(language) === selectedLanguage
-    );
+    return subtitles.find((language) => transformLanguage(language) === selectedLanguage);
 };
 
 // Ensure 'nb' (norsk bokmål) and 'no' (norsk) are treated as equal;
-const transformLanguage = (language: string) =>
-    language === 'no' ? 'nb' : language;
+const transformLanguage = (language: string) => (language === 'no' ? 'nb' : language);

--- a/src/components/_common/relatedSituations/RelatedSituations.tsx
+++ b/src/components/_common/relatedSituations/RelatedSituations.tsx
@@ -1,4 +1,5 @@
 import { BodyLong, Heading } from '@navikt/ds-react';
+
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { MicroCard } from 'components/_common/card/MicroCard';

--- a/src/components/_common/table/Table.tsx
+++ b/src/components/_common/table/Table.tsx
@@ -16,57 +16,49 @@ const TableContext = React.createContext<TableContextProps>({});
 const TableComponent = ({ children }: Props) => {
     const { shadeOnHover } = useContext(TableContext);
 
-    const elements = React.Children.map(
-        children as React.ReactElement,
-        (child: ReactElement) => {
-            const { type, props } = child;
+    const elements = React.Children.map(children as React.ReactElement, (child: ReactElement) => {
+        const { type, props } = child;
 
-            switch (type) {
-                case 'thead':
-                    return (
-                        <DsTable.Header {...props}>
-                            <TableComponent>{props.children}</TableComponent>
-                        </DsTable.Header>
-                    );
-                case 'tbody':
-                    return (
-                        <DsTable.Body {...props}>
-                            <TableComponent>{props.children}</TableComponent>
-                        </DsTable.Body>
-                    );
-                case 'th':
-                    return (
-                        <DsTable.HeaderCell {...props}>
-                            <TableComponent>{props.children}</TableComponent>
-                        </DsTable.HeaderCell>
-                    );
-                case 'tr':
-                    return (
-                        <DsTable.Row {...props} shadeOnHover={shadeOnHover}>
-                            <TableComponent>{props.children}</TableComponent>
-                        </DsTable.Row>
-                    );
-                case 'td':
-                    return (
-                        <DsTable.DataCell {...props}>
-                            <TableComponent>{props.children}</TableComponent>
-                        </DsTable.DataCell>
-                    );
-                default:
-                    return child;
-            }
+        switch (type) {
+            case 'thead':
+                return (
+                    <DsTable.Header {...props}>
+                        <TableComponent>{props.children}</TableComponent>
+                    </DsTable.Header>
+                );
+            case 'tbody':
+                return (
+                    <DsTable.Body {...props}>
+                        <TableComponent>{props.children}</TableComponent>
+                    </DsTable.Body>
+                );
+            case 'th':
+                return (
+                    <DsTable.HeaderCell {...props}>
+                        <TableComponent>{props.children}</TableComponent>
+                    </DsTable.HeaderCell>
+                );
+            case 'tr':
+                return (
+                    <DsTable.Row {...props} shadeOnHover={shadeOnHover}>
+                        <TableComponent>{props.children}</TableComponent>
+                    </DsTable.Row>
+                );
+            case 'td':
+                return (
+                    <DsTable.DataCell {...props}>
+                        <TableComponent>{props.children}</TableComponent>
+                    </DsTable.DataCell>
+                );
+            default:
+                return child;
         }
-    );
+    });
 
     return <>{elements}</>;
 };
 
-export const Table = ({
-    children,
-    zebraStripes = true,
-    shadeOnHover = true,
-    ...rest
-}: Props) => {
+export const Table = ({ children, zebraStripes = true, shadeOnHover = true, ...rest }: Props) => {
     const context = useMemo<TableContextProps>(
         () => ({
             shadeOnHover,

--- a/src/components/_common/text-with-indicator/TextWithIndicator.tsx
+++ b/src/components/_common/text-with-indicator/TextWithIndicator.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import style from './TextWithIndicator.module.scss';
+
 import { classNames } from 'utils/classnames';
+
+import style from './TextWithIndicator.module.scss';
 
 type Props = {
     text: string;
@@ -13,10 +15,7 @@ const TextWithIndicator = (props: Props) => {
     return (
         <div className={style.textWithIndicator}>
             <span
-                className={classNames(
-                    style.indicator,
-                    isActive ? style.active : style.inactive
-                )}
+                className={classNames(style.indicator, isActive ? style.active : style.inactive)}
             />
             <span>
                 {prefix && <span className={style.prefix}>{prefix}&nbsp;</span>}

--- a/src/components/_common/user-tests/UserTests.tsx
+++ b/src/components/_common/user-tests/UserTests.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { UserTestsEditorView } from 'components/_common/user-tests/editor-view/UserTestsEditorView';
 import { UserTestsPublicView } from 'components/_common/user-tests/public-view/UserTestsPublicView';
@@ -18,11 +19,7 @@ export const UserTests = (props: UserTestsComponentProps) => {
 
     return (
         <div className={style.wrapper}>
-            {editorView ? (
-                <UserTestsEditorView {...props} />
-            ) : (
-                <UserTestsPublicView {...props} />
-            )}
+            {editorView ? <UserTestsEditorView {...props} /> : <UserTestsPublicView {...props} />}
         </div>
     );
 };

--- a/src/components/_common/user-tests/editor-view/UserTestsEditorView.tsx
+++ b/src/components/_common/user-tests/editor-view/UserTestsEditorView.tsx
@@ -1,26 +1,20 @@
 import React from 'react';
+import { BodyLong, Detail } from '@navikt/ds-react';
+
 import { UserTestsComponentProps } from 'components/_common/user-tests/UserTests';
 import { UserTestVariant } from 'components/_common/user-tests/variants/UserTestVariant';
 import { formatDateTime, isCurrentTimeInRange } from 'utils/datetime';
-import { BodyLong, Detail } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 
 import style from './UserTestsEditorView.module.scss';
 
-export const UserTestsEditorView = ({
-    tests,
-    selectedTestIds,
-}: UserTestsComponentProps) => {
+export const UserTestsEditorView = ({ tests, selectedTestIds }: UserTestsComponentProps) => {
     const { data } = tests;
 
     const { variants, startTime, endTime } = data;
 
-    const fromString = startTime
-        ? ` fra ${formatDateTime(startTime, 'nb', true)}`
-        : '';
-    const toString = endTime
-        ? ` til ${formatDateTime(endTime, 'nb', true)}`
-        : '';
+    const fromString = startTime ? ` fra ${formatDateTime(startTime, 'nb', true)}` : '';
+    const toString = endTime ? ` til ${formatDateTime(endTime, 'nb', true)}` : '';
 
     const hasDateTimeRange = fromString || toString;
 
@@ -34,16 +28,12 @@ export const UserTestsEditorView = ({
                     <strong>{isActive ? 'aktiv' : 'ikke aktiv'}</strong>
                 </BodyLong>
                 <Detail>
-                    {hasDateTimeRange
-                        ? `Aktivert${fromString}${toString}`
-                        : 'Ingen tidsbegrensing'}
+                    {hasDateTimeRange ? `Aktivert${fromString}${toString}` : 'Ingen tidsbegrensing'}
                 </Detail>
             </div>
             {variants.map((variant) => {
                 const { id, percentage } = variant;
-                const isSelected =
-                    selectedTestIds.length === 0 ||
-                    selectedTestIds.includes(id);
+                const isSelected = selectedTestIds.length === 0 || selectedTestIds.includes(id);
 
                 return (
                     <div key={id} className={style.variant}>
@@ -52,15 +42,12 @@ export const UserTestsEditorView = ({
                             <strong>{id}</strong>
                             {' - Andel: '}
                             <strong>{`${percentage}%`}</strong>
-                            {!isSelected &&
-                                ' (ikke aktivert i denne komponenten)'}
+                            {!isSelected && ' (ikke aktivert i denne komponenten)'}
                         </Detail>
                         <UserTestVariant
                             testsData={data}
                             variant={variant}
-                            className={classNames(
-                                !isSelected && style.disabled
-                            )}
+                            className={classNames(!isSelected && style.disabled)}
                         />
                     </div>
                 );

--- a/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
+++ b/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
-import { UserTestsPublicView } from 'components/_common/user-tests/public-view/UserTestsPublicView';
-import { UserTestsComponentProps } from 'components/_common/user-tests/UserTests';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { mockStore } from 'store/store';
 import Cookie from 'js-cookie';
+
+import { UserTestsPublicView } from 'components/_common/user-tests/public-view/UserTestsPublicView';
+import { UserTestsComponentProps } from 'components/_common/user-tests/UserTests';
+import { mockStore } from 'store/store';
 import { UserTestVariantProps } from 'types/content-props/user-tests-config';
 import { PageContextProvider } from 'store/pageContext';
 
@@ -23,10 +24,7 @@ const baseProps: UserTestsComponentProps = {
     },
 };
 
-const buildProps = (
-    variants: UserTestVariantProps[],
-    selectedTestIds: string[] = []
-) => {
+const buildProps = (variants: UserTestVariantProps[], selectedTestIds: string[] = []) => {
     const props = { ...baseProps };
     props.tests.data.variants = variants;
     props.selectedTestIds = selectedTestIds;
@@ -42,8 +40,7 @@ const UserTestsWithProvider = (props: UserTestsComponentProps) => (
     </PageContextProvider>
 );
 
-const mockRandom = (num: number) =>
-    jest.spyOn(Math, 'random').mockReturnValue(num);
+const mockRandom = (num: number) => jest.spyOn(Math, 'random').mockReturnValue(num);
 
 beforeEach(() => {
     jest.spyOn(Math, 'random').mockClear();
@@ -203,71 +200,43 @@ describe('Multiple variants with limited selection', () => {
         },
     ];
 
-    test.each([0.01, 0.99])(
-        'Should pick the first variant from single selection',
-        () => {
-            render(
-                <UserTestsWithProvider
-                    {...buildProps(variants, ['variant-1'])}
-                />
-            );
+    test.each([0.01, 0.99])('Should pick the first variant from single selection', () => {
+        render(<UserTestsWithProvider {...buildProps(variants, ['variant-1'])} />);
 
-            expect(screen.queryByText('Variant 1')).toBeTruthy();
-            expect(screen.queryByText('Variant 2')).toBeFalsy();
-            expect(screen.queryByText('Variant 3')).toBeFalsy();
-            expect(screen.queryByText('Variant 4')).toBeFalsy();
-        }
-    );
+        expect(screen.queryByText('Variant 1')).toBeTruthy();
+        expect(screen.queryByText('Variant 2')).toBeFalsy();
+        expect(screen.queryByText('Variant 3')).toBeFalsy();
+        expect(screen.queryByText('Variant 4')).toBeFalsy();
+    });
 
-    test.each([0.01, 0.99])(
-        'Should pick the second variant from single selection',
-        () => {
-            render(
-                <UserTestsWithProvider
-                    {...buildProps(variants, ['variant-2'])}
-                />
-            );
+    test.each([0.01, 0.99])('Should pick the second variant from single selection', () => {
+        render(<UserTestsWithProvider {...buildProps(variants, ['variant-2'])} />);
 
-            expect(screen.queryByText('Variant 1')).toBeFalsy();
-            expect(screen.queryByText('Variant 2')).toBeTruthy();
-            expect(screen.queryByText('Variant 3')).toBeFalsy();
-            expect(screen.queryByText('Variant 4')).toBeFalsy();
-        }
-    );
+        expect(screen.queryByText('Variant 1')).toBeFalsy();
+        expect(screen.queryByText('Variant 2')).toBeTruthy();
+        expect(screen.queryByText('Variant 3')).toBeFalsy();
+        expect(screen.queryByText('Variant 4')).toBeFalsy();
+    });
 
-    test.each([0.01, 0.5])(
-        'Should pick the first variant from double selection',
-        () => {
-            mockRandom(0.49);
-            render(
-                <UserTestsWithProvider
-                    {...buildProps(variants, ['variant-1', 'variant-2'])}
-                />
-            );
+    test.each([0.01, 0.5])('Should pick the first variant from double selection', () => {
+        mockRandom(0.49);
+        render(<UserTestsWithProvider {...buildProps(variants, ['variant-1', 'variant-2'])} />);
 
-            expect(screen.queryByText('Variant 1')).toBeTruthy();
-            expect(screen.queryByText('Variant 2')).toBeFalsy();
-            expect(screen.queryByText('Variant 3')).toBeFalsy();
-            expect(screen.queryByText('Variant 4')).toBeFalsy();
-        }
-    );
+        expect(screen.queryByText('Variant 1')).toBeTruthy();
+        expect(screen.queryByText('Variant 2')).toBeFalsy();
+        expect(screen.queryByText('Variant 3')).toBeFalsy();
+        expect(screen.queryByText('Variant 4')).toBeFalsy();
+    });
 
-    test.each([0.501, 0.999])(
-        'Should pick the fourth variant from double selection',
-        () => {
-            mockRandom(0.51);
-            render(
-                <UserTestsWithProvider
-                    {...buildProps(variants, ['variant-1', 'variant-4'])}
-                />
-            );
+    test.each([0.501, 0.999])('Should pick the fourth variant from double selection', () => {
+        mockRandom(0.51);
+        render(<UserTestsWithProvider {...buildProps(variants, ['variant-1', 'variant-4'])} />);
 
-            expect(screen.queryByText('Variant 1')).toBeFalsy();
-            expect(screen.queryByText('Variant 2')).toBeFalsy();
-            expect(screen.queryByText('Variant 3')).toBeFalsy();
-            expect(screen.queryByText('Variant 4')).toBeTruthy();
-        }
-    );
+        expect(screen.queryByText('Variant 1')).toBeFalsy();
+        expect(screen.queryByText('Variant 2')).toBeFalsy();
+        expect(screen.queryByText('Variant 3')).toBeFalsy();
+        expect(screen.queryByText('Variant 4')).toBeTruthy();
+    });
 });
 
 describe('Persist variant selection', () => {

--- a/src/components/_common/user-tests/public-view/UserTestsPublicView.tsx
+++ b/src/components/_common/user-tests/public-view/UserTestsPublicView.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { isCurrentTimeInRange } from 'utils/datetime';
 import { useIsClientSide } from 'utils/useIsClientSide';
 import { UserTestsComponentProps } from 'components/_common/user-tests/UserTests';
@@ -64,9 +65,7 @@ const pickApplicableVariant = ({
 
     const previouslySelectedVariantId = userTestGetSelectedVariantId(cookieId);
     if (previouslySelectedVariantId) {
-        return selectableVariants.find(
-            (variant) => variant.id === previouslySelectedVariantId
-        );
+        return selectableVariants.find((variant) => variant.id === previouslySelectedVariantId);
     }
 
     return selectRandomVariant(variants, selectableVariants);

--- a/src/components/_common/user-tests/variants/UserTestVariant.tsx
+++ b/src/components/_common/user-tests/variants/UserTestVariant.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { BodyLong, Heading } from '@navikt/ds-react';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { classNames } from 'utils/classnames';
-import {
-    UserTestsConfigData,
-    UserTestVariantProps,
-} from 'types/content-props/user-tests-config';
+import { UserTestsConfigData, UserTestVariantProps } from 'types/content-props/user-tests-config';
 
 import style from './UserTestVariant.module.scss';
 
@@ -18,12 +16,7 @@ type Props = {
 export const UserTestVariant = ({ testsData, variant, className }: Props) => {
     const { title, ingress } = testsData;
 
-    const {
-        title: variantTitle,
-        ingress: variantIngress,
-        url,
-        linkText,
-    } = variant;
+    const { title: variantTitle, ingress: variantIngress, url, linkText } = variant;
 
     return (
         <div className={classNames(style.testVariant, className)}>

--- a/src/components/_common/uxsignals-widget/UxSignalsWidget.tsx
+++ b/src/components/_common/uxsignals-widget/UxSignalsWidget.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import Script from 'next/script';
+
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 import style from './UxSignalsWidget.module.scss';
 
@@ -13,19 +14,11 @@ export const UxSignalsWidget = ({ embedCode }: Props) => {
         <>
             <Script
                 type={'module'}
-                src={
-                    'https://uxsignals-frontend.uxsignals.app.iterate.no/embed.js'
-                }
+                src={'https://uxsignals-frontend.uxsignals.app.iterate.no/embed.js'}
                 async={true}
             />
-            <div
-                data-uxsignals-embed={embedCode}
-                className={style.uxSignalsWidget}
-            />
-            <EditorHelp
-                text={'UX Signals rekrutterings-widget'}
-                type={'info'}
-            />
+            <div data-uxsignals-embed={embedCode} className={style.uxSignalsWidget} />
+            <EditorHelp text={'UX Signals rekrutterings-widget'} type={'info'} />
         </>
     );
 };

--- a/src/components/_editor-only/EditorWidgets.tsx
+++ b/src/components/_editor-only/EditorWidgets.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { EditorHacks } from 'components/_editor-only/editor-hacks/EditorHacks';
 import { EditorGlobalWarnings } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
@@ -23,18 +24,12 @@ export const EditorWidgets = ({ content }: Props) => {
     const whiteBg = hasWhiteHeader(content);
 
     return (
-        <div
-            className={classNames(
-                style.outer,
-                whiteBg && style.whiteBackground
-            )}
-        >
+        <div className={classNames(style.outer, whiteBg && style.whiteBackground)}>
             <div className={style.inner}>
                 <EditorHacks content={content} />
-                {!liveId &&
-                    (editorView === 'inline' || editorView === 'edit') && (
-                        <ReferencesInfo content={content} />
-                    )}
+                {!liveId && (editorView === 'inline' || editorView === 'edit') && (
+                    <ReferencesInfo content={content} />
+                )}
                 <EditorGlobalWarnings key={content._id} />
                 {editorView !== 'edit' && <VersionHistory content={content} />}
             </div>

--- a/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.tsx
+++ b/src/components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { BodyLong } from '@navikt/ds-react';
+
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { removeDuplicates } from 'utils/arrays';
-import { BodyLong } from '@navikt/ds-react';
 import { Header } from 'components/_common/headers/Header';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
@@ -10,16 +11,13 @@ import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/E
 import style from './DuplicateIdsWarning.module.scss';
 
 export const DuplicateIdsWarning = () => {
-    const [elementsWithDupeIds, setElementsWithDupeIds] = useState<
-        HTMLElement[]
-    >([]);
+    const [elementsWithDupeIds, setElementsWithDupeIds] = useState<HTMLElement[]>([]);
 
     const linkIdPrefix = useId();
 
-    const uniqueDupeIds = removeDuplicates(
-        elementsWithDupeIds,
-        (a, b) => a.id === b.id
-    ).map((element) => element.id);
+    const uniqueDupeIds = removeDuplicates(elementsWithDupeIds, (a, b) => a.id === b.id).map(
+        (element) => element.id
+    );
 
     const getLinkId = (index: number) => `${linkIdPrefix}-${index}`;
 
@@ -36,8 +34,7 @@ export const DuplicateIdsWarning = () => {
                     // something our editors generelly don't deal with
                     !element1.closest('svg') &&
                     array.some(
-                        (element2, index2) =>
-                            element1.id === element2.id && index1 !== index2
+                        (element2, index2) => element1.id === element2.id && index1 !== index2
                     )
             );
 
@@ -49,9 +46,7 @@ export const DuplicateIdsWarning = () => {
         <>
             {uniqueDupeIds.length > 0 && (
                 <div>
-                    <Header level={'2'}>{`Obs! Denne siden har ${
-                        uniqueDupeIds.length
-                    } id${
+                    <Header level={'2'}>{`Obs! Denne siden har ${uniqueDupeIds.length} id${
                         uniqueDupeIds.length > 1 ? "'er" : ''
                     } med duplikate forekomster:`}</Header>
                     <ul>
@@ -63,11 +58,7 @@ export const DuplicateIdsWarning = () => {
                                         if (element.id === id) {
                                             acc.push(
                                                 <EditorLinkWrapper>
-                                                    <LenkeInline
-                                                        href={`#${getLinkId(
-                                                            index
-                                                        )}`}
-                                                    >
+                                                    <LenkeInline href={`#${getLinkId(index)}`}>
                                                         {`[${acc.length + 1}]`}
                                                     </LenkeInline>
                                                 </EditorLinkWrapper>

--- a/src/components/_editor-only/editor-hacks/EditorHacks.tsx
+++ b/src/components/_editor-only/editor-hacks/EditorHacks.tsx
@@ -1,9 +1,10 @@
 import { ContentProps } from 'types/content-props/_content-common';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
+import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
+
 import { AutoReloadDisableHack } from './auto-refresh-disable/AutoReloadDisableHack';
 import { SetSidepanelToggleHack } from './set-sidepanels-defaults/SetSidepanelToggleHack';
 import { CustomSelectorLinkTargetHack } from './custom-selector-link-target/CustomSelectorLinkTargetHack';
-import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
-import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 // This implements quality-of-life fixes to improve the experiences for Content Studio users
 
@@ -22,9 +23,9 @@ export const EditorHacks = ({ content }: Props) => {
         <>
             {editorView === 'edit' && (
                 <>
-                    {isEditorFeatureEnabled(
-                        EditorFeature.EditorReloadBlocker
-                    ) && <AutoReloadDisableHack content={content} />}
+                    {isEditorFeatureEnabled(EditorFeature.EditorReloadBlocker) && (
+                        <AutoReloadDisableHack content={content} />
+                    )}
                     <CustomSelectorLinkTargetHack />
                     {isEditorFeatureEnabled(EditorFeature.HideLeftPanel) && (
                         <SetSidepanelToggleHack contentId={_id} />

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/AutoReloadDisableHack.tsx
@@ -1,15 +1,17 @@
+import { BodyLong } from '@navikt/ds-react';
+import { useEffect, useState } from 'react';
+
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { BodyLong } from '@navikt/ds-react';
 import { ContentProps } from 'types/content-props/_content-common';
-import { useEffect, useState } from 'react';
+import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
+import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
+
 import {
     hookDispatchEventForBatchContentServerEvent,
     unhookDispatchEventForBatchContentServerEvent,
 } from './dispatch-event-hook';
-import { isEditorFeatureEnabled } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
-import { EditorFeature } from 'components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles';
 
 import style from './AutoRefreshDisableHack.module.scss';
 
@@ -30,13 +32,9 @@ type Props = {
 };
 
 export const AutoReloadDisableHack = ({ content }: Props) => {
-    const [externalUpdateEvent, setExternalUpdateEvent] =
-        useState<CustomEvent | null>(null);
-    const [externalContentChange, setExternalContentChange] =
-        useState<boolean>(false);
-    const [externalUserName, setExternalUserName] = useState<string | null>(
-        null
-    );
+    const [externalUpdateEvent, setExternalUpdateEvent] = useState<CustomEvent | null>(null);
+    const [externalContentChange, setExternalContentChange] = useState<boolean>(false);
+    const [externalUserName, setExternalUserName] = useState<string | null>(null);
 
     useEffect(() => {
         hookDispatchEventForBatchContentServerEvent({
@@ -49,10 +47,7 @@ export const AutoReloadDisableHack = ({ content }: Props) => {
         return unhookDispatchEventForBatchContentServerEvent;
     }, [content]);
 
-    if (
-        !externalContentChange ||
-        !isEditorFeatureEnabled(EditorFeature.ContentModifiedWarning)
-    ) {
+    if (!externalContentChange || !isEditorFeatureEnabled(EditorFeature.ContentModifiedWarning)) {
         return null;
     }
 
@@ -70,11 +65,8 @@ export const AutoReloadDisableHack = ({ content }: Props) => {
                                 e.preventDefault();
                                 setExternalContentChange(false);
                                 if (externalUpdateEvent) {
-                                    externalUpdateEvent.detail.userTriggered =
-                                        true;
-                                    parent.window.dispatchEvent(
-                                        externalUpdateEvent
-                                    );
+                                    externalUpdateEvent.detail.userTriggered = true;
+                                    parent.window.dispatchEvent(externalUpdateEvent);
                                 }
                             }}
                         >

--- a/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
+++ b/src/components/_editor-only/editor-hacks/auto-refresh-disable/dispatch-event-hook.ts
@@ -40,8 +40,7 @@ type BatchContentServerEventDetail = {
     userTriggered?: true;
 };
 
-const getUserNameFromEmail = (email: string) =>
-    email.split('@')[0].replace('.', ' ');
+const getUserNameFromEmail = (email: string) => email.split('@')[0].replace('.', ' ');
 
 const ignoredContentTypes: ReadonlySet<ContentType> = new Set([
     ContentType.GlobalNumberValuesSet,
@@ -88,10 +87,7 @@ export const hookDispatchEventForBatchContentServerEvent = async ({
 
         // We only want to intercept update events of the BatchContentServerEvent type, which is what triggers UI updates
         // for content changes on the client. All other events should be dispatched as normal.
-        if (
-            eventType !== 'BatchContentServerEvent' ||
-            detailType !== NodeServerChangeType.UPDATE
-        ) {
+        if (eventType !== 'BatchContentServerEvent' || detailType !== NodeServerChangeType.UPDATE) {
             return dispatchEvent(event);
         }
 
@@ -105,9 +101,7 @@ export const hookDispatchEventForBatchContentServerEvent = async ({
         // is not very useful.
         // (this probably indicates that the undocumented api used here has changed)
         if (!userId) {
-            logger.error(
-                'Could not determine the current user - dispatching event'
-            );
+            logger.error('Could not determine the current user - dispatching event');
             return dispatchEvent(event);
         }
 
@@ -144,9 +138,7 @@ export const hookDispatchEventForBatchContentServerEvent = async ({
 
                 editorFetchUserInfo(content.modifier).then((userInfo) => {
                     if (userInfo?.displayName) {
-                        setExternalUserName(
-                            getUserNameFromEmail(userInfo.displayName)
-                        );
+                        setExternalUserName(getUserNameFromEmail(userInfo.displayName));
                     }
 
                     setExternalContentChange(true);

--- a/src/components/_editor-only/editor-hacks/custom-selector-link-target/CustomSelectorLinkTargetHack.tsx
+++ b/src/components/_editor-only/editor-hacks/custom-selector-link-target/CustomSelectorLinkTargetHack.tsx
@@ -18,11 +18,7 @@ export const CustomSelectorLinkTargetHack = () => {
         const callback: MutationCallback = (mutations) => {
             mutations.forEach((mutation) => {
                 mutation.addedNodes.forEach((node) => {
-                    if (
-                        (node as Element).classList?.contains(
-                            customSelectorLinkClassName
-                        )
-                    ) {
+                    if ((node as Element).classList?.contains(customSelectorLinkClassName)) {
                         (node as HTMLAnchorElement).target = '_blank';
                     }
                 });

--- a/src/components/_editor-only/editor-hacks/editor-hacks-utils.ts
+++ b/src/components/_editor-only/editor-hacks/editor-hacks-utils.ts
@@ -11,12 +11,10 @@ const CONTENT_REPO_PREFIX = 'com.enonic.cms.';
 // The pathname in the editor view looks like this:
 // /admin/tool/com.enonic.app.contentstudio/main/<project id>/edit/<content id>
 const getProjectIdFromCurrentEditorUrl = () =>
-    typeof window !== 'undefined' &&
-    parent.window.location.pathname.split('/')[5];
+    typeof window !== 'undefined' && parent.window.location.pathname.split('/')[5];
 
 // Content repo-ids look like this: com.enonic.cms.<project-id>
-const getProjectIdFromRepoId = (repoId: string) =>
-    repoId.replace(CONTENT_REPO_PREFIX, '');
+const getProjectIdFromRepoId = (repoId: string) => repoId.replace(CONTENT_REPO_PREFIX, '');
 
 const getContentServiceUrl = (projectId: string) =>
     `${adminOrigin}/admin/rest-v2/cs/cms/${projectId}/content/content`;
@@ -43,13 +41,8 @@ export const editorFetchAdminUserId = () =>
         return res?.user?.key;
     });
 
-export const editorFetchAdminContent = async (
-    contentId: string,
-    repoId?: string
-) => {
-    const projectId = repoId
-        ? getProjectIdFromRepoId(repoId)
-        : getProjectIdFromCurrentEditorUrl();
+export const editorFetchAdminContent = async (contentId: string, repoId?: string) => {
+    const projectId = repoId ? getProjectIdFromRepoId(repoId) : getProjectIdFromCurrentEditorUrl();
 
     if (!projectId) {
         logger.error('Could not determine projectId');
@@ -68,5 +61,4 @@ export const editorFetchUserInfo = async (userId: string) =>
 export const isCurrentEditorRepo = (repoId: string) =>
     getProjectIdFromRepoId(repoId) === getProjectIdFromCurrentEditorUrl();
 
-export const isContentRepo = (repoId?: string) =>
-    repoId?.startsWith(CONTENT_REPO_PREFIX);
+export const isContentRepo = (repoId?: string) => repoId?.startsWith(CONTENT_REPO_PREFIX);

--- a/src/components/_editor-only/editor-hacks/set-sidepanels-defaults/SetSidepanelToggleHack.tsx
+++ b/src/components/_editor-only/editor-hacks/set-sidepanels-defaults/SetSidepanelToggleHack.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+
 import { editorFetchAdminContent } from 'components/_editor-only/editor-hacks/editor-hacks-utils';
 
 /*

--- a/src/components/_editor-only/editor-help/EditorHelp.tsx
+++ b/src/components/_editor-only/editor-help/EditorHelp.tsx
@@ -1,8 +1,9 @@
 import React, { useId } from 'react';
+import { BodyShort } from '@navikt/ds-react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { StaticImage } from 'components/_common/image/StaticImage';
 import { classNames } from 'utils/classnames';
-import { BodyShort } from '@navikt/ds-react';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { RenderToEditorGlobalWarnings } from 'components/_editor-only/global-warnings/EditorGlobalWarnings';
@@ -31,11 +32,7 @@ type Props = {
     type?: 'info' | 'error' | 'help' | 'arrowUp' | 'arrowDown';
 };
 
-export const EditorHelp = ({
-    text,
-    globalWarningText,
-    type = 'help',
-}: Props) => {
+export const EditorHelp = ({ text, globalWarningText, type = 'help' }: Props) => {
     const { editorView } = usePageContentProps();
 
     const id = useId();
@@ -68,9 +65,7 @@ export const EditorHelp = ({
                 <RenderToEditorGlobalWarnings>
                     <span>{globalWarningText}</span>
                     <EditorLinkWrapper>
-                        <LenkeInline href={`#${id}`}>
-                            {'[Til feilen]'}
-                        </LenkeInline>
+                        <LenkeInline href={`#${id}`}>{'[Til feilen]'}</LenkeInline>
                     </EditorLinkWrapper>
                 </RenderToEditorGlobalWarnings>
             )}

--- a/src/components/_editor-only/editor-link-wrapper/EditorLinkWrapper.tsx
+++ b/src/components/_editor-only/editor-link-wrapper/EditorLinkWrapper.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { getRelativePathIfInternal } from 'utils/urls';
 
@@ -28,9 +29,7 @@ export const EditorLinkWrapper = ({ children }: Props) => {
     const { className, href, onClick, target } =
         child.props as React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-    const hrefFinal = href
-        ? getRelativePathIfInternal(href, !!editorView)
-        : undefined;
+    const hrefFinal = href ? getRelativePathIfInternal(href, !!editorView) : undefined;
 
     return (
         <span

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+
 import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
 
 import style from './EditorGlobalWarnings.module.scss';
 
 const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
 
-export const RenderToEditorGlobalWarnings = ({
-    children,
-}: {
-    children: React.ReactNode;
-}) => {
+export const RenderToEditorGlobalWarnings = ({ children }: { children: React.ReactNode }) => {
     const [isFirstRender, setIsFirstRender] = useState(true);
 
     useEffect(() => {
@@ -21,9 +18,7 @@ export const RenderToEditorGlobalWarnings = ({
         return null;
     }
 
-    const element = document.getElementById(
-        EDITOR_GLOBAL_WARNINGS_CONTAINER_ID
-    );
+    const element = document.getElementById(EDITOR_GLOBAL_WARNINGS_CONTAINER_ID);
     if (!element) {
         return null;
     }
@@ -33,10 +28,7 @@ export const RenderToEditorGlobalWarnings = ({
 
 export const EditorGlobalWarnings = () => {
     return (
-        <div
-            className={style.container}
-            id={EDITOR_GLOBAL_WARNINGS_CONTAINER_ID}
-        >
+        <div className={style.container} id={EDITOR_GLOBAL_WARNINGS_CONTAINER_ID}>
             <DuplicateIdsWarning />
         </div>
     );

--- a/src/components/_editor-only/layers-editor-warning/LayersEditorWarning.tsx
+++ b/src/components/_editor-only/layers-editor-warning/LayersEditorWarning.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { Heading } from '@navikt/ds-react';
+
+import { AlertBox } from 'components/_common/alert-box/AlertBox';
 
 export const LayersEditorWarning = () => {
     return (

--- a/src/components/_editor-only/references-info/ReferencesInfo.tsx
+++ b/src/components/_editor-only/references-info/ReferencesInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BodyLong, BodyShort, Heading, Loader } from '@navikt/ds-react';
+
 import { ReferencesInfoResult } from 'components/_editor-only/references-info/result/ReferencesInfoResult';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { useFetchReferencesInfo } from 'components/_editor-only/references-info/useFetchReferencesInfo';
@@ -35,15 +36,10 @@ export const ReferencesInfo = ({ content }: Props) => {
                     <Heading level={'3'} size={'small'}>
                         {`Feil: ${references.message}`}
                     </Heading>
-                    <BodyLong>
-                        {'Forsøk å laste inn editoren på nytt.'}
-                    </BodyLong>
+                    <BodyLong>{'Forsøk å laste inn editoren på nytt.'}</BodyLong>
                 </AlertBox>
             ) : (
-                <ReferencesInfoResult
-                    references={references.references}
-                    content={content}
-                />
+                <ReferencesInfoResult references={references.references} content={content} />
             )}
         </div>
     );

--- a/src/components/_editor-only/references-info/result/ReferencesInfoResult.tsx
+++ b/src/components/_editor-only/references-info/result/ReferencesInfoResult.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Heading } from '@navikt/ds-react';
+
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { Button } from 'components/_common/button/Button';
 import { ReferencesLinks } from 'components/_editor-only/references-info/result/link/ReferencesLinks';

--- a/src/components/_editor-only/references-info/result/link/ReferencesLinks.tsx
+++ b/src/components/_editor-only/references-info/result/link/ReferencesLinks.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { Heading } from '@navikt/ds-react';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { ReferenceItem } from 'components/_editor-only/references-info/types';
-import { Heading } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { adminOrigin } from 'utils/urls';
 import { usePageContentProps } from 'store/pageContext';
@@ -15,11 +16,7 @@ type Props = {
     contentLayer?: string;
 };
 
-export const ReferencesLinks = ({
-    references,
-    headerText,
-    contentLayer,
-}: Props) => {
+export const ReferencesLinks = ({ references, headerText, contentLayer }: Props) => {
     const { editorView } = usePageContentProps();
 
     const languageNames = translator('localeNames', 'no');
@@ -33,17 +30,13 @@ export const ReferencesLinks = ({
                 const { id, name, path, editorPath, layer } = reference;
 
                 const layersIndicatorText =
-                    layer !== contentLayer
-                        ? `[Layer: ${languageNames(layer)}] `
-                        : null;
+                    layer !== contentLayer ? `[Layer: ${languageNames(layer)}] ` : null;
 
                 const href = `${adminOrigin}${editorPath}`;
 
                 return (
                     <div className={style.link} key={id}>
-                        {layersIndicatorText && (
-                            <strong>{layersIndicatorText}</strong>
-                        )}
+                        {layersIndicatorText && <strong>{layersIndicatorText}</strong>}
                         {`${name}: `}
                         <EditorLinkWrapper>
                             <LenkeInline

--- a/src/components/_editor-only/references-info/useFetchReferencesInfo.ts
+++ b/src/components/_editor-only/references-info/useFetchReferencesInfo.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { xpDraftPathPrefix, xpServicePath } from 'utils/urls';
 import { fetchJson } from 'srcCommon/fetch-utils';
 import { ReferencesDataByType } from 'components/_editor-only/references-info/types';
@@ -21,10 +22,7 @@ type ServiceResponse =
 
 const SERVICE_URL = `${xpDraftPathPrefix}${xpServicePath}/references`;
 
-export const useFetchReferencesInfo = (
-    contentId: string,
-    contentLayer?: string
-) => {
+export const useFetchReferencesInfo = (contentId: string, contentLayer?: string) => {
     const [references, setReferences] = useState<ServiceResponse>({
         result: 'notimpl',
     });

--- a/src/components/_editor-only/site-info/SiteInfo.tsx
+++ b/src/components/_editor-only/site-info/SiteInfo.tsx
@@ -1,13 +1,15 @@
 import Head from 'next/head';
 import React from 'react';
+
 import { DocumentParameter } from 'components/_common/metatags/DocumentParameterMetatags';
+
 import { SiteInfoHeader } from './header/SiteInfoHeader';
 import { SiteInfoProps } from './types';
 import { SiteInfoPublishInfo } from './publish-info/SiteInfoPublishInfo';
 import { SiteInfoCustomPaths } from './custom-paths/SiteInfoCustomPaths';
+import { SiteInfoFeatureToggles } from './feature-toggles/SiteInfoFeatureToggles';
 
 import style from './SiteInfo.module.scss';
-import { SiteInfoFeatureToggles } from './feature-toggles/SiteInfoFeatureToggles';
 
 export const SiteInfo = ({
     serverInfo,
@@ -21,10 +23,7 @@ export const SiteInfo = ({
         <>
             <Head>
                 <title>{'nav.no cms status'}</title>
-                <meta
-                    name={DocumentParameter.DecoratorDisabled}
-                    content={'true'}
-                />
+                <meta name={DocumentParameter.DecoratorDisabled} content={'true'} />
             </Head>
             <div className={style.container}>
                 <SiteInfoHeader

--- a/src/components/_editor-only/site-info/_common/links/SiteInfoLink.tsx
+++ b/src/components/_editor-only/site-info/_common/links/SiteInfoLink.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import {
-    adminOrigin,
-    appOrigin,
-    editorPathPrefix,
-    stripXpPathPrefix,
-} from 'utils/urls';
+
+import { adminOrigin, appOrigin, editorPathPrefix, stripXpPathPrefix } from 'utils/urls';
 
 import style from './SiteInfoLink.module.scss';
 
@@ -32,9 +28,7 @@ export const SiteInfoLink = (props: Props) => {
                 onClick={(e) => {
                     e.stopPropagation();
                 }}
-                className={
-                    target === 'editor' ? style.editorLink : style.liveLink
-                }
+                className={target === 'editor' ? style.editorLink : style.liveLink}
             >
                 {target === 'editor' ? 'Åpne i editor' : props.children}
             </a>

--- a/src/components/_editor-only/site-info/custom-paths/SiteInfoCustomPaths.tsx
+++ b/src/components/_editor-only/site-info/custom-paths/SiteInfoCustomPaths.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { TextField } from '@navikt/ds-react';
+
 import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { SiteInfoSubHeader } from 'components/_editor-only/site-info/_common/sub-header/SiteInfoSubHeader';
 import { Expandable } from 'components/_common/expandable/Expandable';
+
 import { SiteInfoCustomPathItem } from './content-item/SiteInfoCustomPathItem';
-import { TextField } from '@navikt/ds-react';
 
 import style from './SiteInfoCustomPaths.module.scss';
 

--- a/src/components/_editor-only/site-info/custom-paths/content-item/SiteInfoCustomPathItem.tsx
+++ b/src/components/_editor-only/site-info/custom-paths/content-item/SiteInfoCustomPathItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { BodyShort, Heading } from '@navikt/ds-react';
+
+import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { SiteInfoLink } from 'components/_editor-only/site-info/_common/links/SiteInfoLink';
 
 import style from './SiteInfoCustomPathItem.module.scss';

--- a/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
+++ b/src/components/_editor-only/site-info/feature-toggles/SiteInfoFeatureToggles.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Checkbox } from '@navikt/ds-react';
+
 import {
     isEditorFeatureEnabled,
     setEditorFeatureToggle,
 } from 'components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils';
-import { Checkbox } from '@navikt/ds-react';
 import { SiteInfoSubHeader } from 'components/_editor-only/site-info/_common/sub-header/SiteInfoSubHeader';
 
 export enum EditorFeature {
@@ -21,8 +22,7 @@ export type EditorFeatureProps = {
 export const editorFeatures: Record<EditorFeature, EditorFeatureProps> = {
     [EditorFeature.HideLeftPanel]: {
         key: EditorFeature.HideLeftPanel,
-        description:
-            'Skjuler venstre-panelet i editoren som standard på komponent-baserte sider',
+        description: 'Skjuler venstre-panelet i editoren som standard på komponent-baserte sider',
         defaultValue: false,
     },
     [EditorFeature.EditorReloadBlocker]: {
@@ -52,10 +52,7 @@ export const SiteInfoFeatureToggles = () => {
                         key={key}
                         defaultChecked={isEditorFeatureEnabled(key)}
                         onClick={(e) => {
-                            setEditorFeatureToggle(
-                                key,
-                                e.currentTarget.checked
-                            );
+                            setEditorFeatureToggle(key, e.currentTarget.checked);
                         }}
                     >
                         {description}

--- a/src/components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils.ts
+++ b/src/components/_editor-only/site-info/feature-toggles/editor-feature-toggles-utils.ts
@@ -1,4 +1,5 @@
 import Cookie from 'js-cookie';
+
 import {
     EditorFeature,
     editorFeatures,
@@ -12,7 +13,5 @@ export const isEditorFeatureEnabled = (feature: EditorFeature) => {
     return cookieValue === undefined ? defaultValue : cookieValue === 'true';
 };
 
-export const setEditorFeatureToggle = (
-    feature: EditorFeature,
-    enable: boolean
-) => Cookie.set(feature, enable.toString(), { expires: 365 });
+export const setEditorFeatureToggle = (feature: EditorFeature, enable: boolean) =>
+    Cookie.set(feature, enable.toString(), { expires: 365 });

--- a/src/components/_editor-only/site-info/header/SiteInfoHeader.tsx
+++ b/src/components/_editor-only/site-info/header/SiteInfoHeader.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { BodyShort } from '@navikt/ds-react';
+
 import { Header } from 'components/_common/headers/Header';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
-import { BodyShort } from '@navikt/ds-react';
 import { ClusterState } from 'components/_editor-only/site-info/types';
 
 import style from './SiteInfoHeader.module.scss';

--- a/src/components/_editor-only/site-info/publish-info/SiteInfoPublishInfo.tsx
+++ b/src/components/_editor-only/site-info/publish-info/SiteInfoPublishInfo.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { SiteInfoPublishInfoList } from './content-list/SiteInfoPublishInfoList';
+
 import { SiteInfoProps } from 'components/_editor-only/site-info/types';
 import { SiteInfoSubHeader } from 'components/_editor-only/site-info/_common/sub-header/SiteInfoSubHeader';
+
+import { SiteInfoPublishInfoList } from './content-list/SiteInfoPublishInfoList';
 
 import style from './SiteInfoPublishInfo.module.scss';
 

--- a/src/components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem.tsx
+++ b/src/components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import { BodyShort, Heading } from '@navikt/ds-react';
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
+
 import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { stripXpPathPrefix } from 'utils/urls';
 import { formatDateTime } from 'utils/datetime';
@@ -36,24 +37,17 @@ export const SiteInfoPublishInfoItem = ({
                 </BodyShort>
             </div>
             <BodyShort size={'small'}>
-                {`${stripXpPathPrefix(path)}${
-                    customPath ? ` (kort-url: ${customPath})` : ''
-                } `}
+                {`${stripXpPathPrefix(path)}${customPath ? ` (kort-url: ${customPath})` : ''} `}
             </BodyShort>
             <BodyShort className={style.publish}>
                 {`Type: ${type.replace('no.nav.navno:', '')} - ${
                     isPrepublish ? 'Publiseres' : 'Publisert'
                 }: ${
-                    publish.from
-                        ? formatDateTime(publish.from)
-                        : '[ingen publiseringsdato angitt]'
+                    publish.from ? formatDateTime(publish.from) : '[ingen publiseringsdato angitt]'
                 }`}
-                {publish.to
-                    ? ` - Avpubliseres: ${formatDateTime(publish.to)}`
-                    : ''}
+                {publish.to ? ` - Avpubliseres: ${formatDateTime(publish.to)}` : ''}
             </BodyShort>
-            {((isPrepublish && !publish.scheduledFrom) ||
-                (publish.to && !publish.scheduledTo)) && (
+            {((isPrepublish && !publish.scheduledFrom) || (publish.to && !publish.scheduledTo)) && (
                 <BodyShort className={style.warning} size={'small'}>
                     <ExclamationmarkTriangleFillIcon />
                     {'Schedule for publisering mangler!'}

--- a/src/components/_editor-only/site-info/publish-info/content-list/SiteInfoPublishInfoList.tsx
+++ b/src/components/_editor-only/site-info/publish-info/content-list/SiteInfoPublishInfoList.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
-import { SiteInfoPublishInfoItem } from 'components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem';
 import { Heading } from '@navikt/ds-react';
+
+import { SiteInfoPublishInfoItem } from 'components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem';
 import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { Expandable } from 'components/_common/expandable/Expandable';
 
@@ -12,11 +13,7 @@ type Props = {
     contentList: SiteInfoContentProps[];
 };
 
-export const SiteInfoPublishInfoList = ({
-    title,
-    titleEmpty,
-    contentList,
-}: Props) => {
+export const SiteInfoPublishInfoList = ({ title, titleEmpty, contentList }: Props) => {
     const { length } = contentList;
 
     return length > 0 ? (

--- a/src/components/_editor-only/version-history/VersionHistory.tsx
+++ b/src/components/_editor-only/version-history/VersionHistory.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import { Heading, Loader } from '@navikt/ds-react';
+import { useRouter } from 'next/compat/router';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
-import { Heading, Loader } from '@navikt/ds-react';
-import { VersionStatus } from './status/VersionStatus';
-import { VersionSelector } from './selector/VersionSelector';
 import { translator } from 'translations';
-import { useRouter } from 'next/compat/router';
 import { Chevron } from 'components/_common/chevron/Chevron';
 import { logger } from 'srcCommon/logger';
+
+import { VersionSelector } from './selector/VersionSelector';
+import { VersionStatus } from './status/VersionStatus';
 
 import style from './VersionHistory.module.scss';
 

--- a/src/components/_editor-only/version-history/selector/VersionSelector.tsx
+++ b/src/components/_editor-only/version-history/selector/VersionSelector.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { classNames } from 'utils/classnames';
 import { BodyLong, Heading, Loader, Radio, RadioGroup } from '@navikt/ds-react';
+
+import { classNames } from 'utils/classnames';
 import { ContentProps } from 'types/content-props/_content-common';
-import { VersionSelectorDateTime } from './selected-datetime/VersionSelectorDateTime';
-import { VersionSelectorPublished } from './published-datetime/VersionSelectorPublished';
 import { fetchJson, objectToQueryString } from 'srcCommon/fetch-utils';
 import { xpDraftPathPrefix, xpServicePath } from 'utils/urls';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
+
+import { VersionSelectorPublished } from './published-datetime/VersionSelectorPublished';
+import { VersionSelectorDateTime } from './selected-datetime/VersionSelectorDateTime';
 
 import style from './VersionSelector.module.scss';
 
@@ -22,18 +24,9 @@ type Props = {
     submitVersionUrl: (url: string) => void;
 };
 
-export const VersionSelector = ({
-    content,
-    isOpen,
-    setIsOpen,
-    submitVersionUrl,
-}: Props) => {
-    const [publishedVersions, setPublishedVersions] = useState<string[] | null>(
-        null
-    );
-    const [selectedPublishedVersion, setSelectedPublishedVersion] = useState<
-        string | null
-    >(null);
+export const VersionSelector = ({ content, isOpen, setIsOpen, submitVersionUrl }: Props) => {
+    const [publishedVersions, setPublishedVersions] = useState<string[] | null>(null);
+    const [selectedPublishedVersion, setSelectedPublishedVersion] = useState<string | null>(null);
     const [selectorType, setSelectorType] = useState<SelectorType>('datetime');
     const [versionsError, setVersionsError] = useState<string | null>(null);
 
@@ -43,32 +36,31 @@ export const VersionSelector = ({
             locale: content.liveLocale || content.layerLocale,
         });
 
-        fetchJson<string[]>(
-            `${PUBLISHED_VERSIONS_SERVICE_URL}${params}`,
-            15000
-        ).then((versions) => {
-            if (!versions) {
-                setVersionsError(
-                    'Kunne ikke hente publiseringstidspunkter - forsøk å laste editoren på nytt (F5)'
+        fetchJson<string[]>(`${PUBLISHED_VERSIONS_SERVICE_URL}${params}`, 15000).then(
+            (versions) => {
+                if (!versions) {
+                    setVersionsError(
+                        'Kunne ikke hente publiseringstidspunkter - forsøk å laste editoren på nytt (F5)'
+                    );
+                    setPublishedVersions([]);
+                    return;
+                }
+
+                setPublishedVersions(versions);
+
+                // Set the selection to a specific version if it was previously selected by the user
+                const selectedVersion = versions.find(
+                    (versionTimestamp) => versionTimestamp === content.timeRequested
                 );
-                setPublishedVersions([]);
-                return;
+
+                if (!selectedVersion) {
+                    return;
+                }
+
+                setSelectedPublishedVersion(selectedVersion);
+                setSelectorType('published');
             }
-
-            setPublishedVersions(versions);
-
-            // Set the selection to a specific version if it was previously selected by the user
-            const selectedVersion = versions.find(
-                (versionTimestamp) => versionTimestamp === content.timeRequested
-            );
-
-            if (!selectedVersion) {
-                return;
-            }
-
-            setSelectedPublishedVersion(selectedVersion);
-            setSelectorType('published');
-        });
+        );
     }, [content]);
 
     useEffect(() => {
@@ -93,10 +85,7 @@ export const VersionSelector = ({
     }, [isOpen, setIsOpen]);
 
     return (
-        <div
-            className={style.versionSelector}
-            id={VERSION_SELECTOR_CONTAINER_ID}
-        >
+        <div className={style.versionSelector} id={VERSION_SELECTOR_CONTAINER_ID}>
             <div className={classNames(style.inner, isOpen && style.open)}>
                 <div className={style.typeSelector}>
                     <RadioGroup
@@ -107,12 +96,8 @@ export const VersionSelector = ({
                         }}
                         disabled={!publishedVersions}
                     >
-                        <Radio value={'datetime'}>
-                            {'Egendefinert tidspunkt'}
-                        </Radio>
-                        <Radio value={'published'}>
-                            {'Publiseringstidspunkt'}
-                        </Radio>
+                        <Radio value={'datetime'}>{'Egendefinert tidspunkt'}</Radio>
+                        <Radio value={'published'}>{'Publiseringstidspunkt'}</Radio>
                     </RadioGroup>
                 </div>
                 <div className={style.input}>

--- a/src/components/_editor-only/version-history/selector/published-datetime/VersionSelectorPublished.tsx
+++ b/src/components/_editor-only/version-history/selector/published-datetime/VersionSelectorPublished.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Select } from '@navikt/ds-react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { formatDateTime } from 'utils/datetime';
 import { getVersionSelectorUrl } from 'components/_editor-only/version-history/selector/versionSelectorUtils';
@@ -40,19 +41,12 @@ export const VersionSelectorPublished = ({
                 className={style.select}
             >
                 {versionTimestamps.map((timestamp, index) => (
-                    <option
-                        value={timestamp}
-                        selected={timestamp === selectedDateTime}
-                        key={index}
-                    >
+                    <option value={timestamp} selected={timestamp === selectedDateTime} key={index}>
                         {formatDateTime(timestamp, 'nb', true)}
                     </option>
                 ))}
             </Select>
-            <VersionSelectorSubmitButton
-                url={url}
-                submitVersionUrl={submitVersionUrl}
-            />
+            <VersionSelectorSubmitButton url={url} submitVersionUrl={submitVersionUrl} />
         </div>
     );
 };

--- a/src/components/_editor-only/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
+++ b/src/components/_editor-only/version-history/selector/selected-datetime/VersionSelectorDateTime.tsx
@@ -1,15 +1,12 @@
 import React, { useState } from 'react';
 import { Checkbox, Label } from '@navikt/ds-react';
+import dayjs from 'dayjs';
+
 import { ContentProps } from 'types/content-props/_content-common';
-import {
-    getCurrentDateAndTime,
-    getCurrentISODate,
-    getUtcTimeFromLocal,
-} from 'utils/datetime';
+import { getCurrentDateAndTime, getCurrentISODate, getUtcTimeFromLocal } from 'utils/datetime';
 import { Branch } from 'types/branch';
 import { getVersionSelectorUrl } from 'components/_editor-only/version-history/selector/versionSelectorUtils';
 import { VersionSelectorSubmitButton } from 'components/_editor-only/version-history/selector/submit-button/VersionSelectorSubmitButton';
-import dayjs from 'dayjs';
 
 import style from './VersionSelectorDateTime.module.scss';
 
@@ -19,17 +16,12 @@ type Props = {
     submitVersionUrl: (url: string) => void;
 };
 
-export const VersionSelectorDateTime = ({
-    content,
-    submitVersionUrl,
-}: Props) => {
+export const VersionSelectorDateTime = ({ content, submitVersionUrl }: Props) => {
     const { timeRequested } = content;
 
     const nbTime = dayjs(timeRequested).locale('nb').format();
 
-    const [initialDate, initialTime] = timeRequested
-        ? nbTime.split('T')
-        : getCurrentDateAndTime();
+    const [initialDate, initialTime] = timeRequested ? nbTime.split('T') : getCurrentDateAndTime();
 
     const [dateSelected, setDateSelected] = useState(initialDate);
     const [timeSelected, setTimeSelected] = useState(initialTime);
@@ -44,9 +36,7 @@ export const VersionSelectorDateTime = ({
     return (
         <>
             <div className={style.left}>
-                <Label id={'version-selector-label'}>
-                    {'Velg tid og dato:'}
-                </Label>
+                <Label id={'version-selector-label'}>{'Velg tid og dato:'}</Label>
                 <input
                     type={'time'}
                     className={style.time}
@@ -73,18 +63,13 @@ export const VersionSelectorDateTime = ({
                     checked={branchSelected === 'master'}
                     id={'version-branch-input'}
                     onChange={(e) => {
-                        setBranchSelected(
-                            e.target.checked ? 'master' : 'draft'
-                        );
+                        setBranchSelected(e.target.checked ? 'master' : 'draft');
                     }}
                     size={'small'}
                 >
                     {'Kun publisert innhold'}
                 </Checkbox>
-                <VersionSelectorSubmitButton
-                    url={url}
-                    submitVersionUrl={submitVersionUrl}
-                />
+                <VersionSelectorSubmitButton url={url} submitVersionUrl={submitVersionUrl} />
             </div>
         </>
     );

--- a/src/components/_editor-only/version-history/selector/submit-button/VersionSelectorSubmitButton.tsx
+++ b/src/components/_editor-only/version-history/selector/submit-button/VersionSelectorSubmitButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Button } from 'components/_common/button/Button';
 
 type Props = {
@@ -6,10 +7,7 @@ type Props = {
     submitVersionUrl: (url: string) => void;
 };
 
-export const VersionSelectorSubmitButton = ({
-    url,
-    submitVersionUrl,
-}: Props) => {
+export const VersionSelectorSubmitButton = ({ url, submitVersionUrl }: Props) => {
     return (
         <Button
             href={url}

--- a/src/components/_editor-only/version-history/status/VersionStatus.tsx
+++ b/src/components/_editor-only/version-history/status/VersionStatus.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { BodyLong } from '@navikt/ds-react';
+import dayjs from 'dayjs';
+
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 import { formatDateTime } from 'utils/datetime';
 import { ContentProps } from 'types/content-props/_content-common';
-import dayjs from 'dayjs';
 import { getVersionSelectorUrl } from 'components/_editor-only/version-history/selector/versionSelectorUtils';
 
 import style from './VersionStatus.module.scss';
@@ -14,18 +15,10 @@ type Props = {
     submitVersionUrl: (url: string) => void;
 };
 
-export const VersionStatus = ({
-    content,
-    requestedDateTime,
-    submitVersionUrl,
-}: Props) => {
+export const VersionStatus = ({ content, requestedDateTime, submitVersionUrl }: Props) => {
     const contentDateTime = content.modifiedTime || content.createdTime;
 
-    const requestedTimeFormatted = formatDateTime(
-        requestedDateTime,
-        'nb',
-        true
-    );
+    const requestedTimeFormatted = formatDateTime(requestedDateTime, 'nb', true);
     const contentTimeFormatted = formatDateTime(contentDateTime, 'nb', true);
 
     const requestedUnixTime = dayjs(requestedDateTime).startOf('minute').unix();

--- a/src/components/_page-warnings/PageWarnings.tsx
+++ b/src/components/_page-warnings/PageWarnings.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
+
 import { translator } from 'translations';
 import { ContentProps } from 'types/content-props/_content-common';
-import { PageWarning } from './page-warning/PageWarning';
 import { hasWhiteHeader } from 'utils/appearance';
+
+import { PageWarning } from './page-warning/PageWarning';
 
 type Props = {
     content: ContentProps;
 };
 
 export const PageWarnings = ({ content }: Props) => {
-    const {
-        isFailover,
-        isPagePreview,
-        originalType,
-        language,
-        redirectToLayer,
-    } = content;
+    const { isFailover, isPagePreview, originalType, language, redirectToLayer } = content;
 
     const whiteBg = hasWhiteHeader(content);
 
@@ -27,14 +23,10 @@ export const PageWarnings = ({ content }: Props) => {
     return (
         <>
             {isPagePreview && (
-                <PageWarning whiteBg={whiteBg}>
-                    {warningLabels('draftWarning')}
-                </PageWarning>
+                <PageWarning whiteBg={whiteBg}>{warningLabels('draftWarning')}</PageWarning>
             )}
             {isFailover && (
-                <PageWarning whiteBg={whiteBg}>
-                    {warningLabels('failoverWarning')}
-                </PageWarning>
+                <PageWarning whiteBg={whiteBg}>{warningLabels('failoverWarning')}</PageWarning>
             )}
             {originalType && isEditorView && (
                 <PageWarning whiteBg={whiteBg} size={'medium'}>
@@ -43,9 +35,7 @@ export const PageWarnings = ({ content }: Props) => {
             )}
             {redirectToLayer && isEditorView && (
                 <PageWarning whiteBg={whiteBg} size={'medium'}>
-                    {warningLabels('layerRedirectWarning')(
-                        localeLabels(redirectToLayer)
-                    )}
+                    {warningLabels('layerRedirectWarning')(localeLabels(redirectToLayer))}
                 </PageWarning>
             )}
         </>

--- a/src/components/_page-warnings/page-warning/PageWarning.tsx
+++ b/src/components/_page-warnings/page-warning/PageWarning.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { classNames } from 'utils/classnames';
 

--- a/src/components/layouts/LayoutContainer.tsx
+++ b/src/components/layouts/LayoutContainer.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutProps } from 'types/component-props/layouts';
 import { BEM, classNames } from 'utils/classnames';
-import { getCommonLayoutStyle } from './LayoutStyle';
 import { usePageContentProps } from 'store/pageContext';
 import { editorAuthstateClassname } from 'components/_common/auth-dependant-render/AuthDependantRender';
+
+import { getCommonLayoutStyle } from './LayoutStyle';
 
 import style from './LayoutContainer.module.scss';
 
@@ -44,14 +46,11 @@ export const LayoutContainer = ({
             className={classNames(
                 style.layout,
                 bem(layoutName),
-                ...(modifiers
-                    ? modifiers.map((mod) => bem(layoutName, mod))
-                    : []),
+                ...(modifiers ? modifiers.map((mod) => bem(layoutName, mod)) : []),
                 paddingConfig === 'fullWidth' && style.fullwidth,
                 paddingConfig === 'standard' && style.standard,
                 config.bgColor?.color && style.bg,
-                editorView === 'edit' &&
-                    editorAuthstateClassname(config.renderOnAuthState),
+                editorView === 'edit' && editorAuthstateClassname(config.renderOnAuthState),
                 divElementProps.className
             )}
             style={{ ...commonLayoutStyle, ...layoutStyle }}

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -1,14 +1,17 @@
 // @ts-nocheck
 // Refactor the layout types before fixing the type errors in this file
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutProps, LayoutType } from 'types/component-props/layouts';
+import { ComponentType } from 'types/component-props/_component-common';
+import { TwoColsPage } from 'components/layouts/two-cols-page/TwoColsPage';
+
 import { FixedColsLayout } from './fixed-cols/FixedColsLayout';
 import { FlexColsLayout } from './flex-cols/FlexColsLayout';
 import { LegacyLayout } from './legacy/LegacyLayout';
 import { PageWithSideMenus } from './page-with-side-menus/PageWithSideMenus';
 import { SectionWithHeaderLayout } from './section-with-header/SectionWithHeaderLayout';
-import { ComponentType } from 'types/component-props/_component-common';
 import { SingleColPage } from './single-col-page/SingleColPage';
 import { SituationPageFlexColsLayout } from './flex-cols/SituationPageFlexColsLayout';
 import { ProductPageFlexColsLayout } from './flex-cols/ProductPageFlexColsLayout';
@@ -17,7 +20,6 @@ import { IndexPage } from './index-page/IndexPage';
 import { useLayoutConfig } from './useLayoutConfig';
 import { AreapageSituationsLayout } from './areapage-situations/AreapageSituationsLayout';
 import { FrontpageLoggedinSectionLayout } from './frontpage-loggedin-section/FrontpageLoggedinSectionLayout';
-import { TwoColsPage } from 'components/layouts/two-cols-page/TwoColsPage';
 
 type Props = {
     pageProps: ContentProps;
@@ -64,11 +66,7 @@ export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
     const LayoutComponent = layoutComponents[descriptor];
 
     if (!LayoutComponent) {
-        return (
-            <div
-                {...editorProps}
-            >{`Unimplemented layout type: ${descriptor}`}</div>
-        );
+        return <div {...editorProps}>{`Unimplemented layout type: ${descriptor}`}</div>;
     }
 
     return (

--- a/src/components/layouts/LayoutStyle.ts
+++ b/src/components/layouts/LayoutStyle.ts
@@ -5,8 +5,7 @@ export const getCommonLayoutStyle = (config: LayoutCommonConfigMixin) => {
         return undefined;
     }
 
-    const { bgColor, marginTop, marginBottom, paddingSides, paddingTopBottom } =
-        config;
+    const { bgColor, marginTop, marginBottom, paddingSides, paddingTopBottom } = config;
 
     return {
         // Check for undefined specifically. We want to allow margin values of 0

--- a/src/components/layouts/Region.tsx
+++ b/src/components/layouts/Region.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { BEM, classNames } from 'utils/classnames';
 import { ComponentMapper } from 'components/ComponentMapper';
@@ -53,10 +54,7 @@ export const Region = ({
             {components.map((component) => {
                 return wrapperFunction && !isEditView ? (
                     wrapperFunction(
-                        <ComponentMapper
-                            componentProps={component}
-                            pageProps={pageProps}
-                        />,
+                        <ComponentMapper componentProps={component} pageProps={pageProps} />,
                         component.path
                     )
                 ) : (

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+
 import { AreapageSituationsProps } from 'types/component-props/layouts/areapage-situations';
 import { ContentProps } from 'types/content-props/_content-common';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
 import { Header } from 'components/_common/headers/Header';
-
 import Region from 'components/layouts/Region';
 
 import style from './AreapageSituationsLayout.module.scss';
@@ -18,12 +18,7 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
 
     if (!config || !regions) {
-        return (
-            <EditorHelp
-                type={'error'}
-                text={'Feil: Komponenten mangler data'}
-            />
-        );
+        return <EditorHelp type={'error'} text={'Feil: Komponenten mangler data'} />;
     }
 
     const elementWrapper = (element: JSX.Element, key: string) => {
@@ -38,12 +33,7 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             layoutProps={layoutProps}
             className={style.container}
         >
-            <Header
-                level={'2'}
-                justify={'left'}
-                size={'large'}
-                className={style.header}
-            >
+            <Header level={'2'} justify={'left'} size={'large'} className={style.header}>
                 {title}
             </Header>
             <EditorHelp

--- a/src/components/layouts/fixed-cols/FixedColsLayout.tsx
+++ b/src/components/layouts/fixed-cols/FixedColsLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import Region from 'components/layouts/Region';
 import { FixedColsLayoutProps } from 'types/component-props/layouts/fixed-cols';
@@ -21,11 +22,7 @@ export const FixedColsLayout = ({ pageProps, layoutProps }: Props) => {
     const { distribution } = config;
 
     return (
-        <LayoutContainer
-            className={style.layout}
-            pageProps={pageProps}
-            layoutProps={layoutProps}
-        >
+        <LayoutContainer className={style.layout} pageProps={pageProps} layoutProps={layoutProps}>
             {Object.values(regions).map((regionProps, index) => {
                 const regionStyle = distribution
                     ? {

--- a/src/components/layouts/flex-cols/FlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/FlexColsLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { FlexColsLayoutProps } from 'types/component-props/layouts/flex-cols';
 import Region from 'components/layouts/Region';
@@ -20,14 +21,7 @@ export const FlexColsLayout = ({ pageProps, layoutProps }: Props) => {
     }
 
     const { config } = layoutProps;
-    const {
-        numCols,
-        justifyContent,
-        toggleCopyButton,
-        collapse,
-        title,
-        anchorId,
-    } = config;
+    const { numCols, justifyContent, toggleCopyButton, collapse, title, anchorId } = config;
 
     const regionStyle = {
         ...(justifyContent && { justifyContent }),
@@ -41,11 +35,7 @@ export const FlexColsLayout = ({ pageProps, layoutProps }: Props) => {
             : numCols;
 
     return (
-        <LayoutContainer
-            pageProps={pageProps}
-            layoutProps={layoutProps}
-            className={style.flexCols}
-        >
+        <LayoutContainer pageProps={pageProps} layoutProps={layoutProps} className={style.flexCols}>
             {title && (
                 <Header
                     level={'2'}

--- a/src/components/layouts/flex-cols/ProductPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/ProductPageFlexColsLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import Region from 'components/layouts/Region';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -13,10 +14,7 @@ type Props = {
     layoutProps: ProductPageFlexColsLayoutProps;
 };
 
-export const ProductPageFlexColsLayout = ({
-    pageProps,
-    layoutProps,
-}: Props) => {
+export const ProductPageFlexColsLayout = ({ pageProps, layoutProps }: Props) => {
     const regionProps = layoutProps.regions?.flexcols;
 
     if (!regionProps) {
@@ -54,9 +52,7 @@ export const ProductPageFlexColsLayout = ({
                 bemModifier={`${calculateColCount()}-cols`}
             />
             <EditorHelp
-                text={
-                    'Redaktørtips: Klikk "marker som klar" hvis kolonnene ikke vises riktig.'
-                }
+                text={'Redaktørtips: Klikk "marker som klar" hvis kolonnene ikke vises riktig.'}
             />
         </LayoutContainer>
     );

--- a/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import Region from 'components/layouts/Region';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -12,10 +13,7 @@ type Props = {
     layoutProps: SituationPageFlexColsLayoutProps;
 };
 
-export const SituationPageFlexColsLayout = ({
-    pageProps,
-    layoutProps,
-}: Props) => {
+export const SituationPageFlexColsLayout = ({ pageProps, layoutProps }: Props) => {
     const regionProps = layoutProps.regions?.flexcols;
 
     if (!regionProps) {
@@ -23,14 +21,7 @@ export const SituationPageFlexColsLayout = ({
     }
 
     const { config } = layoutProps;
-    const {
-        title,
-        numCols,
-        justifyContent,
-        anchorId,
-        toggleCopyButton,
-        shelf,
-    } = config;
+    const { title, numCols, justifyContent, anchorId, toggleCopyButton, shelf } = config;
 
     const regionStyle = {
         ...(justifyContent && { justifyContent }),
@@ -40,8 +31,7 @@ export const SituationPageFlexColsLayout = ({
         return regionProps.components.length % 3 === 0 ? 3 : 2;
     };
 
-    const colCount =
-        typeof numCols === 'number' ? numCols : calculateColCount();
+    const colCount = typeof numCols === 'number' ? numCols : calculateColCount();
 
     const buildModifiers = () => {
         if (!shelf?._selected) {

--- a/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
+++ b/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FrontpageLoggedinSectionLayoutProps } from 'types/component-props/layouts/frontpage-loggedin-section';
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -10,9 +11,9 @@ import { useAuthState } from 'store/hooks/useAuthState';
 import { capitalize } from 'utils/string';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
+import { MoreLink } from 'components/_common/moreLink/MoreLink';
 
 import style from './FrontpageLoggedinSectionLayout.module.scss';
-import { MoreLink } from 'components/_common/moreLink/MoreLink';
 
 const HeaderWithName = ({ headerText }: { headerText: string }) => {
     const { language } = usePageContentProps();
@@ -22,15 +23,8 @@ const HeaderWithName = ({ headerText }: { headerText: string }) => {
     const greetings = translator('greetings', language);
 
     return (
-        <Header
-            level={'2'}
-            size={'large'}
-            justify={'left'}
-            className={style.header}
-        >
-            {name
-                ? headerText.replace('$navn', capitalize(name))
-                : greetings('hi')}
+        <Header level={'2'} size={'large'} justify={'left'} className={style.header}>
+            {name ? headerText.replace('$navn', capitalize(name)) : greetings('hi')}
         </Header>
     );
 };
@@ -40,18 +34,10 @@ type Props = {
     pageProps: ContentProps;
 };
 
-export const FrontpageLoggedinSectionLayout = ({
-    layoutProps,
-    pageProps,
-}: Props) => {
+export const FrontpageLoggedinSectionLayout = ({ layoutProps, pageProps }: Props) => {
     const { config, regions } = layoutProps;
     if (!config || !regions) {
-        return (
-            <EditorHelp
-                type={'error'}
-                text={'Feil: Komponenten mangler data'}
-            />
-        );
+        return <EditorHelp type={'error'} text={'Feil: Komponenten mangler data'} />;
     }
 
     const { header, mypage } = config;
@@ -65,19 +51,10 @@ export const FrontpageLoggedinSectionLayout = ({
                 data-hj-suppress
             >
                 <HeaderWithName headerText={header} />
-                <Header
-                    level={'2'}
-                    size={'small'}
-                    justify={'left'}
-                    className={style.services}
-                >
+                <Header level={'2'} size={'small'} justify={'left'} className={style.services}>
                     Dine tjenester
                 </Header>
-                <Region
-                    pageProps={pageProps}
-                    regionProps={regions.cards}
-                    className={style.cards}
-                />
+                <Region pageProps={pageProps} regionProps={regions.cards} className={style.cards} />
                 <MoreLink link={mypage?.link} />
             </LayoutContainer>
         </AuthDependantRender>

--- a/src/components/layouts/index-page/IndexPage.tsx
+++ b/src/components/layouts/index-page/IndexPage.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
 import Region from 'components/layouts/Region';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
-import { FrontPageAreaNavigation } from './front-page/FrontPageAreaNavigation';
 import { IndexPageProps } from 'types/component-props/pages/index-page';
-import { AreaPageHeader } from './area-page/AreaPageHeader';
 import { getAudience } from 'types/component-props/_mixins';
 import { classNames } from 'utils/classnames';
+
+import { AreaPageHeader } from './area-page/AreaPageHeader';
+import { FrontPageAreaNavigation } from './front-page/FrontPageAreaNavigation';
 
 import style from './IndexPage.module.scss';
 
@@ -25,18 +27,12 @@ export const IndexPage = ({ pageProps, layoutProps }: Props) => {
         <LayoutContainer
             pageProps={pageProps}
             layoutProps={layoutProps}
-            className={classNames(
-                style.indexPage,
-                hasNoTopGap && style.noTopGap
-            )}
+            className={classNames(style.indexPage, hasNoTopGap && style.noTopGap)}
         >
             <>
                 {/* We don't use this region on the AreaPage atm */}
                 {type !== ContentType.AreaPage && (
-                    <Region
-                        pageProps={pageProps}
-                        regionProps={regions.contentTop}
-                    />
+                    <Region pageProps={pageProps} regionProps={regions.contentTop} />
                 )}
                 {type === ContentType.FrontPage ? (
                     <FrontPageAreaNavigation content={pageProps} />

--- a/src/components/layouts/index-page/area-page/AreaPageHeader.tsx
+++ b/src/components/layouts/index-page/area-page/AreaPageHeader.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Heading } from '@navikt/ds-react';
-import { AreaPageHeaderBanner } from './banner/AreaPageHeaderBanner';
+
 import { classNames } from 'utils/classnames';
 import { AreaCardGraphics } from 'components/_common/area-card/graphics/AreaCardGraphics';
 import { AreaPageProps } from 'types/content-props/index-pages-props';
+import graphicsStyle from 'components/_common/area-card/graphics/AreaCardGraphicsCommon.module.scss';
+
+import { AreaPageHeaderBanner } from './banner/AreaPageHeaderBanner';
 
 import style from './AreaPageHeader.module.scss';
-import graphicsStyle from 'components/_common/area-card/graphics/AreaCardGraphicsCommon.module.scss';
 
 type Props = {
     content: AreaPageProps;
@@ -21,16 +23,9 @@ export const AreaPageHeader = ({ content }: Props) => {
                 <Heading level="1" size="xlarge">
                     {header}
                 </Heading>
-                {banner && (
-                    <AreaPageHeaderBanner banner={banner} header={header} />
-                )}
+                {banner && <AreaPageHeaderBanner banner={banner} header={header} />}
             </div>
-            <div
-                className={classNames(
-                    style.gfxContainer,
-                    graphicsStyle.expandGraphics
-                )}
-            >
+            <div className={classNames(style.gfxContainer, graphicsStyle.expandGraphics)}>
                 <AreaCardGraphics type={area} insideCard={false} />
             </div>
         </div>

--- a/src/components/layouts/index-page/area-page/banner/AreaPageHeaderBanner.tsx
+++ b/src/components/layouts/index-page/area-page/banner/AreaPageHeaderBanner.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
+
 import { AreaPageProps } from 'types/content-props/index-pages-props';
 import { getSelectableLinkProps } from 'utils/links-from-content';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { classNames } from 'utils/classnames';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { FancyChevron } from 'components/_common/chevron/FancyChevron';
+import chevronStyle from 'components/_common/chevron/FancyChevronCommon.module.scss';
 
 import style from './AreaPageHeaderBanner.module.scss';
-import chevronStyle from 'components/_common/chevron/FancyChevronCommon.module.scss';
 
 type Props = Pick<AreaPageProps['data'], 'banner' | 'header'>;
 

--- a/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
+++ b/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FrontPageProps } from 'types/content-props/index-pages-props';
 import { Header } from 'components/_common/headers/Header';
 import { AreaCard } from 'components/_common/area-card/AreaCard';
@@ -41,21 +42,14 @@ export const FrontPageAreaNavigation = ({ content }: Props) => {
 
     return (
         <div className={classNames(style.wrapper, audience && style[audience])}>
-            <Header
-                level={'2'}
-                justify={'left'}
-                size={'large'}
-                className={style.header}
-            >
+            <Header level={'2'} justify={'left'} size={'large'} className={style.header}>
                 {areasHeader}
             </Header>
             <nav aria-label="Velg område">
                 <ul
                     className={classNames(
                         style.cards,
-                        navigationRefs.length === 2
-                            ? style.twocols
-                            : style.threecols
+                        navigationRefs.length === 2 ? style.twocols : style.threecols
                     )}
                 >
                     {navigationRefs.map((page) => {

--- a/src/components/layouts/legacy/LegacyLayout.tsx
+++ b/src/components/layouts/legacy/LegacyLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import Region from 'components/layouts/Region';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -14,17 +15,12 @@ type Props = {
     layoutProps: LegacyLayoutProps;
 };
 
-const getNewsArticleProps = (
-    pageProps: ContentProps
-): MainArticleProps | null => {
+const getNewsArticleProps = (pageProps: ContentProps): MainArticleProps | null => {
     const props =
-        pageProps.type === ContentType.MainArticleChapter
-            ? pageProps.data.article
-            : pageProps;
+        pageProps.type === ContentType.MainArticleChapter ? pageProps.data.article : pageProps;
 
     return props?.type === ContentType.MainArticle &&
-        (props.data.contentType === 'news' ||
-            props.data.contentType === 'pressRelease')
+        (props.data.contentType === 'news' || props.data.contentType === 'pressRelease')
         ? props
         : null;
 };
@@ -55,13 +51,7 @@ export const LegacyLayout = ({ pageProps, layoutProps }: Props) => {
                     />
                 )}
             {Object.values(regions).map((regionProps, index) => {
-                return (
-                    <Region
-                        pageProps={pageProps}
-                        regionProps={regionProps}
-                        key={index}
-                    />
-                );
+                return <Region pageProps={pageProps} regionProps={regionProps} key={index} />;
             })}
         </LayoutContainer>
     );

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -1,22 +1,22 @@
 import React, { useEffect, useState } from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { PageWithSideMenusProps } from 'types/component-props/pages/page-with-side-menus';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
-import { MainContentSection } from './main-content-section/MainContentSection';
-import { LeftMenuSection } from './left-menu-section/LeftMenuSection';
-import { RightMenuSection } from './right-menu-section/RightMenuSection';
 import { windowMatchMedia } from 'utils/match-media';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import Config from 'config';
 import Region from 'components/layouts/Region';
 
+import { RightMenuSection } from './right-menu-section/RightMenuSection';
+import { LeftMenuSection } from './left-menu-section/LeftMenuSection';
+import { MainContentSection } from './main-content-section/MainContentSection';
+
 import styles from './PageWithSideMenus.module.scss';
 
 const mobileWidthBreakpoint = Config.vars.mobileBreakpointPx;
 
-const mqlWidthBreakpoint = windowMatchMedia(
-    `(min-width: ${mobileWidthBreakpoint}px)`
-);
+const mqlWidthBreakpoint = windowMatchMedia(`(min-width: ${mobileWidthBreakpoint}px)`);
 
 type Props = {
     pageProps: ContentProps;
@@ -59,14 +59,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
         rightMenuSticky,
     } = config;
 
-    const {
-        pageContent,
-        topPageContent,
-        topLeftMenu,
-        rightMenu,
-        leftMenu,
-        bottomRow,
-    } = regions;
+    const { pageContent, topPageContent, topLeftMenu, rightMenu, leftMenu, bottomRow } = regions;
 
     // The purpose of the topPageContent region is to separate components
     // which should be placed above the left menu in the mobile view
@@ -74,8 +67,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     // contains components
     const shouldRenderTopContentRegion =
         leftMenuToggle &&
-        (topPageContent?.components.length > 0 ||
-            pageProps.editorView === 'edit');
+        (topPageContent?.components.length > 0 || pageProps.editorView === 'edit');
 
     return (
         <LayoutContainer
@@ -97,9 +89,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                                 pageProps={pageProps}
                                 topRegionProps={topLeftMenu}
                                 mainRegionProps={leftMenu}
-                                internalLinks={
-                                    showInternalNav ? anchorLinks : []
-                                }
+                                internalLinks={showInternalNav ? anchorLinks : []}
                                 menuHeader={leftMenuHeader}
                                 sticky={leftMenuSticky}
                             />
@@ -113,17 +103,10 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                                 pageProps={pageProps}
                                 regionProps={topPageContent}
                             />
-                            <EditorHelp
-                                text={
-                                    'Komponenter ovenfor legges over menyen på mobil'
-                                }
-                            />
+                            <EditorHelp text={'Komponenter ovenfor legges over menyen på mobil'} />
                         </>
                     )}
-                    <MainContentSection
-                        pageProps={pageProps}
-                        regionProps={pageContent}
-                    />
+                    <MainContentSection pageProps={pageProps} regionProps={pageContent} />
                 </div>
                 {rightMenuToggle && (
                     <div className={styles.rightCol}>

--- a/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
+++ b/src/components/layouts/page-with-side-menus/left-menu-section/LeftMenuSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { classNames } from 'utils/classnames';
 import Region from 'components/layouts/Region';
 import { RegionProps } from 'types/component-props/layouts';

--- a/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.tsx
+++ b/src/components/layouts/page-with-side-menus/main-content-section/MainContentSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Region from 'components/layouts/Region';
 import { ContentProps } from 'types/content-props/_content-common';
 import { RegionProps } from 'types/component-props/layouts';

--- a/src/components/layouts/page-with-side-menus/right-menu-section/RightMenuSection.tsx
+++ b/src/components/layouts/page-with-side-menus/right-menu-section/RightMenuSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Region from 'components/layouts/Region';
 import { ContentProps } from 'types/content-props/_content-common';
 import { RegionProps } from 'types/component-props/layouts';

--- a/src/components/layouts/product-details-layout/ProductDetailsLayout.tsx
+++ b/src/components/layouts/product-details-layout/ProductDetailsLayout.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+
 import Region from 'components/layouts/Region';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -19,8 +20,7 @@ const getRegionHelpTexts = (
         detailType === ProductDetailType.PROCESSING_TIMES
             ? 'Hovedinnhold, søknad: Vises på oversiktssiden og på produktsiden.'
             : 'Hovedinnhold: Vises på oversiktssiden og på produktsiden.',
-    main_complaint:
-        'Hovedinnhold, klage: Vises på oversiktssiden og på produktsiden.',
+    main_complaint: 'Hovedinnhold, klage: Vises på oversiktssiden og på produktsiden.',
     outro: 'Oppsummering: Vises kun på oversiktssiden.',
 });
 
@@ -43,9 +43,7 @@ type Props = {
 export const ProductDetailsLayout = ({ pageProps, layoutProps }: Props) => {
     const detailType = getProductDetailType(pageProps);
     if (!detailType) {
-        return (
-            <EditorHelp text={'Detalj-type er ikke satt for dette innholdet'} />
-        );
+        return <EditorHelp text={'Detalj-type er ikke satt for dette innholdet'} />;
     }
 
     const { regions } = layoutProps;
@@ -66,23 +64,14 @@ export const ProductDetailsLayout = ({ pageProps, layoutProps }: Props) => {
 
                 // The 'main_complaint' section in product details is only applicable
                 // for product detail types === 'processing_times'
-                if (
-                    name === 'main_complaint' &&
-                    detailType !== 'processing_times'
-                ) {
+                if (name === 'main_complaint' && detailType !== 'processing_times') {
                     return null;
                 }
 
                 return (
                     <Fragment key={name}>
-                        <EditorHelp
-                            text={regionHelpTexts[name]}
-                            type="arrowDown"
-                        />
-                        <Region
-                            pageProps={pageProps}
-                            regionProps={regionProps}
-                        />
+                        <EditorHelp text={regionHelpTexts[name]} type="arrowDown" />
+                        <Region pageProps={pageProps} regionProps={regionProps} />
                     </Fragment>
                 );
             })}

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -7,8 +8,9 @@ import { Header } from 'components/_common/headers/Header';
 import { XpImage } from 'components/_common/image/XpImage';
 import { FilterBar } from 'components/_common/filter-bar/FilterBar';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { SectionNavigation } from './section-navigation/SectionNavigation';
 import { classNames } from 'utils/classnames';
+
+import { SectionNavigation } from './section-navigation/SectionNavigation';
 
 import style from './SectionWithHeaderLayout.module.scss';
 

--- a/src/components/layouts/section-with-header/section-navigation/SectionNavigation.tsx
+++ b/src/components/layouts/section-with-header/section-navigation/SectionNavigation.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
+
 import { ComponentType } from 'types/component-props/_component-common';
 import { RegionProps } from 'types/component-props/layouts';
 import { PartType } from 'types/component-props/parts';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents } from 'utils/amplitude';
+import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 
 import styles from './SectionNavigation.module.scss';
-import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 
 type SectionNavigationProps = {
     introRegion?: RegionProps<'intro'>;
@@ -42,10 +43,7 @@ const getAnchorsFromComponents = (region?: RegionProps) => {
     }, []);
 };
 
-export const SectionNavigation = ({
-    introRegion,
-    contentRegion,
-}: SectionNavigationProps) => {
+export const SectionNavigation = ({ introRegion, contentRegion }: SectionNavigationProps) => {
     const { language } = usePageContentProps();
     const introAnchors = getAnchorsFromComponents(introRegion);
     const contentAnchors = getAnchorsFromComponents(contentRegion);
@@ -58,10 +56,7 @@ export const SectionNavigation = ({
     const getLabels = translator('sectionNavigation', language);
 
     return (
-        <ul
-            aria-label={getLabels('navigationLabel')}
-            className={styles.sectionNavigation}
-        >
+        <ul aria-label={getLabels('navigationLabel')} className={styles.sectionNavigation}>
             {allAnchors.map((anchor) => (
                 <li key={anchor.anchorId}>
                     <LenkeInline

--- a/src/components/layouts/single-col-page/SingleColPage.tsx
+++ b/src/components/layouts/single-col-page/SingleColPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { SingleColPageProps } from 'types/component-props/pages/single-col-page';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';

--- a/src/components/layouts/two-cols-page/TwoColsPage.tsx
+++ b/src/components/layouts/two-cols-page/TwoColsPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { TwoColsPageProps } from 'types/component-props/pages/two-cols-page';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
@@ -19,9 +20,7 @@ export const TwoColsPage = ({ pageProps, layoutProps }: Props) => {
     return (
         <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
             <Region pageProps={pageProps} regionProps={regions.mainCol} />
-            {config.sideColToggle && (
-                <Region pageProps={pageProps} regionProps={regions.sideCol} />
-            )}
+            {config.sideColToggle && <Region pageProps={pageProps} regionProps={regions.sideCol} />}
         </LayoutContainer>
     );
 };

--- a/src/components/layouts/useLayoutConfig.tsx
+++ b/src/components/layouts/useLayoutConfig.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+
 import { LayoutType } from 'types/component-props/layouts';
 import { EmptyObject } from 'types/util-types';
 

--- a/src/components/macros/MacroMapper.tsx
+++ b/src/components/macros/MacroMapper.tsx
@@ -1,7 +1,13 @@
 // @ts-nocheck
 // Refactor the macro types before fixing the type errors in this file
 import React from 'react';
+
 import { MacroPropsCommon, MacroType } from 'types/macro-props/_macros-common';
+import { MacroProductCardMicro } from 'components/macros/product-card-micro/MacroProductCardMicro';
+import { MacroTall } from 'components/macros/tall/MacroTall';
+import { MacroUxSignalsWidget } from 'components/macros/uxsignals-widget/MacroUxSignalsWidget';
+import { MacroLinkToLayer } from 'components/macros/link-to-layer/MacroLinkToLayer';
+
 import { MacroButton } from './button/MacroButton';
 import { MacroButtonBlue } from './button-blue/MacroButtonBlue';
 import { MacroChevronLinkExternal } from './chevron-link-external/MacroChevronLinkExternal';
@@ -25,10 +31,6 @@ import { MacroIngress } from './ingress/MacroIngress';
 import { MacroAlertBox } from './alert-box/MacroAlertBox';
 import { MacroSaksbehandlingstid } from './saksbehandlingstid/MacroSaksbehandlingstid';
 import { MacroPayoutDates } from './payout-dates/MacroPayoutDates';
-import { MacroProductCardMicro } from 'components/macros/product-card-micro/MacroProductCardMicro';
-import { MacroTall } from 'components/macros/tall/MacroTall';
-import { MacroUxSignalsWidget } from 'components/macros/uxsignals-widget/MacroUxSignalsWidget';
-import { MacroLinkToLayer } from 'components/macros/link-to-layer/MacroLinkToLayer';
 
 const macroComponents: {
     [key in MacroType]: React.FunctionComponent<MacroPropsCommon>;

--- a/src/components/macros/alert-box/MacroAlertBox.tsx
+++ b/src/components/macros/alert-box/MacroAlertBox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { MacroAlertBoxProps } from 'types/macro-props/alert-box';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';

--- a/src/components/macros/button-blue/MacroButtonBlue.tsx
+++ b/src/components/macros/button-blue/MacroButtonBlue.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Button } from 'components/_common/button/Button';
 import { MacroButtonBlueProps } from 'types/macro-props/button-blue';
 

--- a/src/components/macros/button/MacroButton.tsx
+++ b/src/components/macros/button/MacroButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroButtonProps } from 'types/macro-props/button';
 import { Button } from 'components/_common/button/Button';
 

--- a/src/components/macros/chatbot-link/MacroChatbotLink.tsx
+++ b/src/components/macros/chatbot-link/MacroChatbotLink.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
+
 import { MacroChatbotLinkProps } from 'types/macro-props/chatbot-link';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { Button } from 'components/_common/button/Button';
 
 type ExtraProps = {
@@ -16,8 +17,7 @@ export const MacroChatbotLink = ({ config }: MacroChatbotLinkProps) => {
     const { text, presentation = 'link' } = config.chatbot_link;
 
     const Element = presentation === 'link' ? LenkeInline : Button;
-    const extraProps: ExtraProps =
-        presentation === 'link' ? {} : { variant: 'secondary' };
+    const extraProps: ExtraProps = presentation === 'link' ? {} : { variant: 'secondary' };
 
     return (
         <Element

--- a/src/components/macros/chevron-link-external/MacroChevronLinkExternal.tsx
+++ b/src/components/macros/chevron-link-external/MacroChevronLinkExternal.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
+
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 import { MacroChevronLinkExternalProps } from 'types/macro-props/chevron-link-external';
 
-export const MacroChevronLinkExternal = ({
-    config,
-}: MacroChevronLinkExternalProps) => {
+export const MacroChevronLinkExternal = ({ config }: MacroChevronLinkExternalProps) => {
     if (!config?.chevron_link_external) {
         return null;
     }

--- a/src/components/macros/chevron-link-internal/MacroChevronLinkInternal.tsx
+++ b/src/components/macros/chevron-link-internal/MacroChevronLinkInternal.tsx
@@ -1,19 +1,14 @@
 import React from 'react';
+
 import { MacroChevronLinkInternalProps } from 'types/macro-props/chevron-link-internal';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 
-export const MacroChevronLinkInternal = ({
-    config,
-}: MacroChevronLinkInternalProps) => {
+export const MacroChevronLinkInternal = ({ config }: MacroChevronLinkInternalProps) => {
     if (!config?.chevron_link_internal) {
         return null;
     }
 
     const { target, text } = config.chevron_link_internal;
 
-    return (
-        <LenkeStandalone href={target?._path}>
-            {text || target?.displayName}
-        </LenkeStandalone>
-    );
+    return <LenkeStandalone href={target?._path}>{text || target?.displayName}</LenkeStandalone>;
 };

--- a/src/components/macros/form-details/MacroFormDetails.tsx
+++ b/src/components/macros/form-details/MacroFormDetails.tsx
@@ -23,10 +23,5 @@ export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
         showAddendums: macroConfig.showAddendums,
     };
 
-    return (
-        <FormDetails
-            formDetails={formDetailsData}
-            displayConfig={displayConfig}
-        />
-    );
+    return <FormDetails formDetails={formDetailsData} displayConfig={displayConfig} />;
 };

--- a/src/components/macros/fotnote/MacroFotnote.tsx
+++ b/src/components/macros/fotnote/MacroFotnote.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroFotnoteProps } from 'types/macro-props/fotnote';
 import { classNames } from 'utils/classnames';
 
@@ -9,9 +10,5 @@ export const MacroFotnote = ({ config }: MacroFotnoteProps) => {
 
     const { fotnote } = config.fotnote;
 
-    return (
-        <sup className={classNames('macro-fotnote', 'navds-detail')}>
-            {fotnote}
-        </sup>
-    );
+    return <sup className={classNames('macro-fotnote', 'navds-detail')}>{fotnote}</sup>;
 };

--- a/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
+++ b/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { MacroGlobalValueWithMathProps } from 'types/macro-props/global-value-with-math';
 import jsep, { Expression } from 'jsep';
+
+import { MacroGlobalValueWithMathProps } from 'types/macro-props/global-value-with-math';
 import { usePageContentProps } from 'store/pageContext';
 import { Language } from 'translations';
 import { formatNumber } from 'utils/math';
 import { logger } from 'srcCommon/logger';
 
-type ExpressionProps =
-    MacroGlobalValueWithMathProps['config']['global_value_with_math'];
+type ExpressionProps = MacroGlobalValueWithMathProps['config']['global_value_with_math'];
 
 export function substituteExpression(expression: string, variables: number[]) {
     return expression.replace(/\$(\d+)/g, (_, idx) => {
@@ -63,16 +63,10 @@ export const evaluateExpression = (
     isEditorView: boolean
 ) => {
     try {
-        const expressionSubstituted = substituteExpression(
-            expression,
-            variables
-        );
+        const expressionSubstituted = substituteExpression(expression, variables);
 
         // jsep only accepts . as decimal separator
-        const expressionWithDotSeparators = expressionSubstituted.replace(
-            ',',
-            '.'
-        );
+        const expressionWithDotSeparators = expressionSubstituted.replace(',', '.');
 
         const parsedExpression = jsep(expressionWithDotSeparators);
         const result = evaluateExpressionJSEP(parsedExpression);
@@ -91,20 +85,14 @@ export const evaluateExpression = (
     }
 };
 
-export const MacroGlobalValueWithMath = ({
-    config,
-}: MacroGlobalValueWithMathProps) => {
+export const MacroGlobalValueWithMath = ({ config }: MacroGlobalValueWithMathProps) => {
     const { language, editorView } = usePageContentProps();
 
     if (!config?.global_value_with_math) {
         return null;
     }
 
-    const value = evaluateExpression(
-        config.global_value_with_math,
-        language,
-        !!editorView
-    );
+    const value = evaluateExpression(config.global_value_with_math, language, !!editorView);
 
     return <>{value}</>;
 };

--- a/src/components/macros/global-value-with-math/macroGlobalValueWithMath.test.ts
+++ b/src/components/macros/global-value-with-math/macroGlobalValueWithMath.test.ts
@@ -1,13 +1,9 @@
-import {
-    substituteExpression,
-    evaluateExpression,
-} from './MacroGlobalValueWithMath';
 import { Language } from 'translations';
 
+import { substituteExpression, evaluateExpression } from './MacroGlobalValueWithMath';
+
 test('substitution', () => {
-    expect(substituteExpression('$1 + $2 * 5', [50, 100])).toEqual(
-        '50 + 100 * 5'
-    );
+    expect(substituteExpression('$1 + $2 * 5', [50, 100])).toEqual('50 + 100 * 5');
 });
 
 test('dagpenger', () => {
@@ -16,11 +12,7 @@ test('dagpenger', () => {
     const variables = [118620];
     const language: Language = 'no';
 
-    const result = evaluateExpression(
-        { expression, decimals, variables },
-        language,
-        true
-    );
+    const result = evaluateExpression({ expression, decimals, variables }, language, true);
 
     expect(result).toBe('711\xa0720');
 });
@@ -31,11 +23,7 @@ test('kompleks matte', () => {
     const variables = [118620];
     const language: Language = 'no';
 
-    const result = evaluateExpression(
-        { expression, decimals, variables },
-        language,
-        true
-    );
+    const result = evaluateExpression({ expression, decimals, variables }, language, true);
 
     expect(result).toBe('279\xa0639,968');
 });
@@ -46,11 +34,7 @@ test('kompleks matte med paranteser', () => {
     const variables = [1186201];
     const language: Language = 'nn';
 
-    const result = evaluateExpression(
-        { expression, decimals, variables },
-        language,
-        true
-    );
+    const result = evaluateExpression({ expression, decimals, variables }, language, true);
 
     expect(result).toBe('80\xa0612,6');
 });
@@ -61,11 +45,7 @@ test('should evaluate a simple expression', () => {
     const variables: number[] = [];
     const language: Language = 'no';
 
-    const result = evaluateExpression(
-        { expression, decimals, variables },
-        language,
-        true
-    );
+    const result = evaluateExpression({ expression, decimals, variables }, language, true);
 
     expect(result).toEqual('4');
 });
@@ -76,11 +56,7 @@ test('should evaluate an expression with variables', () => {
     const variables = [1.23, 4.56];
     const language: Language = 'no';
 
-    const result = evaluateExpression(
-        { expression, decimals, variables },
-        language,
-        true
-    );
+    const result = evaluateExpression({ expression, decimals, variables }, language, true);
 
     expect(result).toEqual('5,79');
 });

--- a/src/components/macros/global-value/MacroGlobalValue.tsx
+++ b/src/components/macros/global-value/MacroGlobalValue.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { MacroGlobalValueProps } from 'types/macro-props/global-value';
 import { formatNumber, isStringOnlyNumber } from 'utils/math';
@@ -7,12 +8,7 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 export const MacroGlobalValue = ({ config }: MacroGlobalValueProps) => {
     const { language } = usePageContentProps();
     if (!config?.global_value) {
-        return (
-            <EditorHelp
-                text={'Teknisk feil: macro-data er ikke gyldig'}
-                type={'error'}
-            />
-        );
+        return <EditorHelp text={'Teknisk feil: macro-data er ikke gyldig'} type={'error'} />;
     }
 
     const { value, decimals } = config.global_value;

--- a/src/components/macros/header-with-anchor/MacroHeaderWithAnchor.tsx
+++ b/src/components/macros/header-with-anchor/MacroHeaderWithAnchor.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { headingToLevel, headingToSize } from 'types/typo-style';
 import { MacroHeaderWithAnchorProps } from 'types/macro-props/header-with-anchor';
 import { Header } from 'components/_common/headers/Header';
@@ -6,9 +7,7 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 import style from './MacroheaderWithAnchor.module.scss';
 
-export const MacroHeaderWithAnchor = ({
-    config,
-}: MacroHeaderWithAnchorProps) => {
+export const MacroHeaderWithAnchor = ({ config }: MacroHeaderWithAnchorProps) => {
     if (!config?.header_with_anchor) {
         return null;
     }
@@ -21,9 +20,7 @@ export const MacroHeaderWithAnchor = ({
     const headerText = body || text;
 
     if (!headerText) {
-        return (
-            <EditorHelp type={'error'} text={'Header-macroen mangler tekst!'} />
-        );
+        return <EditorHelp type={'error'} text={'Header-macroen mangler tekst!'} />;
     }
 
     return (

--- a/src/components/macros/html-fragment/MacroHtmlFragment.tsx
+++ b/src/components/macros/html-fragment/MacroHtmlFragment.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
+
 import { MacroHtmlFragmentProps } from 'types/macro-props/html-fragment';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 export const MacroHtmlFragment = ({ config }: MacroHtmlFragmentProps) => {
     if (!config?.html_fragment) {
-        return (
-            <EditorHelp type={'error'} text={'Macroen mangler konfigurasjon'} />
-        );
+        return <EditorHelp type={'error'} text={'Macroen mangler konfigurasjon'} />;
     }
 
     const htmlProps = config.html_fragment.processedHtml;

--- a/src/components/macros/infoboks/MacroInfoBoks.tsx
+++ b/src/components/macros/infoboks/MacroInfoBoks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroInfoBoksProps } from 'types/macro-props/infoBoks';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';

--- a/src/components/macros/ingress/MacroIngress.tsx
+++ b/src/components/macros/ingress/MacroIngress.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Ingress } from '@navikt/ds-react';
+
 import { MacroIngressProps } from 'types/macro-props/ingress';
 
 export const MacroIngress = ({ config }: MacroIngressProps) => {

--- a/src/components/macros/lenke-filer/MacroLenkeFiler.tsx
+++ b/src/components/macros/lenke-filer/MacroLenkeFiler.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+
 import { MacroLenkeFilerProps } from 'types/macro-props/lenkeFiler';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 

--- a/src/components/macros/link-to-layer/MacroLinkToLayer.tsx
+++ b/src/components/macros/link-to-layer/MacroLinkToLayer.tsx
@@ -1,23 +1,18 @@
 import React from 'react';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { MacroLinkToLayerProps } from 'types/macro-props/link-to-layer';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 export const MacroLinkToLayer = ({ config }: MacroLinkToLayerProps) => {
     if (!config?.link_to_layer) {
-        return (
-            <EditorHelp text={'Macroen mangler konfigurasjon'} type={'error'} />
-        );
+        return <EditorHelp text={'Macroen mangler konfigurasjon'} type={'error'} />;
     }
 
     const { href, newTab, tooltip, body } = config.link_to_layer;
 
     return (
-        <LenkeInline
-            href={href}
-            title={tooltip}
-            target={newTab ? '_blank' : undefined}
-        >
+        <LenkeInline href={href} title={tooltip} target={newTab ? '_blank' : undefined}>
             {body}
         </LenkeInline>
     );

--- a/src/components/macros/payout-dates/MacroPayoutDates.tsx
+++ b/src/components/macros/payout-dates/MacroPayoutDates.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroPayoutDatesProps } from 'types/macro-props/payout-dates';
 import { PayoutDates } from 'components/_common/payout-dates/PayoutDates';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -7,9 +8,7 @@ export const MacroPayoutDates = ({ config }: MacroPayoutDatesProps) => {
     const payoutDatesData = config?.payout_dates?.payoutDates?.data;
 
     if (!payoutDatesData) {
-        return (
-            <EditorHelp text={'Macroen mangler data for utbetalingsdatoer'} />
-        );
+        return <EditorHelp text={'Macroen mangler data for utbetalingsdatoer'} />;
     }
 
     return <PayoutDates payoutDatesData={payoutDatesData} />;

--- a/src/components/macros/phone-link/MacroPhoneLink.tsx
+++ b/src/components/macros/phone-link/MacroPhoneLink.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroPhoneLinkProps } from 'types/macro-props/phone-link';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';

--- a/src/components/macros/product-card-micro/MacroProductCardMicro.tsx
+++ b/src/components/macros/product-card-micro/MacroProductCardMicro.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
+
 import { MacroProductCardMicroProps } from 'types/macro-props/product-card-micro';
 import { MicroCards } from 'components/_common/card/MicroCard';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
-export const MacroProductCardMicro = ({
-    config,
-}: MacroProductCardMicroProps) => {
+export const MacroProductCardMicro = ({ config }: MacroProductCardMicroProps) => {
     if (!config?.product_card_micro) {
         return <EditorHelp text={'Macroen mangler konfigurasjon'} />;
     }

--- a/src/components/macros/product-card-mini/MacroProductCardMini.tsx
+++ b/src/components/macros/product-card-mini/MacroProductCardMini.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroProductCardMiniProps } from 'types/macro-props/product-card-mini';
 import { MiniCard } from 'components/_common/card/MiniCard';
 import { getCardProps } from 'components/_common/card/card-utils';

--- a/src/components/macros/quote/MacroQuote.tsx
+++ b/src/components/macros/quote/MacroQuote.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { MacroQuoteProps } from 'types/macro-props/quote';
 import { classNames } from 'utils/classnames';
+
 import style from './MacroQuote.module.scss';
 
 export const MacroQuote = ({ config }: MacroQuoteProps) => {
@@ -9,8 +11,6 @@ export const MacroQuote = ({ config }: MacroQuoteProps) => {
     }
     const { quote } = config.quote;
     return (
-        <blockquote className={classNames(style.macroQuote, 'navds-body-long')}>
-            {quote}
-        </blockquote>
+        <blockquote className={classNames(style.macroQuote, 'navds-body-long')}>{quote}</blockquote>
     );
 };

--- a/src/components/macros/saksbehandlingstid/MacroSaksbehandlingstid.tsx
+++ b/src/components/macros/saksbehandlingstid/MacroSaksbehandlingstid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { MacroSaksbehandlingstidProps } from 'types/macro-props/saksbehandlingstid';
 import { usePageContentProps } from 'store/pageContext';
 import { Language, translator } from 'translations';
@@ -17,20 +18,13 @@ export const getCaseTimeString = (
     return `${value} ${unitText}`;
 };
 
-export const MacroSaksbehandlingstid = ({
-    config,
-}: MacroSaksbehandlingstidProps) => {
+export const MacroSaksbehandlingstid = ({ config }: MacroSaksbehandlingstidProps) => {
     const macroData = config?.saksbehandlingstid?.caseTime;
 
     const { language } = usePageContentProps();
 
     if (!macroData) {
-        return (
-            <EditorHelp
-                text={'Teknisk feil: macro-data er ikke gyldig'}
-                type={'error'}
-            />
-        );
+        return <EditorHelp text={'Teknisk feil: macro-data er ikke gyldig'} type={'error'} />;
     }
 
     const { value, unit } = macroData;

--- a/src/components/macros/tall/MacroTall.tsx
+++ b/src/components/macros/tall/MacroTall.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { formatNumber } from 'utils/math';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -7,12 +8,7 @@ import { MacroTallProps } from 'types/macro-props/tall';
 export const MacroTall = ({ config }: MacroTallProps) => {
     const { language } = usePageContentProps();
     if (!config?.tall) {
-        return (
-            <EditorHelp
-                text={'Teknisk feil: macroen er ikke konfigurert'}
-                type={'error'}
-            />
-        );
+        return <EditorHelp text={'Teknisk feil: macroen er ikke konfigurert'} type={'error'} />;
     }
 
     const { verdi, decimals } = config.tall;

--- a/src/components/macros/uxsignals-widget/MacroUxSignalsWidget.tsx
+++ b/src/components/macros/uxsignals-widget/MacroUxSignalsWidget.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
+
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { UxSignalsWidget } from 'components/_common/uxsignals-widget/UxSignalsWidget';
 import { MacroUxSignalsWidgetProps } from 'types/macro-props/uxSignalsWidget';
 
 export const MacroUxSignalsWidget = ({ config }: MacroUxSignalsWidgetProps) => {
     if (!config?.uxsignals_widget?.embedCode) {
-        return (
-            <EditorHelp
-                text={'Tom UXSignals macro, sett inn en embed-kode'}
-                type={'error'}
-            />
-        );
+        return <EditorHelp text={'Tom UXSignals macro, sett inn en embed-kode'} type={'error'} />;
     }
 
     return <UxSignalsWidget embedCode={config.uxsignals_widget.embedCode} />;

--- a/src/components/macros/varselboks/MacroVarselBoks.tsx
+++ b/src/components/macros/varselboks/MacroVarselBoks.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { MacroVarselBoksProps } from 'types/macro-props/varselBoks';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
+
 import style from './MacroVarselBoks.module.scss';
 
 // This macro is deprecated

--- a/src/components/macros/video/MacroVideo.tsx
+++ b/src/components/macros/video/MacroVideo.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+
 import { MacroVideoProps } from 'types/macro-props/video';
 import { usePageContentProps } from 'store/pageContext';
 import { QbrickVideo } from 'components/_common/qbrick-video/QbrickVideo';
@@ -9,10 +10,7 @@ import {
 } from 'components/_common/qbrick-video/utils/videoProps';
 import { fetchQbrickMissingProps } from 'components/_common/qbrick-video/utils/videoHelpers';
 
-const buildVideoProps = (
-    macroConfig: MacroVideoProps['config'],
-    contentLanguage: string
-) => {
+const buildVideoProps = (macroConfig: MacroVideoProps['config'], contentLanguage: string) => {
     const { targetContent, video, title, language } = macroConfig.video;
     return targetContent?.data
         ? buildQbrickVideoProps(targetContent.data, language || contentLanguage)

--- a/src/components/pages/calculator-page/CalculatorPage.tsx
+++ b/src/components/pages/calculator-page/CalculatorPage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Calculator } from 'components/_common/calculator/Calculator';
 import { CalculatorProps } from 'types/content-props/calculator-props';
 import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';
-
 import { usePageContentProps } from 'store/pageContext';
 
 import style from './CalculatorPage.module.scss';

--- a/src/components/pages/contact-information-page/ContactInformationPage.tsx
+++ b/src/components/pages/contact-information-page/ContactInformationPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Alert } from '@navikt/ds-react';
+
 import { ContactInformationProps } from 'types/content-props/contact-information-props';
 import { CallOption } from 'components/_common/contact-option/CallOption';
 import { WriteOption } from 'components/_common/contact-option/WriteOption';
@@ -11,11 +12,7 @@ export const ContactInformationPage = (props: ContactInformationProps) => {
     const { data } = props;
     const { contactType } = data;
 
-    const hasContactType = !!(
-        contactType.telephone ||
-        contactType.write ||
-        contactType.chat
-    );
+    const hasContactType = !!(contactType.telephone || contactType.write || contactType.chat);
 
     const hasSpecialHours = !!contactType?.telephone?.specialOpeningHours;
     const hasRegularHours = !!contactType?.telephone?.regularOpeningHours;
@@ -23,8 +20,8 @@ export const ContactInformationPage = (props: ContactInformationProps) => {
     if (!hasContactType) {
         return (
             <div className={style.content}>
-                (Ingen kontakttype eller åpningstider er lagt inn ennå, så
-                forhåndsvisning er ikke mulig!)
+                (Ingen kontakttype eller åpningstider er lagt inn ennå, så forhåndsvisning er ikke
+                mulig!)
             </div>
         );
     }
@@ -33,8 +30,7 @@ export const ContactInformationPage = (props: ContactInformationProps) => {
         return (
             <div className={style.contactInformationPage}>
                 <div className={style.content}>
-                    (Spesielle åpningstider kan ikke forhåndsvises som komponent
-                    på egenhånd.)
+                    (Spesielle åpningstider kan ikke forhåndsvises som komponent på egenhånd.)
                 </div>
             </div>
         );
@@ -69,11 +65,7 @@ export const ContactInformationPage = (props: ContactInformationProps) => {
         if (contactType.chat) {
             const data = contactType?.chat;
             return (
-                <ChatOption
-                    ingress={data.ingress}
-                    alertText={data.alertText}
-                    title={data.title}
-                />
+                <ChatOption ingress={data.ingress} alertText={data.alertText} title={data.title} />
             );
         }
 
@@ -84,8 +76,8 @@ export const ContactInformationPage = (props: ContactInformationProps) => {
         <div className={style.contactInformationPage}>
             <div className={style.content}>
                 <Alert variant="warning" className={style.editorAlert}>
-                    Redaktørvarsel: Denne informasjonen kan være i bruk på tvers
-                    av livssituasjonssider. Endres med varsomhet.
+                    Redaktørvarsel: Denne informasjonen kan være i bruk på tvers av
+                    livssituasjonssider. Endres med varsomhet.
                 </Alert>
                 {buildPreview()}
             </div>

--- a/src/components/pages/contenttype-not-supported-page/ContentTypeNotSupportedPage.tsx
+++ b/src/components/pages/contenttype-not-supported-page/ContentTypeNotSupportedPage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Heading } from '@navikt/ds-react';
-import { ContentProps } from 'types/content-props/_content-common';
 import Head from 'next/head';
+
+import { ContentProps } from 'types/content-props/_content-common';
 import { DocumentParameter } from 'components/_common/metatags/DocumentParameterMetatags';
 
 import style from './ContentTypeNotSupportedPage.module.scss';
@@ -10,10 +11,7 @@ export const ContentTypeNotSupportedPage = (props: ContentProps) => {
     return (
         <div className={style.notSupported}>
             <Head>
-                <meta
-                    name={DocumentParameter.DecoratorDisabled}
-                    content={'true'}
-                />
+                <meta name={DocumentParameter.DecoratorDisabled} content={'true'} />
             </Head>
             <Heading level={'1'} size={'small'}>
                 {'Innholdstypen '}

--- a/src/components/pages/current-topic-page/CurrentTopicPage.tsx
+++ b/src/components/pages/current-topic-page/CurrentTopicPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ComponentMapper } from 'components/ComponentMapper';
 import { CurrentTopicPageProps } from 'types/content-props/dynamic-page-props';
 import { NewsHeader } from 'components/_common/headers/featured-header/FeaturedHeader';
@@ -12,10 +13,7 @@ export const CurrentTopicPage = (props: CurrentTopicPageProps) => {
             <div className={style.contentWrapper}>
                 <div className={style.contentAligner}>
                     <div className={style.content}>
-                        <ComponentMapper
-                            componentProps={props.page}
-                            pageProps={props}
-                        />
+                        <ComponentMapper componentProps={props.page} pageProps={props} />
                     </div>
                 </div>
             </div>

--- a/src/components/pages/dynamic-page/DynamicPage.tsx
+++ b/src/components/pages/dynamic-page/DynamicPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { ComponentMapper } from 'components/ComponentMapper';
 

--- a/src/components/pages/error-page/ErrorPage.tsx
+++ b/src/components/pages/error-page/ErrorPage.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
+import { BodyLong, Heading } from '@navikt/ds-react';
+
 import { ErrorProps } from 'types/content-props/error-props';
+
 import { ErrorContent404 } from './errorcode-content/ErrorContent404';
 import { ErrorContentDefault } from './errorcode-content/ErrorContentDefault';
 import { ErrorContent408 } from './errorcode-content/ErrorContent408';
 import { ErrorContent400 } from './errorcode-content/ErrorContent400';
-import { BodyLong, Heading } from '@navikt/ds-react';
 
 import style from './ErrorPage.module.scss';
 
-const errorContentByCode: Record<
-    number,
-    React.FunctionComponent<ErrorProps>
-> = {
+const errorContentByCode: Record<number, React.FunctionComponent<ErrorProps>> = {
     400: ErrorContent400,
     404: ErrorContent404,
     408: ErrorContent408,

--- a/src/components/pages/error-page/errorcode-content/ErrorContent400.tsx
+++ b/src/components/pages/error-page/errorcode-content/ErrorContent400.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { BodyLong } from '@navikt/ds-react';
+
 import { ErrorProps } from 'types/content-props/error-props';
-import { ErrorFeedbackLink } from './feedback-link/ErrorFeedbackLink';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import Config from 'config';
 import { appOrigin, stripXpPathPrefix } from 'utils/urls';
 import { errorMessageURIErrorPublic } from 'utils/make-error-props';
+
+import { ErrorFeedbackLink } from './feedback-link/ErrorFeedbackLink';
 
 export const ErrorContent400 = (props: ErrorProps) => {
     if (props.data.errorMessage === errorMessageURIErrorPublic) {
@@ -16,9 +18,7 @@ export const ErrorContent400 = (props: ErrorProps) => {
                     {`${appOrigin}${stripXpPathPrefix(props._path)}`}
                 </BodyLong>
                 <BodyLong spacing={true}>
-                    {
-                        'Dersom du fulgte en lenke på nav.no for å komme hit kan du '
-                    }
+                    {'Dersom du fulgte en lenke på nav.no for å komme hit kan du '}
                     <LenkeInline href={Config.urls.errorFeedback}>
                         {'melde fra om teknisk feil'}
                     </LenkeInline>

--- a/src/components/pages/error-page/errorcode-content/ErrorContent404.tsx
+++ b/src/components/pages/error-page/errorcode-content/ErrorContent404.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Heading, BodyLong } from '@navikt/ds-react';
-import { SearchForm } from './search-form/SearchForm';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
+
+import { SearchForm } from './search-form/SearchForm';
 
 import style from './ErrorContent404.module.scss';
 const origin = process.env.APP_ORIGIN;
@@ -19,9 +21,7 @@ export const ErrorContent404 = () => {
                 </BodyLong>
                 <BodyLong>
                     {'Bruk gjerne søket, menyen eller '}
-                    <LenkeInline href={frontpageBase}>
-                        {'gå til forsiden'}
-                    </LenkeInline>
+                    <LenkeInline href={frontpageBase}>{'gå til forsiden'}</LenkeInline>
                     {'.'}
                 </BodyLong>
                 <BodyLong>
@@ -40,9 +40,7 @@ export const ErrorContent404 = () => {
                 <BodyLong>{'The page you requested cannot be found.'}</BodyLong>
                 <BodyLong>
                     {'Go to the '}
-                    <LenkeInline href={`${frontpageBase}/en`}>
-                        {'front page'}
-                    </LenkeInline>
+                    <LenkeInline href={`${frontpageBase}/en`}>{'front page'}</LenkeInline>
                     {', or use one of the links in the menu.'}
                 </BodyLong>
             </div>

--- a/src/components/pages/error-page/errorcode-content/ErrorContent408.tsx
+++ b/src/components/pages/error-page/errorcode-content/ErrorContent408.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BodyLong } from '@navikt/ds-react';
+
 import { ErrorProps } from 'types/content-props/error-props';
+
 import { ErrorFeedbackLink } from './feedback-link/ErrorFeedbackLink';
 
 export const ErrorContent408 = (props: ErrorProps) => {

--- a/src/components/pages/error-page/errorcode-content/ErrorContentDefault.tsx
+++ b/src/components/pages/error-page/errorcode-content/ErrorContentDefault.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BodyLong } from '@navikt/ds-react';
+
 import { ErrorProps } from 'types/content-props/error-props';
+
 import { ErrorFeedbackLink } from './feedback-link/ErrorFeedbackLink';
 
 export const ErrorContentDefault = (props: ErrorProps) => {

--- a/src/components/pages/error-page/errorcode-content/clear-icon/ClearIcon.tsx
+++ b/src/components/pages/error-page/errorcode-content/clear-icon/ClearIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import style from './ClearIcon.module.scss';
 
 export const ClearIcon = () => (

--- a/src/components/pages/error-page/errorcode-content/feedback-link/ErrorFeedbackLink.tsx
+++ b/src/components/pages/error-page/errorcode-content/feedback-link/ErrorFeedbackLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BodyLong } from '@navikt/ds-react';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import Config from 'config';
 
@@ -15,12 +16,9 @@ export const ErrorFeedbackLink = ({ errorId }: Props) => {
                 <LenkeInline href={Config.urls.errorFeedback}>
                     {'melde fra om teknisk feil.'}
                 </LenkeInline>
-                {errorId &&
-                    " Inkluder gjerne feil-id'en under i din tilbakemelding."}
+                {errorId && " Inkluder gjerne feil-id'en under i din tilbakemelding."}
             </BodyLong>
-            {errorId && (
-                <BodyLong size="small">{`Feil-id: ${errorId}`}</BodyLong>
-            )}
+            {errorId && <BodyLong size="small">{`Feil-id: ${errorId}`}</BodyLong>}
         </>
     );
 };

--- a/src/components/pages/error-page/errorcode-content/search-form/SearchForm.tsx
+++ b/src/components/pages/error-page/errorcode-content/search-form/SearchForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Heading, TextField } from '@navikt/ds-react';
+
 import { ClearIcon } from 'components/pages/error-page/errorcode-content/clear-icon/ClearIcon';
 import { Button } from 'components/_common/button/Button';
 
@@ -20,12 +21,7 @@ export const SearchForm = () => {
 
     return (
         <div className={style.search}>
-            <Heading
-                level="2"
-                size="large"
-                className={style.header}
-                id={'search-header'}
-            >
+            <Heading level="2" size="large" className={style.header} id={'search-header'}>
                 {HEADER_TEXT}
             </Heading>
             <form onSubmit={onSearchSubmit} className={style.form}>
@@ -56,11 +52,7 @@ export const SearchForm = () => {
                             <ClearIcon />
                         </Button>
                     )}
-                    <Button
-                        className={style.button}
-                        variant={'primary'}
-                        onClick={onSearchSubmit}
-                    >
+                    <Button className={style.button} variant={'primary'} onClick={onSearchSubmit}>
                         {'Søk'}
                     </Button>
                 </div>

--- a/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
+++ b/src/components/pages/form-details-preview-page/FormDetailsPreviewPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
 import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepLink.tsx
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepLink.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { useRouter } from 'next/compat/router';
+import { LinkPanel } from '@navikt/ds-react';
+
 import { InfoBox } from 'components/_common/info-box/InfoBox';
 import style from 'components/pages/form-intermediate-step-page/FormIntermediateStepPage.module.scss';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
-import { useRouter } from 'next/compat/router';
-import { LinkPanel } from '@navikt/ds-react';
 import { FormIntermediateStep_StepLinkData } from 'components/pages/form-intermediate-step-page/useFormIntermediateStepPageState';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 

--- a/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
+++ b/src/components/pages/form-intermediate-step-page/FormIntermediateStepPage.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Button, Heading } from '@navikt/ds-react';
+import { useRouter } from 'next/compat/router';
+
 import { translator } from 'translations';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 import { FormIntermediateStepPageProps } from 'types/content-props/form-intermediate-step';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
-import { useRouter } from 'next/compat/router';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { useFormIntermediateStepPageState } from 'components/pages/form-intermediate-step-page/useFormIntermediateStepPageState';
 import { FormIntermediateStepLink } from 'components/pages/form-intermediate-step-page/FormIntermediateStepLink';

--- a/src/components/pages/form-intermediate-step-page/useFormIntermediateStepPageState.tsx
+++ b/src/components/pages/form-intermediate-step-page/useFormIntermediateStepPageState.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/compat/router';
+
 import {
     FormIntermediateStepPageProps,
     FormIntermediateStep_CompoundedStepData,

--- a/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
+++ b/src/components/pages/forms-overview-page/FormsOverviewPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
     FormsOverviewAudienceOptions,
     FormsOverviewProps,
@@ -38,9 +39,7 @@ export const FormsOverviewPage = (props: FormsOverviewProps) => {
 
     if (page.descriptor !== 'no.nav.navno:two-cols-page') {
         return (
-            <EditorHelp
-                text={`Ugyldig page-komponent for skjemaoversikt: ${page.descriptor}`}
-            />
+            <EditorHelp text={`Ugyldig page-komponent for skjemaoversikt: ${page.descriptor}`} />
         );
     }
 
@@ -50,32 +49,18 @@ export const FormsOverviewPage = (props: FormsOverviewProps) => {
     const audienceSubCategoryLinks = getLinksIfTransportPage(audience);
 
     return (
-        <div
-            className={classNames(
-                style.page,
-                config.sideColToggle && style.withSideCol
-            )}
-        >
-            <IllustrationStatic
-                illustration={illustration}
-                className={style.pictogram}
-            />
+        <div className={classNames(style.page, config.sideColToggle && style.withSideCol)}>
+            <IllustrationStatic illustration={illustration} className={style.pictogram} />
             <div className={style.main}>
                 <FormsOverviewHeader {...props} />
                 {audienceSubCategoryLinks ? (
-                    <FormsOverviewAudienceLinks
-                        links={audienceSubCategoryLinks}
-                    />
+                    <FormsOverviewAudienceLinks links={audienceSubCategoryLinks} />
                 ) : (
                     <FormsOverviewList {...props} />
                 )}
             </div>
             {config.sideColToggle && (
-                <Region
-                    pageProps={props}
-                    regionProps={regions.sideCol}
-                    className={style.aside}
-                />
+                <Region pageProps={props} regionProps={regions.sideCol} className={style.aside} />
             )}
         </div>
     );

--- a/src/components/pages/forms-overview-page/audience-links/FormsOverviewAudienceLinks.tsx
+++ b/src/components/pages/forms-overview-page/audience-links/FormsOverviewAudienceLinks.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Ingress } from '@navikt/ds-react';
+
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 
 import style from './FormsOverviewAudienceLinks.module.scss';

--- a/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
 import { FormsOverviewListPanel } from 'components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel';
 import { OverviewFilters } from 'components/_common/overview-filters/OverviewFilters';
@@ -33,11 +34,9 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
 
     const formNumberFromSearch = getExactFormNumberIfFormSearch(textFilter);
 
-    const numFilterTypes = [
-        areasFilterToggle,
-        taxonomyFilterToggle,
-        textFilterToggle,
-    ].filter(Boolean).length;
+    const numFilterTypes = [areasFilterToggle, taxonomyFilterToggle, textFilterToggle].filter(
+        Boolean
+    ).length;
 
     useEffect(() => {
         getFilteredList({

--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -1,17 +1,15 @@
 import React, { useState } from 'react';
+import { BodyLong } from '@navikt/ds-react';
+
 import { fetchPageCacheContent } from 'utils/fetch/fetch-cache-content';
 import { ContentType } from 'types/content-props/_content-common';
-import {
-    FormDetailsListItemProps,
-    FormsOverviewData,
-} from 'types/content-props/forms-overview';
+import { FormDetailsListItemProps, FormsOverviewData } from 'types/content-props/forms-overview';
 import {
     FormDetails,
     FormDetailsComponentProps,
 } from 'components/_common/form-details/FormDetails';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
 import { ProductPanelExpandable } from 'components/_common/product-panel/ProductPanelExpandable';
-import { BodyLong } from '@navikt/ds-react';
 import { OverviewMicroCards } from 'components/_common/card/overview-microcard/OverviewMicroCards';
 import { usePageContentProps } from 'store/pageContext';
 import { Language, translator } from 'translations';
@@ -41,10 +39,7 @@ const buildSubHeader = (
     const taxonomyTranslations = translator('taxonomies', language);
     const areaTranslations = translator('areas', language);
 
-    return [
-        ...taxonomy.map(taxonomyTranslations),
-        ...area.map(areaTranslations),
-    ]
+    return [...taxonomy.map(taxonomyTranslations), ...area.map(areaTranslations)]
         .filter(Boolean)
         .join(', ');
 };
@@ -76,9 +71,7 @@ export const FormsOverviewListPanel = ({
 
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
-    const [formDetailsPages, setFormDetailsPages] = useState<
-        null | FormDetailsPageProps[]
-    >(null);
+    const [formDetailsPages, setFormDetailsPages] = useState<null | FormDetailsPageProps[]>(null);
 
     const { language } = usePageContentProps();
 
@@ -96,9 +89,7 @@ export const FormsOverviewListPanel = ({
             .then((contentFromCache) => {
                 const validFormDetails = contentFromCache.filter((content) => {
                     if (!content) {
-                        setError(
-                            'Teknisk feil: Noen av skjemainngangene kunne ikke lastes'
-                        );
+                        setError('Teknisk feil: Noen av skjemainngangene kunne ikke lastes');
                         return false;
                     }
 
@@ -125,9 +116,7 @@ export const FormsOverviewListPanel = ({
                 opprinnelse: 'skjemaoversikt accordion',
             }}
         >
-            {!isAddendumPage && (
-                <BodyLong className={style.ingress}>{ingress}</BodyLong>
-            )}
+            {!isAddendumPage && <BodyLong className={style.ingress}>{ingress}</BodyLong>}
             {formDetailsPages?.map((formDetail) => (
                 <FormDetails
                     formDetails={formDetail.data}

--- a/src/components/pages/forms-overview-page/header/FormsOverviewHeader.tsx
+++ b/src/components/pages/forms-overview-page/header/FormsOverviewHeader.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { BodyShort } from '@navikt/ds-react';
+
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
 import Region from 'components/layouts/Region';
 import { PageHeader } from 'components/_common/headers/page-header/PageHeader';
-import { BodyShort } from '@navikt/ds-react';
 
 import style from './FormsOverviewHeader.module.scss';
 
@@ -12,11 +13,7 @@ export const FormsOverviewHeader = (props: FormsOverviewProps) => {
 
     return (
         <div className={style.container}>
-            <PageHeader
-                size={'xlarge'}
-                justify={'left'}
-                className={style.header}
-            >
+            <PageHeader size={'xlarge'} justify={'left'} className={style.header}>
                 {title}
             </PageHeader>
             <BodyShort className={style.subHeader}>{underTitle}</BodyShort>

--- a/src/components/pages/fragment-page/FragmentPage.tsx
+++ b/src/components/pages/fragment-page/FragmentPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FragmentPageProps } from 'types/content-props/fragment-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 
@@ -8,10 +9,7 @@ export const FragmentPage = (props: FragmentPageProps) => {
     return (
         <div className={style.fragmentPage}>
             <div className={style.components}>
-                <ComponentMapper
-                    componentProps={props.fragment}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.fragment} pageProps={props} />
             </div>
         </div>
     );

--- a/src/components/pages/generic-page/GenericPage.tsx
+++ b/src/components/pages/generic-page/GenericPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { GenericPageProps} from 'types/content-props/dynamic-page-props';
+
+import { GenericPageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
@@ -8,10 +9,7 @@ export const GenericPage = (props: GenericPageProps) => {
         <article className={'genericPage'}>
             <ThemedPageHeader contentProps={props} />
             <div className={'content'}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>
     );

--- a/src/components/pages/global-values-page/GlobalValuesPage.tsx
+++ b/src/components/pages/global-values-page/GlobalValuesPage.tsx
@@ -1,22 +1,24 @@
 import React, { useEffect, useState } from 'react';
-import { GlobalValuesProps } from 'types/content-props/global-values-props';
 import { Select, Heading } from '@navikt/ds-react';
-import { GVMessages } from './components/messages/GVMessages';
-import { GVAddItem } from './components/values/add-item/GVAddItem';
+import Head from 'next/head';
+
+import { GlobalValuesProps } from 'types/content-props/global-values-props';
 import {
     setContentIdAction,
     setEditorEnabledAction,
     setValueItemsAction,
 } from 'store/slices/gvEditorState';
 import { store } from 'store/store';
-import { GVItemsCustomOrder } from './components/values/GVItemsCustomOrder';
-import { GVItemsSorted } from './components/values/GVItemsSorted';
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
 import { ContentType } from 'types/content-props/_content-common';
-import Head from 'next/head';
 import { DocumentParameter } from 'components/_common/metatags/DocumentParameterMetatags';
 import Config from 'config';
 import { LayersEditorWarning } from 'components/_editor-only/layers-editor-warning/LayersEditorWarning';
+
+import { GVItemsSorted } from './components/values/GVItemsSorted';
+import { GVItemsCustomOrder } from './components/values/GVItemsCustomOrder';
+import { GVAddItem } from './components/values/add-item/GVAddItem';
+import { GVMessages } from './components/messages/GVMessages';
 
 import style from './GlobalValuesPage.module.scss';
 
@@ -55,10 +57,7 @@ const GlobalValuesDisplay = ({ displayName, type }: GlobalValuesProps) => {
     return (
         <div className={style.globalValuesPage}>
             <Head>
-                <meta
-                    name={DocumentParameter.DecoratorDisabled}
-                    content={'true'}
-                />
+                <meta name={DocumentParameter.DecoratorDisabled} content={'true'} />
             </Head>
             <div className={style.headerRow}>
                 <Heading level={'1'} size={'large'}>
@@ -117,12 +116,8 @@ const GlobalValuesDisplay = ({ displayName, type }: GlobalValuesProps) => {
 
 export const GlobalValuesPage = (props: GlobalValuesProps) => {
     store.dispatch(setContentIdAction({ contentId: props._id }));
-    store.dispatch(
-        setValueItemsAction({ valueItems: props.data?.valueItems || [] })
-    );
-    store.dispatch(
-        setEditorEnabledAction(props.layerLocale === Config.vars.defaultLocale)
-    );
+    store.dispatch(setValueItemsAction({ valueItems: props.data?.valueItems || [] }));
+    store.dispatch(setEditorEnabledAction(props.layerLocale === Config.vars.defaultLocale));
 
     return <GlobalValuesDisplay {...props} />;
 };

--- a/src/components/pages/global-values-page/api/globalValuesServiceFetch.ts
+++ b/src/components/pages/global-values-page/api/globalValuesServiceFetch.ts
@@ -3,13 +3,7 @@ import { xpDraftPathPrefix, xpServicePath } from 'utils/urls';
 
 const SERVICE_URL = `${xpDraftPathPrefix}${xpServicePath}/globalValues`;
 
-type GVRequestTypes =
-    | 'usage'
-    | 'add'
-    | 'modify'
-    | 'remove'
-    | 'getValueSet'
-    | 'reorder';
+type GVRequestTypes = 'usage' | 'add' | 'modify' | 'remove' | 'getValueSet' | 'reorder';
 
 export const globalValuesServiceFetch = <ResponseType>(
     requestType: GVRequestTypes,

--- a/src/components/pages/global-values-page/api/services/reorder.ts
+++ b/src/components/pages/global-values-page/api/services/reorder.ts
@@ -3,10 +3,7 @@ import { GVMessageProps } from 'components/pages/global-values-page/components/m
 
 type ServiceResponse = GVMessageProps;
 
-export const gvServiceReorderItems = (
-    orderedKeys: string[],
-    contentId: string
-) =>
+export const gvServiceReorderItems = (orderedKeys: string[], contentId: string) =>
     globalValuesServiceFetch<ServiceResponse>('reorder', {
         orderedKeys,
         contentId,

--- a/src/components/pages/global-values-page/components/button/GVButton.tsx
+++ b/src/components/pages/global-values-page/components/button/GVButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Button } from 'components/_common/button/Button';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 

--- a/src/components/pages/global-values-page/components/messages/GVMessages.tsx
+++ b/src/components/pages/global-values-page/components/messages/GVMessages.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { classNames } from 'utils/classnames';
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
 import { GVButton } from 'components/pages/global-values-page/components/button/GVButton';
@@ -19,13 +20,7 @@ export const GVMessages = () => {
     return (
         <div className={style.gvMessages}>
             {messages.map((msg, index) => (
-                <div
-                    className={classNames(
-                        msg.level || 'info',
-                        'navds-body-long'
-                    )}
-                    key={index}
-                >
+                <div className={classNames(msg.level || 'info', 'navds-body-long')} key={index}>
                     {msg.message}
                 </div>
             ))}

--- a/src/components/pages/global-values-page/components/values/GVItemsCustomOrder.tsx
+++ b/src/components/pages/global-values-page/components/values/GVItemsCustomOrder.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { List, arrayMove } from 'react-movable';
-import { GVItem } from './item/GVItem';
+import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
+import { OnChangeMeta } from 'react-movable/lib/types';
+
 import { classNames } from 'utils/classnames';
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
-import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 import { gvServiceReorderItems } from 'components/pages/global-values-page/api/services/reorder';
-import { OnChangeMeta } from 'react-movable/lib/types';
 import { logger } from 'srcCommon/logger';
+
+import { GVItem } from './item/GVItem';
 
 import styleCommon from './GVItems.module.scss';
 import styleCustomOrder from './GVItemsCustomOrder.module.scss';
 
 export const GVItemsCustomOrder = () => {
-    const { valueItems, setValueItems, contentId, setMessages, editorEnabled } =
-        useGvEditorState();
+    const { valueItems, setValueItems, contentId, setMessages, editorEnabled } = useGvEditorState();
 
     const reorderItems = ({ oldIndex, newIndex }: OnChangeMeta) => {
         const newSortedItems = arrayMove(valueItems, oldIndex, newIndex);
@@ -27,9 +28,7 @@ export const GVItemsCustomOrder = () => {
             if (!res || res.level === 'error') {
                 const msg = res?.message?.toString() || 'Ukjent feil';
 
-                logger.error(
-                    `Error from reorder request on ${contentId} - ${msg}`
-                );
+                logger.error(`Error from reorder request on ${contentId} - ${msg}`);
                 setMessages([
                     {
                         message: `Feil ved omsortering av verdier: ${msg}`,

--- a/src/components/pages/global-values-page/components/values/GVItemsSorted.tsx
+++ b/src/components/pages/global-values-page/components/values/GVItemsSorted.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { GVItem } from './item/GVItem';
+
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
+
+import { GVItem } from './item/GVItem';
 
 import style from './GVItems.module.scss';
 

--- a/src/components/pages/global-values-page/components/values/add-item/GVAddItem.tsx
+++ b/src/components/pages/global-values-page/components/values/add-item/GVAddItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { GVButton } from 'components/pages/global-values-page/components/button/GVButton';
 import { classNames } from 'utils/classnames';
 import { GVItemEditor } from 'components/pages/global-values-page/components/values/item-editor/GVItemEditor';

--- a/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/GVItemEditor.tsx
@@ -1,18 +1,17 @@
 import React, { useEffect, useState } from 'react';
+import { BodyShort } from '@navikt/ds-react';
+
 import { GVButton } from 'components/pages/global-values-page/components/button/GVButton';
 import { GlobalValueItem } from 'types/content-props/global-values-props';
-import {
-    generateGvUsageMessages,
-    gvNameExists,
-} from 'components/pages/global-values-page/utils';
+import { generateGvUsageMessages, gvNameExists } from 'components/pages/global-values-page/utils';
 import { gvServiceAddItem } from 'components/pages/global-values-page/api/services/add';
 import { gvServiceModifyItem } from 'components/pages/global-values-page/api/services/modify';
 import { gvServiceRemoveItem } from 'components/pages/global-values-page/api/services/remove';
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
 import { gvServiceGetValueSet } from 'components/pages/global-values-page/api/services/getValueSet';
 import { gvServiceGetUsage } from 'components/pages/global-values-page/api/services/usage';
-import { BodyShort } from '@navikt/ds-react';
 import { GVMessageProps } from 'components/pages/global-values-page/components/messages/GVMessages';
+
 import {
     GVItemEditorInputCaseTime,
     gvProcessCaseTimeInput,
@@ -35,22 +34,21 @@ type Props = {
     | { item?: undefined; newType: GlobalValueItem['type'] }
 );
 
-const defaultInputState: { [key in GlobalValueItem['type']]: GlobalValueItem } =
-    {
-        numberValue: {
-            type: 'numberValue',
-            key: '',
-            itemName: '',
-            numberValue: '',
-        },
-        caseTime: {
-            type: 'caseTime',
-            key: '',
-            itemName: '',
-            unit: 'months',
-            value: '',
-        },
-    };
+const defaultInputState: { [key in GlobalValueItem['type']]: GlobalValueItem } = {
+    numberValue: {
+        type: 'numberValue',
+        key: '',
+        itemName: '',
+        numberValue: '',
+    },
+    caseTime: {
+        type: 'caseTime',
+        key: '',
+        itemName: '',
+        unit: 'months',
+        value: '',
+    },
+};
 
 export const GVItemEditor = ({ item, newType, onClose }: Props) => {
     const [inputState, setInputState] = useState<GlobalValueItem | null>(
@@ -65,8 +63,7 @@ export const GVItemEditor = ({ item, newType, onClose }: Props) => {
         }
     }, [item]);
 
-    const { valueItems, contentId, setValueItems, setMessages } =
-        useGvEditorState();
+    const { valueItems, contentId, setValueItems, setMessages } = useGvEditorState();
 
     const onFetchError = (e: any) => {
         setMessages([{ message: `Server-feil: ${e}`, level: 'error' }]);
@@ -80,9 +77,7 @@ export const GVItemEditor = ({ item, newType, onClose }: Props) => {
 
     const updateAndClose = () => {
         onClose?.();
-        gvServiceGetValueSet(contentId).then(
-            (res) => res?.items && setValueItems(res.items)
-        );
+        gvServiceGetValueSet(contentId).then((res) => res?.items && setValueItems(res.items));
     };
 
     const deleteItem = async () => {
@@ -202,39 +197,25 @@ export const GVItemEditor = ({ item, newType, onClose }: Props) => {
                     {awaitDeleteConfirm ? (
                         <>
                             <BodyShort className={style.deleteConfirmMsg}>
-                                {
-                                    'Obs: Denne verdien kan være i bruk - er du sikker?'
-                                }
+                                {'Obs: Denne verdien kan være i bruk - er du sikker?'}
                             </BodyShort>
-                            <GVButton
-                                variant={'danger'}
-                                onClick={deleteConfirm}
-                            >
+                            <GVButton variant={'danger'} onClick={deleteConfirm}>
                                 {'Bekreft sletting'}
                             </GVButton>
-                            <GVButton
-                                variant={'secondary'}
-                                onClick={deleteCancel}
-                            >
+                            <GVButton variant={'secondary'} onClick={deleteCancel}>
                                 {'Avbryt sletting'}
                             </GVButton>
                         </>
                     ) : (
                         <>
-                            <GVButton
-                                variant={'primary'}
-                                onClick={validateAndSubmitItem}
-                            >
+                            <GVButton variant={'primary'} onClick={validateAndSubmitItem}>
                                 {'Lagre verdi'}
                             </GVButton>
                             <GVButton variant={'primary'} onClick={onClose}>
                                 {'Avbryt'}
                             </GVButton>
                             {!newType && (
-                                <GVButton
-                                    variant={'danger'}
-                                    onClick={deleteItem}
-                                >
+                                <GVButton variant={'danger'} onClick={deleteItem}>
                                     {'Slett'}
                                 </GVButton>
                             )}

--- a/src/components/pages/global-values-page/components/values/item-editor/case-time/GVItemEditorInputCaseTime.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/case-time/GVItemEditorInputCaseTime.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Select, TextField } from '@navikt/ds-react';
-import {
-    GlobalCaseTimeSetItem,
-    GlobalCaseTimeUnit,
-} from 'types/content-props/global-values-props';
+
+import { GlobalCaseTimeSetItem, GlobalCaseTimeUnit } from 'types/content-props/global-values-props';
 
 type Errors = { [key in keyof GlobalCaseTimeSetItem]?: string };
 
@@ -38,11 +36,7 @@ type Props = {
     setInputState: (inputState: GlobalCaseTimeSetItem) => void;
 };
 
-export const GVItemEditorInputCaseTime = ({
-    inputState,
-    errors,
-    setInputState,
-}: Props) => {
+export const GVItemEditorInputCaseTime = ({ inputState, errors, setInputState }: Props) => {
     const inputValue = inputState.value ? inputState.value.toString() : '';
 
     return (

--- a/src/components/pages/global-values-page/components/values/item-editor/number-value/GVItemEditorInputNumberValue.tsx
+++ b/src/components/pages/global-values-page/components/values/item-editor/number-value/GVItemEditorInputNumberValue.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
+
 import { GlobalNumberValueItem } from 'types/content-props/global-values-props';
 
 type Errors = { [key in keyof GlobalNumberValueItem]?: string };
@@ -7,9 +8,7 @@ type Errors = { [key in keyof GlobalNumberValueItem]?: string };
 export const gvProcessNumberValueInput = (input: GlobalNumberValueItem) => {
     const processedInput = {
         numberValue:
-            typeof input.numberValue === 'string'
-                ? Number(input.numberValue)
-                : input.numberValue,
+            typeof input.numberValue === 'string' ? Number(input.numberValue) : input.numberValue,
     };
 
     const { numberValue } = processedInput;
@@ -31,14 +30,8 @@ type Props = {
     setInputState: (inputState: GlobalNumberValueItem) => void;
 };
 
-export const GVItemEditorInputNumberValue = ({
-    inputState,
-    errors,
-    setInputState,
-}: Props) => {
-    const inputValue = inputState.numberValue
-        ? inputState.numberValue.toString()
-        : '';
+export const GVItemEditorInputNumberValue = ({ inputState, errors, setInputState }: Props) => {
+    const inputValue = inputState.numberValue ? inputState.numberValue.toString() : '';
 
     return (
         <>

--- a/src/components/pages/global-values-page/components/values/item/GVItem.tsx
+++ b/src/components/pages/global-values-page/components/values/item/GVItem.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { BodyShort, Heading } from '@navikt/ds-react';
+
 import { GlobalValueItem } from 'types/content-props/global-values-props';
 import { GVButton } from 'components/pages/global-values-page/components/button/GVButton';
 import { GVItemEditor } from 'components/pages/global-values-page/components/values/item-editor/GVItemEditor';
 import { useGvEditorState } from 'store/hooks/useGvEditorState';
 import { gvServiceGetUsage } from 'components/pages/global-values-page/api/services/usage';
 import { generateGvUsageMessages } from 'components/pages/global-values-page/utils';
-import { BodyShort, Heading } from '@navikt/ds-react';
 import { getCaseTimeString } from 'components/macros/saksbehandlingstid/MacroSaksbehandlingstid';
 
 import style from './GVItem.module.scss';
@@ -42,13 +43,8 @@ const ItemView = ({ item }: Props) => {
 };
 
 export const GVItem = (props: Props) => {
-    const {
-        setMessages,
-        contentId,
-        itemsEditState,
-        setItemEditState,
-        editorEnabled,
-    } = useGvEditorState();
+    const { setMessages, contentId, itemsEditState, setItemEditState, editorEnabled } =
+        useGvEditorState();
     const { item } = props;
     const { key } = item;
     const editMode = itemsEditState[key];
@@ -56,10 +52,7 @@ export const GVItem = (props: Props) => {
     return (
         <div className={style.gvItem}>
             {editMode ? (
-                <GVItemEditor
-                    item={item}
-                    onClose={() => setItemEditState(key, false)}
-                />
+                <GVItemEditor item={item} onClose={() => setItemEditState(key, false)} />
             ) : (
                 <ItemView item={item} />
             )}
@@ -75,27 +68,19 @@ export const GVItem = (props: Props) => {
                 )}
                 <GVButton
                     onClick={async () => {
-                        await gvServiceGetUsage(item.key, contentId).then(
-                            (res) => {
-                                if (!res) {
-                                    setMessages([
-                                        {
-                                            message:
-                                                'Server-feil ved uthenting av verdier',
-                                            level: 'error',
-                                        },
-                                    ]);
-                                    return;
-                                }
-
-                                setMessages(
-                                    generateGvUsageMessages(
-                                        res.usage,
-                                        item.itemName
-                                    )
-                                );
+                        await gvServiceGetUsage(item.key, contentId).then((res) => {
+                            if (!res) {
+                                setMessages([
+                                    {
+                                        message: 'Server-feil ved uthenting av verdier',
+                                        level: 'error',
+                                    },
+                                ]);
+                                return;
                             }
-                        );
+
+                            setMessages(generateGvUsageMessages(res.usage, item.itemName));
+                        });
                     }}
                 >
                     {'Vis bruk'}

--- a/src/components/pages/global-values-page/utils.tsx
+++ b/src/components/pages/global-values-page/utils.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
+
 import { GlobalValueItem } from 'types/content-props/global-values-props';
-import { GVMessageProps } from './components/messages/GVMessages';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 import { adminOrigin, editorPathPrefix, xpDraftPathPrefix } from 'utils/urls';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
 import { UsageContentInfo } from 'components/pages/global-values-page/api/services/usage';
 
-export const gvNameExists = (
-    itemName: string,
-    items: GlobalValueItem[],
-    key?: string
-) =>
-    items.find(
-        (item) => item.itemName === itemName && (!key || item.key !== key)
-    );
+import { GVMessageProps } from './components/messages/GVMessages';
+
+export const gvNameExists = (itemName: string, items: GlobalValueItem[], key?: string) =>
+    items.find((item) => item.itemName === itemName && (!key || item.key !== key));
 
 const getUsageMessages = (usage: UsageContentInfo[]) => {
     if (!usage || usage.length === 0) {
@@ -26,10 +22,7 @@ const getUsageMessages = (usage: UsageContentInfo[]) => {
                 <>
                     <EditorLinkWrapper>
                         <LenkeStandalone
-                            href={content.path.replace(
-                                '/www.nav.no',
-                                xpDraftPathPrefix
-                            )}
+                            href={content.path.replace('/www.nav.no', xpDraftPathPrefix)}
                             target={'_blank'}
                             withChevron={false}
                             onClick={(e) => {
@@ -70,8 +63,7 @@ export const generateGvUsageMessages = (
                 level: 'error',
             },
             {
-                message:
-                    'Prøv igjen, eller kontakt #team-personbruker dersom problemet vedvarer',
+                message: 'Prøv igjen, eller kontakt #team-personbruker dersom problemet vedvarer',
                 level: 'info',
             },
         ];

--- a/src/components/pages/guide-page/GuidePage.tsx
+++ b/src/components/pages/guide-page/GuidePage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { GuidePageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -10,10 +11,7 @@ export const GuidePage = (props: GuidePageProps) => {
         <article className={style.guidePage}>
             <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>
     );

--- a/src/components/pages/large-table-page/LargeTablePage.tsx
+++ b/src/components/pages/large-table-page/LargeTablePage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LargeTableProps } from 'types/content-props/large-table-props';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 

--- a/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
+++ b/src/components/pages/main-article-chapter-page/MainArticleChapterPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentType } from 'types/content-props/_content-common';
 import { RedirectPage } from 'components/pages/redirect-page/RedirectPage';
 import { DynamicPage } from 'components/pages/dynamic-page/DynamicPage';

--- a/src/components/pages/office-branch-page/OfficeBranchPage.tsx
+++ b/src/components/pages/office-branch-page/OfficeBranchPage.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { ComponentMapper } from 'components/ComponentMapper';
 import { OfficeBranchPageProps } from 'types/content-props/dynamic-page-props';
-import { OfficePageHeader } from './office-page-header/OfficePageHeader';
-import { OfficeDetails } from './office-details/OfficeDetails';
 import { classNames } from 'utils/classnames';
 import { logger } from 'srcCommon/logger';
+
+import { OfficePageHeader } from './office-page-header/OfficePageHeader';
+import { OfficeDetails } from './office-details/OfficeDetails';
 
 import styles from './OfficeBranchPage.module.scss';
 
@@ -17,17 +19,11 @@ export const OfficeBranchPage = (props: OfficeBranchPageProps) => {
 
     return (
         <div className={styles.officeBranchPage}>
-            <OfficePageHeader
-                officeDetails={props.data}
-                showTimeStamp={false}
-            />
+            <OfficePageHeader officeDetails={props.data} showTimeStamp={false} />
             <OfficeDetails officeData={props.data} />
             <div className={classNames(styles.content, styles.pageContent)}>
                 {editorialPage && (
-                    <ComponentMapper
-                        componentProps={editorialPage.page}
-                        pageProps={props}
-                    />
+                    <ComponentMapper componentProps={editorialPage.page} pageProps={props} />
                 )}
             </div>
         </div>

--- a/src/components/pages/office-branch-page/office-details/OfficeDetails.tsx
+++ b/src/components/pages/office-branch-page/office-details/OfficeDetails.tsx
@@ -1,12 +1,14 @@
 import { Heading } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { translator } from 'translations';
-import { Reception } from './reception/Reception';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { usePageContentProps } from 'store/pageContext';
+import { forceArray } from 'utils/arrays';
+
+import { Reception } from './reception/Reception';
 import { PhonePoster } from './phonePoster/PhonePoster';
 import { OfficeInformation } from './officeInformation/OfficeInformation';
-import { forceArray } from 'utils/arrays';
 
 import styles from './OfficeDetails.module.scss';
 
@@ -23,15 +25,11 @@ export const OfficeDetails = ({ officeData }: OfficeDetailsProps) => {
 
     return (
         <div className={styles.wide}>
-            <div
-                className={classNames(styles.officeDetails, styles.pageContent)}
-            >
+            <div className={classNames(styles.officeDetails, styles.pageContent)}>
                 <Heading level="2" size="large" className={styles.header}>
                     {getOfficeTranslations('youFindUsHere')}
                 </Heading>
-                {publikumsmottak.length > 0 && (
-                    <Reception receptions={publikumsmottak} />
-                )}
+                {publikumsmottak.length > 0 && <Reception receptions={publikumsmottak} />}
                 <PhonePoster officeData={officeData} />
                 <OfficeInformation officeData={officeData} />
             </div>

--- a/src/components/pages/office-branch-page/office-details/officeInformation/OfficeInformation.tsx
+++ b/src/components/pages/office-branch-page/office-details/officeInformation/OfficeInformation.tsx
@@ -1,4 +1,5 @@
 import { ExpansionCard, BodyShort, Heading } from '@navikt/ds-react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
@@ -15,18 +16,13 @@ export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
     const getOfficeTranslations = translator('office', language);
 
     const title = getOfficeTranslations('officeInformation');
-    const { postadresse, beliggenhet, organisasjonsnummer, enhetNr } =
-        officeData;
+    const { postadresse, beliggenhet, organisasjonsnummer, enhetNr } = officeData;
 
     const visitingAddress = officeDetailsFormatAddress(beliggenhet, true);
     const postalAddress = officeDetailsFormatAddress(postadresse, true);
 
     return (
-        <ExpansionCard
-            aria-label={title}
-            className={styles.officeInformation}
-            size="small"
-        >
+        <ExpansionCard aria-label={title} className={styles.officeInformation} size="small">
             <ExpansionCard.Header className={styles.expansionCardHeader}>
                 <ExpansionCard.Title as="h2" size="small">
                     {title}
@@ -55,14 +51,12 @@ export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
                             </Heading>
                             {organisasjonsnummer && (
                                 <BodyShort>
-                                    {getOfficeTranslations('orgNumber')}:{' '}
-                                    {organisasjonsnummer}
+                                    {getOfficeTranslations('orgNumber')}: {organisasjonsnummer}
                                 </BodyShort>
                             )}
                             {enhetNr && (
                                 <BodyShort>
-                                    {getOfficeTranslations('officeNumber')}:{' '}
-                                    {enhetNr}
+                                    {getOfficeTranslations('officeNumber')}: {enhetNr}
                                 </BodyShort>
                             )}
                         </section>

--- a/src/components/pages/office-branch-page/office-details/phonePoster/AudienceChannels.tsx
+++ b/src/components/pages/office-branch-page/office-details/phonePoster/AudienceChannels.tsx
@@ -1,4 +1,5 @@
 import { BodyShort } from '@navikt/ds-react';
+
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { AudienceContact } from 'types/content-props/office-details-props';
 import { officeDetailsFormatPhoneNumber } from 'components/pages/office-branch-page/office-details/utils';
@@ -9,20 +10,13 @@ type AudienceChannelsProps = {
     publikumskanaler: AudienceContact[];
 };
 
-export const AudienceChannels = ({
-    publikumskanaler,
-}: AudienceChannelsProps) => {
+export const AudienceChannels = ({ publikumskanaler }: AudienceChannelsProps) => {
     const buildChannel = (channel: AudienceContact) => {
         return (
-            <BodyShort
-                key={channel.sortOrder}
-                className={styles.audienceChannels}
-            >
+            <BodyShort key={channel.sortOrder} className={styles.audienceChannels}>
                 {`${channel.beskrivelse}: `}
                 {channel.epost && (
-                    <LenkeBase href={`mailto:${channel.epost}`}>
-                        {channel.epost}
-                    </LenkeBase>
+                    <LenkeBase href={`mailto:${channel.epost}`}>{channel.epost}</LenkeBase>
                 )}
                 {channel.telefon && (
                     <LenkeBase href={`tel:${channel.telefon}`}>

--- a/src/components/pages/office-branch-page/office-details/phonePoster/PhonePoster.tsx
+++ b/src/components/pages/office-branch-page/office-details/phonePoster/PhonePoster.tsx
@@ -1,26 +1,24 @@
 import React from 'react';
 import { BodyLong, BodyShort, Heading } from '@navikt/ds-react';
+import { PhoneFillIcon } from '@navikt/aksel-icons';
+
 import { OfficeDetailsProps } from 'components/pages/office-branch-page/office-details/OfficeDetails';
 import { translator } from 'translations';
 import { officeDetailsFormatPhoneNumber } from 'components/pages/office-branch-page/office-details/utils';
 import { usePageContentProps } from 'store/pageContext';
-import { PhoneFillIcon } from '@navikt/aksel-icons';
 import { forceArray } from 'utils/arrays';
-import { AudienceChannels } from './AudienceChannels';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import Config from 'config';
 
+import { AudienceChannels } from './AudienceChannels';
+
 import styles from './PhonePoster.module.scss';
 
-const humanReadablePhoneNumber = officeDetailsFormatPhoneNumber(
-    Config.vars.hovedNummer
-);
+const humanReadablePhoneNumber = officeDetailsFormatPhoneNumber(Config.vars.hovedNummer);
 
 export const PhonePoster = ({ officeData }: OfficeDetailsProps) => {
     const { language } = usePageContentProps();
-    const publikumskanaler = forceArray(
-        officeData.brukerkontakt?.publikumskanaler
-    );
+    const publikumskanaler = forceArray(officeData.brukerkontakt?.publikumskanaler);
     const getOfficeTranslations = translator('office', language);
 
     return (
@@ -29,14 +27,8 @@ export const PhonePoster = ({ officeData }: OfficeDetailsProps) => {
                 {getOfficeTranslations('phoneToNav')}
             </Heading>
             <BodyShort className={styles.phoneNumberWrapper}>
-                <LenkeBase
-                    href={Config.urls.hovedNummerTlf}
-                    className={styles.phoneNumber}
-                >
-                    <PhoneFillIcon
-                        aria-hidden="true"
-                        className={styles.telephoneIcon}
-                    />
+                <LenkeBase href={Config.urls.hovedNummerTlf} className={styles.phoneNumber}>
+                    <PhoneFillIcon aria-hidden="true" className={styles.telephoneIcon} />
                     {humanReadablePhoneNumber}
                 </LenkeBase>
             </BodyShort>

--- a/src/components/pages/office-branch-page/office-details/reception/OpeningHours.tsx
+++ b/src/components/pages/office-branch-page/office-details/reception/OpeningHours.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 import { OpeningHours as OpeningHoursProps } from 'types/content-props/office-details-props';
@@ -35,9 +36,7 @@ export const OpeningHours = ({ openingHours }: Props) => {
         }
 
         if (opening.fra && opening.til) {
-            return `${normalizeTimeLabel(opening.fra)}–${normalizeTimeLabel(
-                opening.til
-            )}`;
+            return `${normalizeTimeLabel(opening.fra)}–${normalizeTimeLabel(opening.til)}`;
         }
 
         return closedLabel;

--- a/src/components/pages/office-branch-page/office-details/reception/Reception.tsx
+++ b/src/components/pages/office-branch-page/office-details/reception/Reception.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { BodyLong, Tabs } from '@navikt/ds-react';
+
 import { AudienceReception } from 'types/content-props/office-details-props';
 import { forceArray } from 'utils/arrays';
-import { SingleReception } from './SingleReception';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
+
+import { SingleReception } from './SingleReception';
 
 import style from './Reception.module.scss';
 
@@ -21,11 +23,7 @@ export const Reception = ({ receptions }: Props) => {
         if (!reception) {
             return '(Ukjent sted)';
         }
-        return (
-            reception.stedsbeskrivelse ||
-            reception.besoeksadresse?.poststed ||
-            '(Ukjent sted)'
-        );
+        return reception.stedsbeskrivelse || reception.besoeksadresse?.poststed || '(Ukjent sted)';
     };
 
     const getIdFromLabel = (label: string) => {
@@ -52,11 +50,7 @@ export const Reception = ({ receptions }: Props) => {
             <BodyLong className={style.chooseBetweenOffices}>
                 {getOfficeTranslations('chooseBetweenOffices')}
             </BodyLong>
-            <Tabs
-                value={state}
-                onChange={setState}
-                className={style.officeTabs}
-            >
+            <Tabs value={state} onChange={setState} className={style.officeTabs}>
                 <Tabs.List>
                     {receptionArray.map((loc: AudienceReception, index) => {
                         const locationLabel = getLocation(loc);

--- a/src/components/pages/office-branch-page/office-details/reception/SingleReception.tsx
+++ b/src/components/pages/office-branch-page/office-details/reception/SingleReception.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { BodyShort, Heading } from '@navikt/ds-react';
-import {
-    ClockFillIcon,
-    InformationSquareFillIcon,
-    HouseFillIcon,
-} from '@navikt/aksel-icons';
+import { ClockFillIcon, InformationSquareFillIcon, HouseFillIcon } from '@navikt/aksel-icons';
+
 import { classNames } from 'utils/classnames';
 import { translator } from 'translations';
 import {
@@ -16,8 +13,9 @@ import {
     officeDetailsFormatAudienceReception,
     officeDetailsGetFutureOpeningExceptions,
 } from 'components/pages/office-branch-page/office-details/utils';
-import { OpeningHours } from './OpeningHours';
 import { usePageContentProps } from 'store/pageContext';
+
+import { OpeningHours } from './OpeningHours';
 
 import style from './SingleReception.module.scss';
 
@@ -26,12 +24,8 @@ export const SingleReception = (props: AudienceReception) => {
 
     const getLabel = translator('office', language);
 
-    const {
-        address,
-        adkomstbeskrivelse,
-        openingHours,
-        openingHoursExceptions,
-    } = officeDetailsFormatAudienceReception(props);
+    const { address, adkomstbeskrivelse, openingHours, openingHoursExceptions } =
+        officeDetailsFormatAudienceReception(props);
 
     const futureOpeningHoursExceptions =
         officeDetailsGetFutureOpeningExceptions(openingHoursExceptions);
@@ -53,18 +47,10 @@ export const SingleReception = (props: AudienceReception) => {
             </section>
             {openingHours.length > 0 && (
                 <>
-                    <Heading
-                        level="3"
-                        size="medium"
-                        spacing
-                        className={style.heading}
-                    >
+                    <Heading level="3" size="medium" spacing className={style.heading}>
                         <ClockFillIcon
                             aria-hidden="true"
-                            className={classNames(
-                                style.headingIcon,
-                                style.iconClock
-                            )}
+                            className={classNames(style.headingIcon, style.iconClock)}
                         />
                         {getLabel('openingHoursWithoutAppointment')}
                     </Heading>
@@ -80,10 +66,7 @@ export const SingleReception = (props: AudienceReception) => {
                 </>
             )}
             <div className={style.appointmentBookingInfo}>
-                <InformationSquareFillIcon
-                    className={style.iconInfo}
-                    aria-hidden="true"
-                />
+                <InformationSquareFillIcon className={style.iconInfo} aria-hidden="true" />
                 {getLabel('youCanMakeAppointment')}
             </div>
         </div>

--- a/src/components/pages/office-branch-page/office-details/utils.ts
+++ b/src/components/pages/office-branch-page/office-details/utils.ts
@@ -14,9 +14,7 @@ export const officeDetailsFormatAddress = (
     }
     let formatedAddress: string;
     if (address.type === 'postboksadresse') {
-        const postboksanlegg = address.postboksanlegg
-            ? ` ${address.postboksanlegg}`
-            : '';
+        const postboksanlegg = address.postboksanlegg ? ` ${address.postboksanlegg}` : '';
         formatedAddress = `Postboks ${address.postboksnummer}${postboksanlegg}`;
     } else {
         const husnummer = address.husnummer ? ` ${address.husnummer}` : '';
@@ -39,10 +37,7 @@ export const officeDetailsFormatPhoneNumber = (phoneNumber?: string) => {
     return phoneNumber
         .replace(/ /g, '')
         .split('')
-        .reduce(
-            (acc, digit, index) => acc + digit + (index % 2 === 1 ? ' ' : ''),
-            ''
-        )
+        .reduce((acc, digit, index) => acc + digit + (index % 2 === 1 ? ' ' : ''), '')
         .trim();
 };
 
@@ -70,30 +65,24 @@ type FormattedAudienceReception = {
 export const officeDetailsFormatAudienceReception = (
     audienceReception: AudienceReception
 ): FormattedAudienceReception => {
-    const aapningstider =
-        audienceReception.aapningstider.reduce<OpeningHoursBuckets>(
-            (acc, elem) => {
-                if (elem.dato) {
-                    acc.exceptions.push(elem);
-                } else {
-                    acc.regular.push(elem);
-                }
-                return acc;
-            },
-            {
-                regular: [],
-                exceptions: [],
+    const aapningstider = audienceReception.aapningstider.reduce<OpeningHoursBuckets>(
+        (acc, elem) => {
+            if (elem.dato) {
+                acc.exceptions.push(elem);
+            } else {
+                acc.regular.push(elem);
             }
-        );
+            return acc;
+        },
+        {
+            regular: [],
+            exceptions: [],
+        }
+    );
 
     return {
-        address: officeDetailsFormatAddress(
-            audienceReception.besoeksadresse,
-            true
-        ),
-        place:
-            audienceReception.stedsbeskrivelse ||
-            audienceReception.besoeksadresse?.poststed,
+        address: officeDetailsFormatAddress(audienceReception.besoeksadresse, true),
+        place: audienceReception.stedsbeskrivelse || audienceReception.besoeksadresse?.poststed,
         openingHoursExceptions: aapningstider.exceptions,
         openingHours: aapningstider.regular.sort(
             (a, b) => dagArr.indexOf(a.dag) - dagArr.indexOf(b.dag)

--- a/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.tsx
+++ b/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { classNames } from 'utils/classnames';
 import { BodyShort, Heading } from '@navikt/ds-react';
+
+import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { joinWithConjunction } from 'utils/string';
-import {
-    AudienceReception,
-    OfficeDetailsData,
-} from 'types/content-props/office-details-props';
+import { AudienceReception, OfficeDetailsData } from 'types/content-props/office-details-props';
 
 import style from './OfficePageHeader.module.scss';
 
@@ -49,10 +47,7 @@ export const OfficePageHeader = ({ officeDetails }: Props) => {
                     </BodyShort>
                     {subTitle && (
                         <>
-                            <BodyShort
-                                size="small"
-                                className={style.branchNamesLabel}
-                            >
+                            <BodyShort size="small" className={style.branchNamesLabel}>
                                 {subTitle}
                             </BodyShort>
                         </>

--- a/src/components/pages/office-branch-page/utils.ts
+++ b/src/components/pages/office-branch-page/utils.ts
@@ -15,10 +15,7 @@ const dayNameKey: Record<LegacyDayNames, TranslationDayNameKeys> = {
     Fredag: 'fri',
 } as const;
 
-export const buildDayLabel = (
-    opening: OpeningHoursProps,
-    language: Language
-): string => {
+export const buildDayLabel = (opening: OpeningHoursProps, language: Language): string => {
     const weekdayNames = translator('dateTime', language)('weekDayNames');
 
     const { dato, dag } = opening;

--- a/src/components/pages/office-editorial-page/OfficeEditorialPage.tsx
+++ b/src/components/pages/office-editorial-page/OfficeEditorialPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ComponentMapper } from 'components/ComponentMapper';
 import { OfficeEditorialPageProps } from 'types/content-props/dynamic-page-props';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -10,10 +11,7 @@ export const OfficeEditorialPage = (props: OfficeEditorialPageProps) => {
         <div className={style.officeEditorialPage}>
             <ThemedPageHeader contentProps={props} showTimeStamp={false} />
             <div className={style.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </div>
     );

--- a/src/components/pages/overview-page/OverviewPage.tsx
+++ b/src/components/pages/overview-page/OverviewPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -40,10 +41,7 @@ export const OverviewPage = (props: OverviewPageProps) => {
         <article className={style.overviewPage}>
             <ThemedPageHeader contentProps={props} showTimeStamp={false} />
             <div className={style.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
             <div className={style.content}>
                 <div className={style.filters}>

--- a/src/components/pages/overview-page/product-panel/OverviewProductDetailsPanel.tsx
+++ b/src/components/pages/overview-page/product-panel/OverviewProductDetailsPanel.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { BodyLong } from '@navikt/ds-react';
+
 import { ComponentMapper } from 'components/ComponentMapper';
 import { fetchPageCacheContent } from 'utils/fetch/fetch-cache-content';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
@@ -9,7 +11,6 @@ import { ProductPanelExpandable } from 'components/_common/product-panel/Product
 import { LayoutProps } from 'types/component-props/layouts';
 import { OverviewMicroCards } from 'components/_common/card/overview-microcard/OverviewMicroCards';
 import { OverviewPageProductItem } from 'types/content-props/overview-props';
-import { BodyLong } from '@navikt/ds-react';
 
 import style from './OverviewProductDetailsPanel.module.scss';
 
@@ -19,24 +20,13 @@ type Props = {
     productDetails: OverviewPageProductItem;
 };
 
-export const OverviewProductDetailsPanel = ({
-    detailType,
-    pageProps,
-    productDetails,
-}: Props) => {
-    const {
-        productDetailsPath,
-        anchorId,
-        illustration,
-        title,
-        productLinks,
-        ingress,
-    } = productDetails;
+export const OverviewProductDetailsPanel = ({ detailType, pageProps, productDetails }: Props) => {
+    const { productDetailsPath, anchorId, illustration, title, productLinks, ingress } =
+        productDetails;
 
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [productDetailsPage, setProductDetailsPage] =
-        useState<LayoutProps | null>(null);
+    const [productDetailsPage, setProductDetailsPage] = useState<LayoutProps | null>(null);
 
     const { language } = usePageContentProps();
 
@@ -54,11 +44,7 @@ export const OverviewProductDetailsPanel = ({
         fetchPageCacheContent(productDetailsPath)
             .then((contentFromCache) => {
                 if (contentFromCache?.type !== ContentType.ProductDetails) {
-                    setError(
-                        `Teknisk feil: Kunne ikke laste ${detailTypeStrings(
-                            detailType
-                        )}.`
-                    );
+                    setError(`Teknisk feil: Kunne ikke laste ${detailTypeStrings(detailType)}.`);
                     return null;
                 }
 
@@ -75,9 +61,7 @@ export const OverviewProductDetailsPanel = ({
             header={title}
             illustration={illustration}
             anchorId={anchorId}
-            contentLoaderCallback={
-                isSimpleOverview ? undefined : handleProductDetailsFetch
-            }
+            contentLoaderCallback={isSimpleOverview ? undefined : handleProductDetailsFetch}
             error={error}
             isLoading={isLoading}
             withCopyLink={!isSimpleOverview}
@@ -88,15 +72,9 @@ export const OverviewProductDetailsPanel = ({
             {isSimpleOverview ? (
                 <BodyLong>{ingress}</BodyLong>
             ) : productDetailsPage ? (
-                <ComponentMapper
-                    componentProps={productDetailsPage}
-                    pageProps={pageProps}
-                />
+                <ComponentMapper componentProps={productDetailsPage} pageProps={pageProps} />
             ) : null}
-            <OverviewMicroCards
-                productLinks={productLinks}
-                className={style.microCard}
-            />
+            <OverviewMicroCards productLinks={productLinks} className={style.microCard} />
         </ProductPanelExpandable>
     );
 };

--- a/src/components/pages/payout-dates-page/PayoutDatesPage.tsx
+++ b/src/components/pages/payout-dates-page/PayoutDatesPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PayoutDatesProps } from 'types/content-props/payout-dates';
 import { PayoutDates } from 'components/_common/payout-dates/PayoutDates';
 import Config from 'config';
@@ -11,13 +12,8 @@ export const PayoutDatesPage = (props: PayoutDatesProps) => {
 
     return (
         <>
-            {layerLocale !== Config.vars.defaultLocale && (
-                <LayersEditorWarning />
-            )}
-            <PayoutDates
-                payoutDatesData={props.data}
-                className={style.payoutDatesPage}
-            />
+            {layerLocale !== Config.vars.defaultLocale && <LayersEditorWarning />}
+            <PayoutDates payoutDatesData={props.data} className={style.payoutDatesPage} />
         </>
     );
 };

--- a/src/components/pages/press-landing-page/PressLandingPage.tsx
+++ b/src/components/pages/press-landing-page/PressLandingPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PressLandingPageProps } from 'types/content-props/dynamic-page-props';
 import { PressTopSection } from 'components/_common/press-landing/PressTopSection';
 import { PressNews } from 'components/_common/press-landing/PressNews';

--- a/src/components/pages/product-details-page/ProductDetailsPage.tsx
+++ b/src/components/pages/product-details-page/ProductDetailsPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ProductDetailsProps } from 'types/content-props/dynamic-page-props';
 import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';
@@ -12,10 +13,7 @@ export const ProductDetailsPage = (props: ProductDetailsProps) => {
         // Samme styling som ProductPage
         <div className={'productPage'}>
             <div className={'content'}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </div>
     );

--- a/src/components/pages/product-page/ProductPage.tsx
+++ b/src/components/pages/product-page/ProductPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ProductPageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -10,10 +11,7 @@ export const ProductPage = (props: ProductPageProps) => {
         <article className={styles.productPage}>
             <ThemedPageHeader contentProps={props} />
             <div className={styles.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>
     );

--- a/src/components/pages/redirect-page/RedirectPage.tsx
+++ b/src/components/pages/redirect-page/RedirectPage.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/compat/router';
-import { getTargetIfRedirect } from 'utils/redirects';
 import { BodyLong, Loader } from '@navikt/ds-react';
+
+import { getTargetIfRedirect } from 'utils/redirects';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { ContentProps } from 'types/content-props/_content-common';
 import { RedirectTo404 } from 'components/_common/redirect-to-404/RedirectTo404';

--- a/src/components/pages/situation-page/SituationPage.tsx
+++ b/src/components/pages/situation-page/SituationPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { SituationPageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -10,10 +11,7 @@ export const SituationPage = (props: SituationPageProps) => {
         <article className={styles.situationPage}>
             <ThemedPageHeader contentProps={props} />
             <div className={styles.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>
     );

--- a/src/components/pages/template-page/TemplatePage.tsx
+++ b/src/components/pages/template-page/TemplatePage.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+
 import { DynamicPage } from 'components/pages/dynamic-page/DynamicPage';
+import { ContentType } from 'types/content-props/_content-common';
+import { TemplateProps } from 'types/content-props/template-props';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+
 import { linkListDataMock } from './mocks/linkListDataMock';
 import { linkPanelsDataMock } from './mocks/linkPanelsDataMock';
 import { mainArticleDataMock } from './mocks/mainArticleDataMock';
 import { mainPanelDataMock } from './mocks/mainPanelsDataMock';
-import { ContentType } from 'types/content-props/_content-common';
-import { TemplateProps } from 'types/content-props/template-props';
-import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 const legacyMockData = {
     ...linkListDataMock,

--- a/src/components/pages/themed-article-page/ThemedArticlePage.tsx
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ThemedArticlePageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
@@ -10,10 +11,7 @@ export const ThemedArticlePage = (props: ThemedArticlePageProps) => {
         <article className={style.themedArticlePage}>
             <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
-                <ComponentMapper
-                    componentProps={props.page}
-                    pageProps={props}
-                />
+                <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>
     );

--- a/src/components/pages/user-tests-config-preview-page/UserTestsConfigPreviewPage.tsx
+++ b/src/components/pages/user-tests-config-preview-page/UserTestsConfigPreviewPage.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
+import Head from 'next/head';
+
 import { UserTestsConfigProps } from 'types/content-props/user-tests-config';
 import { UserTests } from 'components/_common/user-tests/UserTests';
 import { DocumentParameter } from 'components/_common/metatags/DocumentParameterMetatags';
-import Head from 'next/head';
 
 export const UserTestsConfigPreviewPage = (props: UserTestsConfigProps) => {
     return (
         <>
             <Head>
-                <meta
-                    name={DocumentParameter.DecoratorDisabled}
-                    content={'true'}
-                />
+                <meta name={DocumentParameter.DecoratorDisabled} content={'true'} />
             </Head>
             <UserTests tests={props} selectedTestIds={[]} />
         </>

--- a/src/components/pages/video-preview-page/VideoPreviewPage.tsx
+++ b/src/components/pages/video-preview-page/VideoPreviewPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { VideoPageProps } from 'types/content-props/video';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { QbrickVideo } from 'components/_common/qbrick-video/QbrickVideo';

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -1,11 +1,21 @@
 // @ts-nocheck
 import React from 'react';
+
 import {
     PartCurrentType,
     PartDeprecatedType,
     PartLegacyType,
     PartType,
 } from 'types/component-props/parts';
+import { ComponentType, PartComponentProps } from 'types/component-props/_component-common';
+import { ContentProps } from 'types/content-props/_content-common';
+import { BEM, classNames } from 'utils/classnames';
+import { CalculatorPart } from 'components/parts/calculator/CalculatorPart';
+import { editorAuthstateClassname } from 'components/_common/auth-dependant-render/AuthDependantRender';
+import { UxSignalsWidgetPart } from 'components/parts/uxsignals-widget/UxSignalsWidgetPart';
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+import { UserTestsPart } from 'components/parts/user-tests/UserTestsPart';
+
 import { MainArticleChapterNavigation } from './_legacy/main-article-chapter-navigation/MainArticleChapterNavigation';
 import { MainPanels } from './_legacy/main-panels/MainPanels';
 import { MenuList } from './_legacy/menu-list/MenuList';
@@ -16,20 +26,13 @@ import { LinkPanelPart } from './link-panel/LinkPanelPart';
 import { LinkPanelsLegacyPart } from './_legacy/link-panels/LinkPanelsLegacyPart';
 import LinkLists from './_legacy/link-lists/LinkLists';
 import { MainArticle } from './_legacy/main-article/MainArticle';
-import {
-    ComponentType,
-    PartComponentProps,
-} from 'types/component-props/_component-common';
-import { ContentProps } from 'types/content-props/_content-common';
 import { OfficeInformation } from './_legacy/office-information/OfficeInformation';
 import { HeaderPart } from './header/HeaderPart';
 import { LinkListPart } from './link-list/LinkListPart';
 import { NewsListPart } from './news-list/NewsListPart';
 import PublishingCalendar from './_legacy/publishing-calendar/PublishingCalendar';
 import PublishingCalendarEntry from './_legacy/publishing-calendar/PublishingCalendarEntry';
-import { BEM, classNames } from 'utils/classnames';
 import { HtmlArea } from './html-area/HtmlArea';
-import { CalculatorPart } from 'components/parts/calculator/CalculatorPart';
 import { ProductDetailsPart } from './product-details/ProductDetailsPart';
 import { PageHeaderPart } from './page-header/PageHeaderPart';
 import { ButtonPart } from './button/ButtonPart';
@@ -42,16 +45,12 @@ import { ProductCardPart } from './product-card/ProductCard';
 import { OfficeEditorialDetail } from './office-editorial-detail/OfficeEditorialDetail';
 import { ContactOptionPart } from './contact-option/ContactOptionPart';
 import { ProductCardMicroPart } from './product-card-micro/ProductCardMicro';
-import { editorAuthstateClassname } from 'components/_common/auth-dependant-render/AuthDependantRender';
 import { PayoutDatesPart } from './payout-dates/PayoutDatesPart';
 import { AreaCardPart } from './area-card/AreaCardPart';
 import { AreapageSituationCardPart } from './areapage-situation-card/AreapageSituationCardPart';
 import { LoggedinCardPart } from './loggedin-card/LoggedinCardPart';
 import { FrontpageContactPart } from './frontpage-contact/FrontpageContactPart';
-import { UxSignalsWidgetPart } from 'components/parts/uxsignals-widget/UxSignalsWidgetPart';
 import { FormDetailsPart } from './form-details/FormDetailsPart';
-import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { UserTestsPart } from 'components/parts/user-tests/UserTestsPart';
 import { ReadMorePart } from './read-more/ReadMorePart';
 import { AccordionPart } from './accordion/AccordionPart';
 import { AlternativeAudiencePart } from './alternative-audience/AlternativeAudiencePart';
@@ -62,10 +61,7 @@ type Props = {
     pageProps: ContentProps;
 };
 
-const partsWithPageData: Record<
-    PartLegacyType,
-    React.FunctionComponent<ContentProps>
-> = {
+const partsWithPageData: Record<PartLegacyType, React.FunctionComponent<ContentProps>> = {
     [PartType.LinkLists]: LinkLists,
     [PartType.LinkPanels]: LinkPanelsLegacyPart,
     [PartType.MainArticle]: MainArticle,
@@ -79,10 +75,7 @@ const partsWithPageData: Record<
     [PartType.PublishingCalendarEntry]: PublishingCalendarEntry,
 };
 
-const partsWithOwnData: Record<
-    PartCurrentType,
-    React.FunctionComponent<PartComponentProps>
-> = {
+const partsWithOwnData: Record<PartCurrentType, React.FunctionComponent<PartComponentProps>> = {
     [PartType.AlertBox]: AlertBoxPart,
     [PartType.Header]: HeaderPart,
     [PartType.LinkPanel]: LinkPanelPart,
@@ -144,10 +137,7 @@ const PartComponent = ({ partProps, pageProps }: Props) => {
     }
 
     return (
-        <EditorHelp
-            text={`Part-komponenten er ikke implementert: "${descriptor}"`}
-            type={'info'}
-        />
+        <EditorHelp text={`Part-komponenten er ikke implementert: "${descriptor}"`} type={'info'} />
     );
 };
 

--- a/src/components/parts/_image/ImageComponent.tsx
+++ b/src/components/parts/_image/ImageComponent.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import {
-    ComponentType,
-    ImageComponentProps,
-} from 'types/component-props/_component-common';
 import { BodyShort } from '@navikt/ds-react';
+
+import { ComponentType, ImageComponentProps } from 'types/component-props/_component-common';
 import { NextImage } from 'components/_common/image/NextImage';
 
 import style from './Image.module.scss';

--- a/src/components/parts/_legacy/link-lists/LinkLists.tsx
+++ b/src/components/parts/_legacy/link-lists/LinkLists.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ContentList } from 'components/_common/content-list/ContentList';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
 import { translator } from 'translations';
@@ -13,10 +14,7 @@ const LinkLists = (props: SectionPageProps) => {
     const { newsContents, moreNewsUrl, ntkContents, scContents } = data;
 
     const newsUrlAbsolute =
-        moreNewsUrl &&
-        (moreNewsUrl.startsWith('/')
-            ? `${appOrigin}${moreNewsUrl}`
-            : moreNewsUrl);
+        moreNewsUrl && (moreNewsUrl.startsWith('/') ? `${appOrigin}${moreNewsUrl}` : moreNewsUrl);
 
     return (
         <>

--- a/src/components/parts/_legacy/link-panels/LinkPanelsLegacyPart.tsx
+++ b/src/components/parts/_legacy/link-panels/LinkPanelsLegacyPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LenkepanelListe } from 'components/_common/lenkepanel-liste/LenkepanelListe';
 import { SectionPageProps } from 'types/content-props/section-page-props';
 
@@ -8,7 +9,5 @@ export const LinkPanelsLegacyPart = (props: SectionPageProps) => {
         return null;
     }
 
-    return (
-        <LenkepanelListe title={panelsHeading} items={panelItems} {...props} />
-    );
+    return <LenkepanelListe title={panelsHeading} items={panelItems} {...props} />;
 };

--- a/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
+++ b/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BodyLong, Heading } from '@navikt/ds-react';
+
 import { translator } from 'translations';
 import { classNames } from 'utils/classnames';
 import { ContentType, ContentProps } from 'types/content-props/_content-common';

--- a/src/components/parts/_legacy/main-article/MainArticle.tsx
+++ b/src/components/parts/_legacy/main-article/MainArticle.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Heading, Ingress } from '@navikt/ds-react';
+
 import { ContentType } from 'types/content-props/_content-common';
 import { MainArticleProps } from 'types/content-props/main-article-props';
 import { MainArticleChapterProps } from 'types/content-props/main-article-chapter-props';
 import ArtikkelDato from 'components/parts/_legacy/main-article/komponenter/ArtikkelDato';
-import { Heading, Ingress } from '@navikt/ds-react';
 import { Innholdsfortegnelse } from 'components/parts/_legacy/main-article/komponenter/Innholdsfortegnelse';
 import { MainArticleText } from 'components/parts/_legacy/main-article/komponenter/MainArticleText';
 import { Faktaboks } from 'components/parts/_legacy/main-article/komponenter/Faktaboks';
@@ -19,9 +20,7 @@ type Props = MainArticleProps | MainArticleChapterProps;
 
 // Get props from the chapter article if the content is a chapter
 const getPropsToRender = (propsInitial: Props) =>
-    propsInitial.type === ContentType.MainArticleChapter
-        ? propsInitial.data.article
-        : propsInitial;
+    propsInitial.type === ContentType.MainArticleChapter ? propsInitial.data.article : propsInitial;
 
 export const MainArticle = (propsInitial: Props) => {
     const props = getPropsToRender(propsInitial);
@@ -29,35 +28,23 @@ export const MainArticle = (propsInitial: Props) => {
         return null;
     }
 
-    const {
-        data,
-        language,
-        publish,
-        createdTime,
-        modifiedTime,
-        displayName,
-        _path,
-    } = props;
+    const { data, language, publish, createdTime, modifiedTime, displayName, _path } = props;
 
     const isNewsArticle =
-        props.data.contentType === 'news' ||
-        props.data.contentType === 'pressRelease';
+        props.data.contentType === 'news' || props.data.contentType === 'pressRelease';
 
     const style = isNewsArticle ? styleNews : stylePermanent;
 
     const getLabel = translator('mainArticle', language);
 
-    const hasTableOfContents = !!(
-        data?.hasTableOfContents && data?.hasTableOfContents !== 'none'
-    );
+    const hasTableOfContents = !!(data?.hasTableOfContents && data?.hasTableOfContents !== 'none');
 
     const innholdsfortegnelse = parseInnholdsfortegnelse(
         data.text?.processedHtml,
         hasTableOfContents
     );
 
-    const headerClassName =
-        innholdsfortegnelse.length === 0 ? style.header : style.headerWithToc;
+    const headerClassName = innholdsfortegnelse.length === 0 ? style.header : style.headerWithToc;
 
     return (
         <article className={style.article}>
@@ -71,12 +58,7 @@ export const MainArticle = (propsInitial: Props) => {
                     type={isNewsArticle ? 'newsPress' : 'normal'}
                 />
                 {!isNewsArticle && (
-                    <Heading
-                        level={'1'}
-                        size={'xlarge'}
-                        className={style.title}
-                        spacing
-                    >
+                    <Heading level={'1'} size={'xlarge'} className={style.title} spacing>
                         {displayName}
                     </Heading>
                 )}
@@ -101,11 +83,7 @@ export const MainArticle = (propsInitial: Props) => {
                 />
             )}
             {data.social && (
-                <SosialeMedier
-                    social={data.social}
-                    displayName={displayName}
-                    contentPath={_path}
-                />
+                <SosialeMedier social={data.social} displayName={displayName} contentPath={_path} />
             )}
             <Bilde picture={data.picture} />
         </article>

--- a/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/ArtikkelDato.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { BodyLong, Detail } from '@navikt/ds-react';
+
 import { formatDate, getPublishedDateTime } from 'utils/datetime';
 import { classNames } from 'utils/classnames';
-import { BodyLong, Detail } from '@navikt/ds-react';
 import { usePageContentProps } from 'store/pageContext';
 
 import styles from './ArtikkelDato.module.scss';
@@ -20,12 +21,7 @@ type Props = {
 
 const ArtikkelDato = (props: Props) => {
     const { language } = usePageContentProps();
-    const {
-        modifiedTime,
-        publishLabel,
-        modifiedLabel,
-        type = 'normal',
-    } = props;
+    const { modifiedTime, publishLabel, modifiedLabel, type = 'normal' } = props;
 
     const hasMonthName = type === 'newsPress';
     const hasYear = type === 'newsPress';

--- a/src/components/parts/_legacy/main-article/komponenter/Bilde.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/Bilde.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Picture } from 'types/content-props/main-article-props';
 import { XpImage } from 'components/_common/image/XpImage';
 
@@ -17,24 +18,14 @@ export const Bilde = (props: Props) => {
     const { size, target } = picture;
 
     const imgClass =
-        size === '40'
-            ? style.figureSmall
-            : size === '70'
-              ? style.figureMedium
-              : style.figureFull;
+        size === '40' ? style.figureSmall : size === '70' ? style.figureMedium : style.figureFull;
 
     return (
         <div className={style.figureContainer}>
             <figure className={imgClass}>
-                <XpImage
-                    imageProps={target}
-                    alt={picture.altText || ''}
-                    maxWidth={768}
-                />
+                <XpImage imageProps={target} alt={picture.altText || ''} maxWidth={768} />
                 {picture.caption && (
-                    <figcaption className="decorated">
-                        {picture.caption}
-                    </figcaption>
+                    <figcaption className="decorated">{picture.caption}</figcaption>
                 )}
             </figure>
         </div>

--- a/src/components/parts/_legacy/main-article/komponenter/Faktaboks.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/Faktaboks.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { StaticImage } from 'components/_common/image/StaticImage';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+
 import { Heading } from '@navikt/ds-react';
 
 import style from './Faktaboks.module.scss';
@@ -21,13 +23,7 @@ export const Faktaboks = ({ label, fakta, version = '1' }: Props) => {
 
     return (
         <div className={version === '1' ? style.facts_v1 : style.facts_v2}>
-            {version === '1' && (
-                <StaticImage
-                    imageData={icon}
-                    alt=""
-                    className={style.factIcon}
-                />
-            )}
+            {version === '1' && <StaticImage imageData={icon} alt="" className={style.factIcon} />}
             <Heading level="2" size="medium" className={style.decorated}>
                 {label}
             </Heading>

--- a/src/components/parts/_legacy/main-article/komponenter/Innholdsfortegnelse.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/Innholdsfortegnelse.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 
 import style from './Innholdsfortegnelse.module.scss';
@@ -18,9 +19,7 @@ export const Innholdsfortegnelse = ({ label, innholdsfortegnelse }: Props) => {
             <ol>
                 {innholdsfortegnelse.map((item, index) => (
                     <li key={index}>
-                        <LenkeBase href={`#chapter-${index + 1}`}>
-                            {item}
-                        </LenkeBase>
+                        <LenkeBase href={`#chapter-${index + 1}`}>{item}</LenkeBase>
                     </li>
                 ))}
             </ol>

--- a/src/components/parts/_legacy/main-article/komponenter/MainArticleText.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/MainArticleText.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
+
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 
 const injectTableOfContentsIds = (htmlText: string) => {
     let index = 1;
 
-    return htmlText.replace(
-        /<h3>/g,
-        () => `<h3 id="chapter-${index++}" class="chapter-header">`
-    );
+    return htmlText.replace(/<h3>/g, () => `<h3 id="chapter-${index++}" class="chapter-header">`);
 };
 
 type Props = {
@@ -17,11 +15,7 @@ type Props = {
     hasTableOfContents?: boolean;
 };
 
-export const MainArticleText = ({
-    htmlProps,
-    className,
-    hasTableOfContents,
-}: Props) => {
+export const MainArticleText = ({ htmlProps, className, hasTableOfContents }: Props) => {
     const html = hasTableOfContents
         ? injectTableOfContentsIds(htmlProps.processedHtml)
         : htmlProps.processedHtml;

--- a/src/components/parts/_legacy/main-article/komponenter/NewsPressHeader.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/NewsPressHeader.tsx
@@ -1,4 +1,5 @@
 import { Detail, Heading } from '@navikt/ds-react';
+
 import { ArticleContentType } from 'types/content-props/main-article-props';
 import { Language, translator } from 'translations';
 import { StaticImage } from 'components/_common/image/StaticImage';
@@ -14,11 +15,7 @@ type NewsPressHeaderProps = {
     type: ArticleContentType;
 };
 
-export const NewsPressHeader = ({
-    language,
-    title,
-    type,
-}: NewsPressHeaderProps) => {
+export const NewsPressHeader = ({ language, title, type }: NewsPressHeaderProps) => {
     const icon = type === 'news' ? newsPaper : pressSpeaker;
     const getLabel = translator('mainArticle', language);
 
@@ -27,14 +24,8 @@ export const NewsPressHeader = ({
     return (
         <section className={styles.newsPressHeader}>
             <div className={styles.tagWrapper}>
-                <StaticImage
-                    imageData={icon}
-                    alt={''}
-                    className={styles.tagIcon}
-                />
-                <Detail className={styles.tagLabel}>
-                    {getLabel(tagLocaleId)}
-                </Detail>
+                <StaticImage imageData={icon} alt={''} className={styles.tagIcon} />
+                <Detail className={styles.tagLabel}>{getLabel(tagLocaleId)}</Detail>
             </div>
             <Heading level={'1'} size={'xlarge'}>
                 {title}

--- a/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
+++ b/src/components/parts/_legacy/main-article/komponenter/SosialeMedier.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { getInternalAbsoluteUrl } from 'utils/urls';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
 import { SocialMedia } from 'types/content-props/main-article-props';
@@ -41,12 +42,7 @@ const SosialeMedierLink = ({ type, text, href }: LinkProps) => {
 
     return (
         <li>
-            <LenkeBase
-                href={href}
-                analyticsLabel={text}
-                className={style.ikon}
-                {...handlers}
-            >
+            <LenkeBase href={href} analyticsLabel={text} className={style.ikon} {...handlers}>
                 {hoverFocusIcon({
                     iconDefault: `${type}-filled.svg`,
                     iconActive: `${type}-inverted.svg`,

--- a/src/components/parts/_legacy/main-article/komponenter/parseInnholdsfortegnelse.ts
+++ b/src/components/parts/_legacy/main-article/komponenter/parseInnholdsfortegnelse.ts
@@ -1,7 +1,4 @@
-export const parseInnholdsfortegnelse = (
-    htmlText?: string,
-    hasTableOfContents?: boolean
-) => {
+export const parseInnholdsfortegnelse = (htmlText?: string, hasTableOfContents?: boolean) => {
     if (!hasTableOfContents || !htmlText) {
         return [];
     }

--- a/src/components/parts/_legacy/main-panels/MainPanels.tsx
+++ b/src/components/parts/_legacy/main-panels/MainPanels.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { BodyLong } from '@navikt/ds-react';
+
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import LenkepanelNavNo from 'components/_common/lenkepanel-legacy/LenkepanelNavNo';
 import { translator } from 'translations';
 import { SectionPageProps } from 'types/content-props/section-page-props';

--- a/src/components/parts/_legacy/menu-list/MenuList.tsx
+++ b/src/components/parts/_legacy/menu-list/MenuList.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
+import { Accordion } from '@navikt/ds-react';
+
 import { translator } from 'translations';
 import { LinkItem, MenuListItemKey } from 'types/menu-list-items';
 import { ContentType } from 'types/content-props/_content-common';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { Accordion } from '@navikt/ds-react';
 import { MainArticleProps } from 'types/content-props/main-article-props';
 import { MainArticleChapterProps } from 'types/content-props/main-article-chapter-props';
 import { PageListProps } from 'types/content-props/page-list-props';
 
 import style from './MenuList.module.scss';
 
-export const MenuList = (
-    props: MainArticleProps | MainArticleChapterProps | PageListProps
-) => {
+export const MenuList = (props: MainArticleProps | MainArticleChapterProps | PageListProps) => {
     const { type, language } = props;
 
-    const propsActual =
-        type === ContentType.MainArticleChapter ? props.data?.article : props;
+    const propsActual = type === ContentType.MainArticleChapter ? props.data?.article : props;
 
     if (!propsActual?.data?.menuListItems) {
         return null;
@@ -25,9 +23,7 @@ export const MenuList = (
     const getLabel = translator('relatedContent', language);
 
     const { _selected, ...menuListItems } = propsActual.data.menuListItems;
-    const validItemKeys = _selected.filter(
-        (key) => !!menuListItems[key]?.links?.length
-    );
+    const validItemKeys = _selected.filter((key) => !!menuListItems[key]?.links?.length);
 
     return (
         validItemKeys.length > 0 && (
@@ -36,18 +32,12 @@ export const MenuList = (
                     // We asserted previously that links are defined for items mapped from validItemKeys
                     const { links } = menuListItems[key] as Required<LinkItem>;
                     const isOpen =
-                        key === MenuListItemKey.Shortcuts &&
-                        type === ContentType.PageList;
+                        key === MenuListItemKey.Shortcuts && type === ContentType.PageList;
 
                     return (
                         <Accordion key={key}>
-                            <Accordion.Item
-                                defaultOpen={isOpen}
-                                className={style.panel}
-                            >
-                                <Accordion.Header>
-                                    {getLabel(key) || key}
-                                </Accordion.Header>
+                            <Accordion.Item defaultOpen={isOpen} className={style.panel}>
+                                <Accordion.Header>{getLabel(key) || key}</Accordion.Header>
                                 <Accordion.Content>
                                     <ul>
                                         {links.map((link, i) => (

--- a/src/components/parts/_legacy/office-information/OfficeInfoEmail.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInfoEmail.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { Heading, BodyShort } from '@navikt/ds-react';
+
 import { LegacyOfficeEMail } from 'types/content-props/office-information-props';
 
-const includedUnitTypes: ReadonlySet<string> = new Set([
-    'HMS',
-    'ALS',
-    'TILTAK',
-]);
+const includedUnitTypes: ReadonlySet<string> = new Set(['HMS', 'ALS', 'TILTAK']);
 
 type Props = {
     email?: LegacyOfficeEMail;

--- a/src/components/parts/_legacy/office-information/OfficeInformation.tsx
+++ b/src/components/parts/_legacy/office-information/OfficeInformation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Reception } from './reception/Reception';
-import { SpecialInformation } from './SpecialInfo';
+import { Heading, BodyLong, BodyShort } from '@navikt/ds-react';
+
 import {
     officeDetailsFormatAddress,
     officeDetailsFormatPhoneNumber,
@@ -8,10 +8,12 @@ import {
 import { OfficeInfoEmail } from 'components/parts/_legacy/office-information/OfficeInfoEmail';
 import { translator } from 'translations';
 import ArtikkelDato from 'components/parts/_legacy/main-article/komponenter/ArtikkelDato';
-import { Heading, BodyLong, BodyShort } from '@navikt/ds-react';
 import { OfficeInformationProps } from 'types/content-props/office-information-props';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
 import { forceArray } from 'utils/arrays';
+
+import { SpecialInformation } from './SpecialInfo';
+import { Reception } from './reception/Reception';
 
 import style from './OfficeInformation.module.scss';
 
@@ -35,10 +37,7 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                     publishLabel={getLabelMain('published')}
                     modifiedLabel={getLabelMain('lastChanged')}
                 />
-                <Heading
-                    level="1"
-                    size="large"
-                >{`${unit.navn} - kontorinformasjon`}</Heading>
+                <Heading level="1" size="large">{`${unit.navn} - kontorinformasjon`}</Heading>
             </header>
             {['HMS', 'ALS', 'TILTAK'].includes(unit.type) && location && (
                 <div>
@@ -54,9 +53,7 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                     <Heading level="2" size="small">
                         Telefon
                     </Heading>
-                    <BodyShort>
-                        {officeDetailsFormatPhoneNumber(contact.telefonnummer)}
-                    </BodyShort>
+                    <BodyShort>{officeDetailsFormatPhoneNumber(contact.telefonnummer)}</BodyShort>
                     {contact.telefonnummerKommentar && (
                         <BodyShort>{contact.telefonnummerKommentar}</BodyShort>
                     )}
@@ -68,9 +65,8 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                 </Heading>
                 {unit.type === 'ALS' ? (
                     <BodyLong>
-                        Du kan skrive til oss hvis du ønsker hjelp til å
-                        rekruttere, inkludere arbeidstakere og forebygge
-                        sykefravær, se{' '}
+                        Du kan skrive til oss hvis du ønsker hjelp til å rekruttere, inkludere
+                        arbeidstakere og forebygge sykefravær, se{' '}
                         <LenkeInline href="https://kontaktskjema.arbeidsgiver.nav.no/s/">
                             kontaktskjema for arbeidsgivere
                         </LenkeInline>
@@ -86,8 +82,8 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                         <LenkeInline href="https://www.nav.no/soknader/nb/person">
                             NAVs skjemaveileder.
                         </LenkeInline>{' '}
-                        Skjemaveilederen gir deg hjelp til å velge rett skjema
-                        og rett adresse det skal sendes til.
+                        Skjemaveilederen gir deg hjelp til å velge rett skjema og rett adresse det
+                        skal sendes til.
                     </BodyLong>
                 )}
             </div>
@@ -128,10 +124,7 @@ export const OfficeInformation = (props: OfficeInformationProps) => {
                 </div>
             )}
             {publikumsmottak.length > 0 && (
-                <Reception
-                    receptions={publikumsmottak}
-                    language={props.language}
-                />
+                <Reception receptions={publikumsmottak} language={props.language} />
             )}
         </article>
     );

--- a/src/components/parts/_legacy/office-information/SpecialInfo.tsx
+++ b/src/components/parts/_legacy/office-information/SpecialInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { Heading } from '@navikt/ds-react';
+
+import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 
 import style from './SpecialInfo.module.scss';
 
@@ -11,9 +12,7 @@ function specialInfoParseLink(infoContent: string) {
     };
 
     const isBalanced = (str: string) => {
-        return (
-            (str.match(/{/g) || []).length === (str.match(/}/g) || []).length
-        );
+        return (str.match(/{/g) || []).length === (str.match(/}/g) || []).length;
     };
 
     const pattern = /\{((.*?):(.*?))\}/g;
@@ -47,10 +46,7 @@ const parseSpecialInfo = (infoContent: string) => {
     // replace urls
     const urls = specialInfoParseLink(parsedString);
     urls.forEach((url) => {
-        parsedString = parsedString.replace(
-            url.match,
-            `<a href='${url.url}'>${url.text}</a>`
-        );
+        parsedString = parsedString.replace(url.match, `<a href='${url.url}'>${url.text}</a>`);
     });
 
     return parsedString;

--- a/src/components/parts/_legacy/office-information/reception/OpeningHours.tsx
+++ b/src/components/parts/_legacy/office-information/reception/OpeningHours.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LegacyOfficeOpeningHoursProps } from 'types/content-props/office-information-props';
 import { Table } from 'components/_common/table/Table';
 
@@ -10,9 +11,7 @@ export const OpeningHours = (props: {
     const { openingHours } = props;
 
     // Handle cases where one openinghour may include both day and date.
-    const buildDayInformation = (
-        opening: LegacyOfficeOpeningHoursProps
-    ): string => {
+    const buildDayInformation = (opening: LegacyOfficeOpeningHoursProps): string => {
         const { dato, dag } = opening;
         if (dato && dag) {
             return `${dag}, ${dato}`;
@@ -22,9 +21,7 @@ export const OpeningHours = (props: {
     };
 
     // Handle cases where openinghour may include different parts depending on day.
-    const buildOpeningInformation = (
-        opening: LegacyOfficeOpeningHoursProps
-    ): string => {
+    const buildOpeningInformation = (opening: LegacyOfficeOpeningHoursProps): string => {
         let tempString = '';
         if (opening.fra && opening.til) {
             tempString = `${opening.fra} - ${opening.til}`;
@@ -65,8 +62,7 @@ export const OpeningHours = (props: {
                                     ''}
                             </td>
                             <td>
-                                {openingInformation ||
-                                hasSomeOpeningInformationAndComments
+                                {openingInformation || hasSomeOpeningInformationAndComments
                                     ? opening.kommentar
                                     : ''}
                             </td>

--- a/src/components/parts/_legacy/office-information/reception/Reception.tsx
+++ b/src/components/parts/_legacy/office-information/reception/Reception.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import { Heading, BodyShort } from '@navikt/ds-react';
+
 import { formatDate } from 'utils/datetime';
 import { translator, Language } from 'translations';
 import {
     LegacyOfficeAudienceReception,
     LegacyOfficeOpeningHoursProps,
 } from 'types/content-props/office-information-props';
-import { Heading, BodyShort } from '@navikt/ds-react';
-import { OpeningHours } from './OpeningHours';
 import { forceArray } from 'utils/arrays';
 import { officeDetailsFormatAddress } from 'components/pages/office-branch-page/office-details/utils';
+
+import { OpeningHours } from './OpeningHours';
 
 import style from './Reception.module.scss';
 
@@ -21,14 +23,8 @@ type FormattedAudienceReception = {
 
 const dagArr: string[] = ['Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag'];
 
-const sortOpeningHours = (
-    a: LegacyOfficeOpeningHoursProps,
-    b: LegacyOfficeOpeningHoursProps
-) => {
-    return (
-        (a.dag ? dagArr.indexOf(a.dag) : -1) -
-        (b.dag ? dagArr.indexOf(b.dag) : -1)
-    );
+const sortOpeningHours = (a: LegacyOfficeOpeningHoursProps, b: LegacyOfficeOpeningHoursProps) => {
+    return (a.dag ? dagArr.indexOf(a.dag) : -1) - (b.dag ? dagArr.indexOf(b.dag) : -1);
 };
 
 const formatAudienceReception = (
@@ -63,22 +59,14 @@ const formatAudienceReception = (
     );
 
     return {
-        address: officeDetailsFormatAddress(
-            audienceReception.besoeksadresse,
-            true
-        ),
-        place:
-            audienceReception.stedsbeskrivelse ||
-            audienceReception.besoeksadresse.poststed,
+        address: officeDetailsFormatAddress(audienceReception.besoeksadresse, true),
+        place: audienceReception.stedsbeskrivelse || audienceReception.besoeksadresse.poststed,
         openingHoursExceptions: aapningstider.exceptions,
         openingHours: aapningstider.regular.sort(sortOpeningHours),
     };
 };
 
-type ReceptionType =
-    | LegacyOfficeAudienceReception[]
-    | LegacyOfficeAudienceReception
-    | undefined;
+type ReceptionType = LegacyOfficeAudienceReception[] | LegacyOfficeAudienceReception | undefined;
 
 type Props = {
     receptions: ReceptionType;
@@ -112,9 +100,7 @@ export const Reception = (props: Props) => {
                                     Spesielle åpningstider
                                 </Heading>
                                 <OpeningHours
-                                    openingHours={
-                                        reception.openingHoursExceptions
-                                    }
+                                    openingHours={reception.openingHoursExceptions}
                                     closedLabel={getLabel('closed')}
                                     metaKey="exception"
                                 />

--- a/src/components/parts/_legacy/page-heading/PageHeading.tsx
+++ b/src/components/parts/_legacy/page-heading/PageHeading.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Heading, Ingress } from '@navikt/ds-react';
+
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 
 import style from './PageHeading.module.scss';
 
 const PageHeading = (props: ContentProps) => {
     const displayName = props.displayName;
-    const ingress =
-        props.type !== ContentType.SectionPage && props.data?.ingress;
+    const ingress = props.type !== ContentType.SectionPage && props.data?.ingress;
 
     return (
         <section className={style.pageHeading}>

--- a/src/components/parts/_legacy/page-list/PageList.tsx
+++ b/src/components/parts/_legacy/page-list/PageList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Heading, BodyLong, Ingress } from '@navikt/ds-react';
+
 import ArtikkelDato from 'components/parts/_legacy/main-article/komponenter/ArtikkelDato';
 import { translator } from 'translations';
 import { PageListProps } from 'types/content-props/page-list-props';
@@ -21,9 +22,7 @@ export const PageList = (props: PageListProps) => {
         .filter((section) => props._id !== section._id)
         .sort(
             orderListByPublishedDate
-                ? (a, b) =>
-                      new Date(b.createdTime).getTime() -
-                      new Date(a.createdTime).getTime()
+                ? (a, b) => new Date(b.createdTime).getTime() - new Date(a.createdTime).getTime()
                 : undefined
         );
 
@@ -48,25 +47,15 @@ export const PageList = (props: PageListProps) => {
             )}
             <div className={style.list}>
                 {sectionContents.map((section) => {
-                    const {
-                        displayName,
-                        _path,
-                        publish,
-                        modifiedTime,
-                        createdTime,
-                        data,
-                    } = section;
+                    const { displayName, _path, publish, modifiedTime, createdTime, data } =
+                        section;
 
-                    const ingress = data
-                        ? data.ingress || data.description
-                        : undefined;
+                    const ingress = data ? data.ingress || data.description : undefined;
 
                     return (
                         <article key={_path} className={style.row}>
                             <BodyLong>
-                                <LenkeInline href={_path}>
-                                    {displayName}
-                                </LenkeInline>
+                                <LenkeInline href={_path}>{displayName}</LenkeInline>
                             </BodyLong>
                             {ingress && (
                                 <div className={style.ingress}>

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendar.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Heading, Ingress, Table } from '@navikt/ds-react';
+
 import { translator } from 'translations';
 import { PublishingCalendarProps } from 'types/content-props/publishing-calendar-props';
-import PublishingCalendarEntry, {
-    sortEntries,
-} from './PublishingCalendarEntry';
+
+import PublishingCalendarEntry, { sortEntries } from './PublishingCalendarEntry';
 
 // eslint-disable-next-line css-modules/no-unused-class
 import style from './PublishingCalendar.module.scss';
@@ -19,21 +19,15 @@ const PublishingCalendar = (props: PublishingCalendarProps) => {
                 {props.displayName}
             </Heading>
             {props.data.ingress && (
-                <Ingress className={style.ingress}>
-                    {props.data.ingress}
-                </Ingress>
+                <Ingress className={style.ingress}>{props.data.ingress}</Ingress>
             )}
             <Table zebraStripes>
                 <Table.Header>
                     <Table.Row>
                         <Table.HeaderCell scope="col">
-                            <span className={style.dateHeader}>
-                                {getLabel('publishdate')}
-                            </span>
+                            <span className={style.dateHeader}>{getLabel('publishdate')}</span>
                         </Table.HeaderCell>
-                        <Table.HeaderCell scope="col">
-                            {getLabel('event')}
-                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col">{getLabel('event')}</Table.HeaderCell>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntry.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Table, BodyLong } from '@navikt/ds-react';
+
 import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
 
 // eslint-disable-next-line css-modules/no-unused-class
@@ -37,9 +38,7 @@ export const sortEntries = (
     }); // Dato for publisering: stigende
 };
 
-const processEntry = (
-    item: PublishingCalendarEntryProps
-): PublishingCalendarEntryData => {
+const processEntry = (item: PublishingCalendarEntryProps): PublishingCalendarEntryData => {
     const publDate = new Date(item.data.date);
     return {
         displayName: item.displayName,

--- a/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
+++ b/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryPage.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
+import { Table } from '@navikt/ds-react';
+
 import { classNames } from 'utils/classnames';
 import { PublishingCalendarEntryProps } from 'types/content-props/publishing-calendar-props';
+
 import PublishingCalendarEntry from './PublishingCalendarEntry';
-import { Table } from '@navikt/ds-react';
 
 // eslint-disable-next-line css-modules/no-unused-class
 import style from './PublishingCalendar.module.scss';
 
 // For preview only - hacks layout from PublishingCalendar
-export const PublishingCalendarEntryPage = (
-    props: PublishingCalendarEntryProps
-) => {
+export const PublishingCalendarEntryPage = (props: PublishingCalendarEntryProps) => {
     return (
         <div className={classNames('layout', 'layout__main')}>
             <div className={classNames('region', 'region region__first')}>

--- a/src/components/parts/_text/TextComponentXp.tsx
+++ b/src/components/parts/_text/TextComponentXp.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import {
-    ComponentType,
-    TextComponentProps,
-} from 'types/component-props/_component-common';
+
+import { ComponentType, TextComponentProps } from 'types/component-props/_component-common';
 
 type Props = {
     textProps: TextComponentProps;
@@ -21,11 +19,7 @@ export const TextComponentXp = ({ textProps, editMode }: Props) => {
 
     if (!text) {
         if (editMode) {
-            return (
-                <div {...editorProps}>
-                    {'Tom tekst-komponent, klikk for å redigere'}
-                </div>
-            );
+            return <div {...editorProps}>{'Tom tekst-komponent, klikk for å redigere'}</div>;
         }
         return null;
     }

--- a/src/components/parts/alert-box/AlertBoxPart.tsx
+++ b/src/components/parts/alert-box/AlertBoxPart.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { AlertProps } from '@navikt/ds-react';
+
 import { AlertBoxPartProps } from 'types/component-props/parts/alert-box';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { AlertBox } from 'components/_common/alert-box/AlertBox';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { AlertProps } from '@navikt/ds-react';
 
 // These types were used by a previous version of the design system component
 // and are still used for the type property on the backend

--- a/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
+++ b/src/components/parts/alternative-audience/AlternativeAudiencePart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { AlternativeAudience } from 'components/_common/alternativeAudience/AlternativeAudience';
 import { AlternativeAudienceProps } from 'types/component-props/parts/alternative-audience';

--- a/src/components/parts/area-card/AreaCardPart.tsx
+++ b/src/components/parts/area-card/AreaCardPart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+
 import { AreaCardPartProps } from 'types/component-props/parts/area-card';
 import { getSelectableLinkProps } from 'utils/links-from-content';
-
 import { AreaCard } from 'components/_common/area-card/AreaCard';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 

--- a/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
+++ b/src/components/parts/areapage-situation-card/AreapageSituationCardPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { classNames } from 'utils/classnames';
 import { translator } from 'translations';
 import { AreapageSituationCardPartProps } from 'types/component-props/parts/areapage-situation-card';

--- a/src/components/parts/button/ButtonPart.tsx
+++ b/src/components/parts/button/ButtonPart.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { ButtonProps } from '@navikt/ds-react';
+
 import { ButtonPartProps } from 'types/component-props/parts/button';
 import { getSelectableLinkProps } from 'utils/links-from-content';
 import { Button } from 'components/_common/button/Button';
-import { ButtonProps } from '@navikt/ds-react';
 
 import style from './ButtonPart.module.scss';
 

--- a/src/components/parts/calculator/CalculatorPart.tsx
+++ b/src/components/parts/calculator/CalculatorPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { CalculatorProps } from 'types/component-props/parts/calculator';
 import { Calculator } from 'components/_common/calculator/Calculator';
 import { FilteredContent } from 'components/_common/filtered-content/FilteredContent';
@@ -11,10 +12,7 @@ export const CalculatorPart = ({ config }: CalculatorProps) => {
 
     return (
         <FilteredContent filters={config.filters}>
-            <Calculator
-                calculatorData={config.targetCalculator.data}
-                header={config.header}
-            />
+            <Calculator calculatorData={config.targetCalculator.data} header={config.header} />
         </FilteredContent>
     );
 };

--- a/src/components/parts/contact-option/ContactOptionPart.tsx
+++ b/src/components/parts/contact-option/ContactOptionPart.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
+
 import { DefaultOption } from 'components/_common/contact-option/DefaultOption';
 import { CallOption } from 'components/_common/contact-option/CallOption';
-import {
-    ChannelType,
-    ContactOptionProps,
-} from 'types/component-props/parts/contact-option';
+import { ChannelType, ContactOptionProps } from 'types/component-props/parts/contact-option';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { WriteOption } from 'components/_common/contact-option/WriteOption';
 import { usePageContentProps } from 'store/pageContext';
@@ -18,20 +16,12 @@ const editorHelpText: Record<ChannelWithSharedInfo, string> = {
     chat: 'Velg en "chat"-side før denne kontaktkanalen kan vises. Alternativt vises standard chat-tekstinnhold.',
 };
 
-const channelsWithSharedInfo: ReadonlySet<ChannelType> = new Set([
-    'call',
-    'write',
-    'chat',
-]);
+const channelsWithSharedInfo: ReadonlySet<ChannelType> = new Set(['call', 'write', 'chat']);
 
-const isChannelWithSharedInfo = (
-    channel: ChannelType
-): channel is ChannelWithSharedInfo => channelsWithSharedInfo.has(channel);
+const isChannelWithSharedInfo = (channel: ChannelType): channel is ChannelWithSharedInfo =>
+    channelsWithSharedInfo.has(channel);
 
-export const ContactOptionPart = ({
-    config,
-    pageProps,
-}: ContactOptionProps) => {
+export const ContactOptionPart = ({ config, pageProps }: ContactOptionProps) => {
     const { editorView } = usePageContentProps();
 
     const channel = config?.contactOptions?._selected;
@@ -62,10 +52,7 @@ export const ContactOptionPart = ({
             return (
                 <WriteOption
                     {...sharedContactInformation.data.contactType.write}
-                    ingress={
-                        ingress ||
-                        sharedContactInformation.data.contactType.write?.ingress
-                    }
+                    ingress={ingress || sharedContactInformation.data.contactType.write?.ingress}
                 />
             );
         }
@@ -73,10 +60,7 @@ export const ContactOptionPart = ({
             return (
                 <ChatOption
                     {...sharedContactInformation.data.contactType.chat}
-                    ingress={
-                        ingress ||
-                        sharedContactInformation.data.contactType.chat?.ingress
-                    }
+                    ingress={ingress || sharedContactInformation.data.contactType.chat?.ingress}
                 />
             );
         }

--- a/src/components/parts/filters-menu/FilterCheckbox.tsx
+++ b/src/components/parts/filters-menu/FilterCheckbox.tsx
@@ -1,10 +1,12 @@
 import { useId } from 'react';
+
 import { Filter } from 'types/store/filter-menu';
 import { classNames } from 'utils/classnames';
 import { StaticImage } from 'components/_common/image/StaticImage';
 
 import checkboxIcon from './checkbox.svg';
 import checkedIcon from './checked.svg';
+
 import style from './FilterCheckbox.module.scss';
 
 type FilterCheckboxProps = {
@@ -21,12 +23,7 @@ export const FilterCheckbox = ({
     const id = useId();
 
     return (
-        <div
-            className={classNames(
-                style.filterCheckbox,
-                isSelected && style.selected
-            )}
-        >
+        <div className={classNames(style.filterCheckbox, isSelected && style.selected)}>
             <input
                 type="checkbox"
                 onChange={onToggleFilterHandler}
@@ -35,19 +32,9 @@ export const FilterCheckbox = ({
                 id={id}
                 className={style.checkbox}
             />
-            <label
-                htmlFor={id}
-                className={classNames(
-                    style.label,
-                    isSelected && style.selected
-                )}
-            >
+            <label htmlFor={id} className={classNames(style.label, isSelected && style.selected)}>
                 {isSelected ? (
-                    <StaticImage
-                        imageData={checkedIcon}
-                        alt=""
-                        className={style.selected}
-                    />
+                    <StaticImage imageData={checkedIcon} alt="" className={style.selected} />
                 ) : (
                     <StaticImage imageData={checkboxIcon} alt="" />
                 )}

--- a/src/components/parts/filters-menu/FiltersMenu.tsx
+++ b/src/components/parts/filters-menu/FiltersMenu.tsx
@@ -1,19 +1,18 @@
 import React, { useEffect } from 'react';
 import { BodyLong, CheckboxGroup } from '@navikt/ds-react';
+
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { translator } from 'translations';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 import { usePageContentProps } from 'store/pageContext';
-import {
-    Category,
-    FilterMenuProps,
-} from 'types/component-props/parts/filter-menu';
+import { Category, FilterMenuProps } from 'types/component-props/parts/filter-menu';
 import { ExpandableComponentWrapper } from 'components/_common/expandable/ExpandableComponentWrapper';
 import { FilterExplanation } from 'components/_common/filter-bar/FilterExplanation';
-import { FilterCheckbox } from './FilterCheckbox';
 import { Filter } from 'types/store/filter-menu';
 import { Header } from 'components/_common/headers/Header';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+
+import { FilterCheckbox } from './FilterCheckbox';
 import { checkIfFilterFirstInPage } from './helpers';
 
 import style from './FiltersMenu.module.scss';
@@ -21,12 +20,8 @@ import style from './FiltersMenu.module.scss';
 export const FiltersMenu = ({ config, path, pageProps }: FilterMenuProps) => {
     const { categories, description, expandableTitle, title } = config;
 
-    const {
-        clearFiltersForPage,
-        selectedFilters,
-        setAvailableFilters,
-        toggleFilter,
-    } = useFilterState();
+    const { clearFiltersForPage, selectedFilters, setAvailableFilters, toggleFilter } =
+        useFilterState();
 
     const isFirstFilterInPage = checkIfFilterFirstInPage({
         path,
@@ -118,17 +113,13 @@ export const FiltersMenu = ({ config, path, pageProps }: FilterMenuProps) => {
                                         onToggleFilterHandler(filter, category);
                                     }}
                                     filter={filter}
-                                    isSelected={selectedFilters.includes(
-                                        filter.id
-                                    )}
+                                    isSelected={selectedFilters.includes(filter.id)}
                                     key={filterIndex}
                                 />
                             ))}
                             <FilterExplanation
                                 selectedFilters={selectedFilters}
-                                availableFilters={category.filters.map(
-                                    (filter) => filter.id
-                                )}
+                                availableFilters={category.filters.map((filter) => filter.id)}
                             />
                         </CheckboxGroup>
                     );

--- a/src/components/parts/filters-menu/helpers.ts
+++ b/src/components/parts/filters-menu/helpers.ts
@@ -17,17 +17,13 @@ export const checkIfFilterFirstInPage = ({ path, page }: Props) => {
         return true;
     }
 
-    const allComponents = Object.values(regions).reduce(
-        (collection, regionObject) => {
-            const { components } = regionObject;
-            return [...collection, ...components];
-        },
-        []
-    );
+    const allComponents = Object.values(regions).reduce((collection, regionObject) => {
+        const { components } = regionObject;
+        return [...collection, ...components];
+    }, []);
 
     const allFilterMenus = allComponents.filter(
-        (component: PartComponentProps) =>
-            component.descriptor === PartType.FiltersMenu
+        (component: PartComponentProps) => component.descriptor === PartType.FiltersMenu
     );
 
     if (allFilterMenus.length === 0) {

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FormDetailsProps } from 'types/component-props/parts/form-details';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { FormDetails } from 'components/_common/form-details/FormDetails';
@@ -13,8 +14,7 @@ export const FormDetailsPart = ({ config, pageProps }: FormDetailsProps) => {
     // When all product pages have been re-organized, we can remove the reference and
     // config for showTitleAsLevel4.
     const showTitleAsLevel4 =
-        pageProps.type === ContentType.ProductPage &&
-        pageProps.data?.showSubsectionNavigation;
+        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
 
     if (!targetFormDetails) {
         return <EditorHelp text={'Velg hvilken skjemadetalj som skal vises'} />;
@@ -28,10 +28,7 @@ export const FormDetailsPart = ({ config, pageProps }: FormDetailsProps) => {
 
     return (
         <FilteredContent {...config}>
-            <FormDetails
-                formDetails={formDetails}
-                displayConfig={modifiedDisplayConfig}
-            />
+            <FormDetails formDetails={formDetails} displayConfig={modifiedDisplayConfig} />
         </FilteredContent>
     );
 };

--- a/src/components/parts/frontpage-contact/FrontpageContactAlert.tsx
+++ b/src/components/parts/frontpage-contact/FrontpageContactAlert.tsx
@@ -12,10 +12,12 @@ type Props = {
 export const FrontpageContactAlert = ({ alertText, yellow = false }: Props) => {
     return (
         //Inspirert av Alert fra Designsystemet, med noen modifikasjoner på ikon og styling.
-        <div
-            className={`${style.alert} ${yellow ? style.yellow : style.white}`}
-        >
-            <ExclamationmarkTriangleIcon title="Advarsel" className={style.alertIcon} aria-hidden={true} />
+        <div className={`${style.alert} ${yellow ? style.yellow : style.white}`}>
+            <ExclamationmarkTriangleIcon
+                title="Advarsel"
+                className={style.alertIcon}
+                aria-hidden={true}
+            />
             <BodyLong as="div">{alertText}</BodyLong>
         </div>
     );

--- a/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
+++ b/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
+import { Heading } from '@navikt/ds-react';
+
 import { FrontpageContanctPartProps } from 'types/component-props/parts/frontpage-contact';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { LinkPanelNavno } from 'components/_common/linkpanel/LinkPanelNavno';
-import { Heading } from '@navikt/ds-react';
 import { ContentType } from 'types/content-props/_content-common';
 import { ChatbotLinkPanel } from 'components/_common/chatbot/ChatbotLinkPanel';
+
 import { FrontpageContactAlert } from './FrontpageContactAlert';
 
 import style from './FrontpageContactPart.module.scss';
 
-export const FrontpageContactPart = ({
-    config,
-}: FrontpageContanctPartProps) => {
+export const FrontpageContactPart = ({ config }: FrontpageContanctPartProps) => {
     if (!config) {
         return <EditorHelp text={'Komponenten er ikke konfigerert'} />;
     }
@@ -32,8 +32,7 @@ export const FrontpageContactPart = ({
             : contactUsLink._path);
 
     const getChatIngress = () => {
-        const sharedContact =
-            sharedContactInformation[0]?.data?.contactType?.chat;
+        const sharedContact = sharedContactInformation[0]?.data?.contactType?.chat;
         const specialOpeningHours = sharedContact?.specialOpeningHours;
 
         const chatTitle = config.chatTitle || sharedContact?.title || '';
@@ -43,8 +42,7 @@ export const FrontpageContactPart = ({
             sharedContact?.ingress?.processedHtml ||
             '';
 
-        const chatAlertText =
-            config.chatAlertText || sharedContact?.alertText || '';
+        const chatAlertText = config.chatAlertText || sharedContact?.alertText || '';
 
         return { chatTitle, chatIngress, chatAlertText };
     };
@@ -69,10 +67,7 @@ export const FrontpageContactPart = ({
                     linkText={contactUsTitle}
                 >
                     {contactUsAlertText && (
-                        <FrontpageContactAlert
-                            alertText={contactUsAlertText}
-                            yellow
-                        />
+                        <FrontpageContactAlert alertText={contactUsAlertText} yellow />
                     )}
                     {contactUsIngress}
                 </LinkPanelNavno>

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopics.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Header } from 'components/_common/headers/Header';
 import { FrontpageCurrentTopicsProps } from 'types/component-props/parts/frontpage-current-topics';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -10,9 +11,7 @@ import { MoreLink } from 'components/_common/moreLink/MoreLink';
 
 import style from './FrontpageCurrentTopics.module.scss';
 
-export const FrontpageCurrentTopics = ({
-    config,
-}: FrontpageCurrentTopicsProps) => {
+export const FrontpageCurrentTopics = ({ config }: FrontpageCurrentTopicsProps) => {
     const { language } = usePageContentProps();
     const { contentList, title, link } = config;
 
@@ -22,12 +21,7 @@ export const FrontpageCurrentTopics = ({
 
     return (
         <div className={style.currentTopics}>
-            <Header
-                size={'large'}
-                level={'2'}
-                justify={'left'}
-                className={style.header}
-            >
+            <Header size={'large'} level={'2'} justify={'left'} className={style.header}>
                 {title}
             </Header>
             <ul className={style.list}>

--- a/src/components/parts/frontpage-shortcuts/FrontpageShortcuts.tsx
+++ b/src/components/parts/frontpage-shortcuts/FrontpageShortcuts.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Header } from 'components/_common/headers/Header';
 import { FrontpageShortcutsProps } from 'types/component-props/parts/frontpage-shortcuts';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
@@ -9,17 +10,8 @@ import { IllustrationStatic } from 'components/_common/illustration/static/Illus
 
 import style from './FrontpageShortcuts.module.scss';
 
-export const FrontpageShortcuts = ({
-    config,
-    pageProps,
-}: FrontpageShortcutsProps) => {
-    const {
-        shortcuts,
-        title: sectionTitle,
-        bgColor,
-        itemColor,
-        hoverColor,
-    } = config;
+export const FrontpageShortcuts = ({ config, pageProps }: FrontpageShortcutsProps) => {
+    const { shortcuts, title: sectionTitle, bgColor, itemColor, hoverColor } = config;
 
     if (!shortcuts || shortcuts.length === 0) {
         return <EditorHelp text={'Velg minst en snarvei'} />;
@@ -41,18 +33,11 @@ export const FrontpageShortcuts = ({
             }
         >
             {sectionTitle && (
-                <Header
-                    size="large"
-                    level="2"
-                    justify="left"
-                    className={style.header}
-                >
+                <Header size="large" level="2" justify="left" className={style.header}>
                     {sectionTitle}
                 </Header>
             )}
-            <ul
-                className={classNames(style.list, threeCols && style.threeCols)}
-            >
+            <ul className={classNames(style.list, threeCols && style.threeCols)}>
                 {shortcuts.map((item) => {
                     const { target, customIllustration, customTitle } = item;
                     if (!target?.data) {
@@ -60,10 +45,8 @@ export const FrontpageShortcuts = ({
                     }
 
                     const href = target.data.url || target._path;
-                    const title =
-                        customTitle || target.data.title || target.displayName;
-                    const illustration =
-                        customIllustration || target.data.illustration;
+                    const title = customTitle || target.data.title || target.displayName;
+                    const illustration = customIllustration || target.data.illustration;
 
                     return (
                         <li key={title}>
@@ -71,11 +54,7 @@ export const FrontpageShortcuts = ({
                                 href={href}
                                 linkUnderline={'none'}
                                 analyticsLinkGroup={title}
-                                icon={
-                                    <IllustrationStatic
-                                        illustration={illustration}
-                                    />
-                                }
+                                icon={<IllustrationStatic illustration={illustration} />}
                                 className={classNames(
                                     style.item,
                                     audience && style[`item_${audience}`]

--- a/src/components/parts/header/HeaderPart.tsx
+++ b/src/components/parts/header/HeaderPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { HeaderProps } from 'types/component-props/parts/header';
 import { Header } from 'components/_common/headers/Header';
 import { headingToLevel, headingToSize } from 'types/typo-style';

--- a/src/components/parts/html-area/HtmlArea.tsx
+++ b/src/components/parts/html-area/HtmlArea.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { HtmlAreaProps } from 'types/component-props/parts/html-area';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { ExpandableComponentWrapper } from 'components/_common/expandable/ExpandableComponentWrapper';
@@ -9,9 +10,7 @@ import style from './HtmlArea.module.scss';
 
 export const HtmlArea = ({ config }: HtmlAreaProps) => {
     if (!config?.html) {
-        return (
-            <EditorHelp text={'Tom innholdskomponent. Klikk for å redigere.'} />
-        );
+        return <EditorHelp text={'Tom innholdskomponent. Klikk for å redigere.'} />;
     }
     return (
         <FilteredContent {...config}>

--- a/src/components/parts/link-list/LinkListPart.tsx
+++ b/src/components/parts/link-list/LinkListPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { DynamicLinkListProps } from 'types/component-props/parts/link-list';
 import { Lenkeliste } from 'components/_common/lenkeliste/Lenkeliste';
 import { ContentList } from 'components/_common/content-list/ContentList';
@@ -48,9 +49,7 @@ export const LinkListPart = ({ config }: DynamicLinkListProps) => {
 
     return ListComponent ? (
         <div className={style.linkList}>
-            <ExpandableComponentWrapper {...config}>
-                {ListComponent}
-            </ExpandableComponentWrapper>
+            <ExpandableComponentWrapper {...config}>{ListComponent}</ExpandableComponentWrapper>
         </div>
     ) : null;
 };

--- a/src/components/parts/link-panel/LinkPanelPart.tsx
+++ b/src/components/parts/link-panel/LinkPanelPart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { LinkPanelPartProps } from 'types/component-props/parts/link-panel';
 import { Heading, LinkPanel } from '@navikt/ds-react';
+
+import { LinkPanelPartProps } from 'types/component-props/parts/link-panel';
 import { classNames } from 'utils/classnames';
 import { getSelectableLinkProps } from 'utils/links-from-content';
 import { LenkeBase } from 'components/_common/lenke/LenkeBase';
@@ -25,26 +26,19 @@ export const LinkPanelPart = ({ config }: LinkPanelPartProps) => {
 
     const linkProps = getSelectableLinkProps(link);
 
-    const bgUrl =
-        background?.mediaUrl && getMediaUrl(background.mediaUrl, isEditorView);
+    const bgUrl = background?.mediaUrl && getMediaUrl(background.mediaUrl, isEditorView);
 
     const selectedVariant = variant?._selected;
     const variantConfig = selectedVariant && variant[selectedVariant];
 
     const isVerticalLayout =
-        selectedVariant === 'vertical' ||
-        selectedVariant === 'verticalWithBgColor';
-    const legacyAnalyticsComponentLabel = isVerticalLayout
-        ? 'main-panels'
-        : 'link-panel';
+        selectedVariant === 'vertical' || selectedVariant === 'verticalWithBgColor';
+    const legacyAnalyticsComponentLabel = isVerticalLayout ? 'main-panels' : 'link-panel';
 
     return (
         <LinkPanel
             href={linkProps.url}
-            className={classNames(
-                style.linkPanel,
-                isVerticalLayout ? `vertical` : 'horizontal'
-            )}
+            className={classNames(style.linkPanel, isVerticalLayout ? `vertical` : 'horizontal')}
             border={true}
             style={
                 bgUrl
@@ -69,14 +63,11 @@ export const LinkPanelPart = ({ config }: LinkPanelPartProps) => {
                             aria-hidden={'true'}
                             className={classNames(
                                 style.icon,
-                                selectedVariant === 'verticalWithBgColor' &&
-                                    style.bg
+                                selectedVariant === 'verticalWithBgColor' && style.bg
                             )}
                             style={{
-                                ...(selectedVariant ===
-                                    'verticalWithBgColor' && {
-                                    backgroundColor:
-                                        variantConfig?.iconBg?.color,
+                                ...(selectedVariant === 'verticalWithBgColor' && {
+                                    backgroundColor: variantConfig?.iconBg?.color,
                                     alignItems: variantConfig?.iconJustify,
                                 }),
                             }}

--- a/src/components/parts/loggedin-card/LoggedinCardPart.tsx
+++ b/src/components/parts/loggedin-card/LoggedinCardPart.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
+
 import {
     LoggedinCardProps,
     LoggedInCardTypeProps,
     LoggedInCardTypes,
 } from 'types/component-props/parts/loggedin-card';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+
 import { LoggedinCardMeldekort } from './cards/LoggedinCardMeldekort';
 
 const CardComponents: {
-    [cardType in LoggedInCardTypes]: React.FunctionComponent<
-        LoggedInCardTypeProps[cardType]
-    >;
+    [cardType in LoggedInCardTypes]: React.FunctionComponent<LoggedInCardTypeProps[cardType]>;
 } = {
     meldekort: LoggedinCardMeldekort,
 };

--- a/src/components/parts/loggedin-card/cards/LoggedinCardMeldekort.tsx
+++ b/src/components/parts/loggedin-card/cards/LoggedinCardMeldekort.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LoggedInCardTypeProps } from 'types/component-props/parts/loggedin-card';
 import { useAuthState } from 'store/hooks/useAuthState';
 import { getSelectableLinkProps } from 'utils/links-from-content';

--- a/src/components/parts/news-list/NewsListPart.tsx
+++ b/src/components/parts/news-list/NewsListPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { DynamicNewsListProps } from 'types/component-props/parts/news-list';
 import { ContentList } from 'components/_common/content-list/ContentList';
 import { LenkeStandalone } from 'components/_common/lenke/LenkeStandalone';
@@ -25,10 +26,7 @@ export const NewsListPart = ({ config }: DynamicNewsListProps) => {
                     listType={'chevron'}
                 />
                 {moreNews && (
-                    <LenkeStandalone
-                        href={moreNews.url}
-                        className={style.moreNews}
-                    >
+                    <LenkeStandalone href={moreNews.url} className={style.moreNews}>
                         {moreNews.text}
                     </LenkeStandalone>
                 )}

--- a/src/components/parts/office-editorial-detail/OfficeEditorialDetail.tsx
+++ b/src/components/parts/office-editorial-detail/OfficeEditorialDetail.tsx
@@ -1,27 +1,25 @@
-import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import React from 'react';
+
+import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import {
     DetailType,
     OfficeEditorialDetailProps,
 } from 'types/component-props/parts/office-editorial-detail';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { ContentType } from 'types/content-props/_content-common';
+
 import { ServiceInformation } from './details/ServiceInformation';
 import { SocialHelpLinks } from './details/SocialHelpLinks';
 import { SocialHelpPayoutInformation } from './details/SocialHelpPayoutInformation';
 import { SocialHelpPostalInformation } from './details/SocialHelpPostalInformation';
 import { PlaceholderIndicator } from './PlaceholderIndicator';
 
-const getDetailComponent = (
-    type: DetailType
-): React.FunctionComponent<DetailProps> => {
+const getDetailComponent = (type: DetailType): React.FunctionComponent<DetailProps> => {
     const detailComponents = {
         [DetailType.SERVICE_INFORMATION]: ServiceInformation,
         [DetailType.SOCIAL_HELP_LINKS]: SocialHelpLinks,
-        [DetailType.SOCIAL_HELP_PAYOUT_INFORMATION]:
-            SocialHelpPayoutInformation,
-        [DetailType.SOCIAL_HELP_POSTAL_INFORMATION]:
-            SocialHelpPostalInformation,
+        [DetailType.SOCIAL_HELP_PAYOUT_INFORMATION]: SocialHelpPayoutInformation,
+        [DetailType.SOCIAL_HELP_POSTAL_INFORMATION]: SocialHelpPostalInformation,
     };
 
     return detailComponents[type];
@@ -31,10 +29,7 @@ export type DetailProps = {
     officeData: OfficeDetailsData;
 };
 
-export const OfficeEditorialDetail = ({
-    config,
-    pageProps,
-}: OfficeEditorialDetailProps) => {
+export const OfficeEditorialDetail = ({ config, pageProps }: OfficeEditorialDetailProps) => {
     const { detailType } = config;
 
     if (!detailType) {
@@ -46,11 +41,9 @@ export const OfficeEditorialDetail = ({
     // Note these texts are presented to editors only to give an idea
     // of what information the placeholder represent.
     const editorTranslation: { [key in DetailType]: string } = {
-        [DetailType.SERVICE_INFORMATION]:
-            'informasjon om tjenestene til kontoret.',
+        [DetailType.SERVICE_INFORMATION]: 'informasjon om tjenestene til kontoret.',
         [DetailType.SOCIAL_HELP_LINKS]: 'lenke til søknad om sosialhjelp.',
-        [DetailType.SOCIAL_HELP_PAYOUT_INFORMATION]:
-            'informasjon om utbetaling av sosialhjelp',
+        [DetailType.SOCIAL_HELP_PAYOUT_INFORMATION]: 'informasjon om utbetaling av sosialhjelp',
         [DetailType.SOCIAL_HELP_POSTAL_INFORMATION]:
             'informasjon om postkasse/henting av søknad for sosialhjelp.',
     };

--- a/src/components/parts/office-editorial-detail/PlaceholderIndicator.tsx
+++ b/src/components/parts/office-editorial-detail/PlaceholderIndicator.tsx
@@ -4,8 +4,6 @@ type PlaceholderIndicatorProps = {
     children: React.ReactNode;
 };
 
-export const PlaceholderIndicator = ({
-    children,
-}: PlaceholderIndicatorProps) => {
+export const PlaceholderIndicator = ({ children }: PlaceholderIndicatorProps) => {
     return <div className={styles.placeholderIndicator}>{children}</div>;
 };

--- a/src/components/parts/office-editorial-detail/details/ServiceInformation.tsx
+++ b/src/components/parts/office-editorial-detail/details/ServiceInformation.tsx
@@ -32,11 +32,7 @@ export const ServiceInformation = ({ officeData }: DetailProps) => {
                         </li>
                     );
                 }
-                return (
-                    <li key={service.type}>
-                        {getServiceTranslation(service.type)}
-                    </li>
-                );
+                return <li key={service.type}>{getServiceTranslation(service.type)}</li>;
             })}
         </ul>
     );

--- a/src/components/parts/office-editorial-detail/details/SocialHelpLinks.tsx
+++ b/src/components/parts/office-editorial-detail/details/SocialHelpLinks.tsx
@@ -5,9 +5,7 @@ import { DetailProps } from 'components/parts/office-editorial-detail/OfficeEdit
 import styles from './SocialHelpLinks.module.scss';
 
 export const SocialHelpLinks = ({ officeData }: DetailProps) => {
-    const socialHelpLinks = forceArray(
-        officeData.brukerkontakt?.sosialhjelp?.digitaleSoeknader
-    );
+    const socialHelpLinks = forceArray(officeData.brukerkontakt?.sosialhjelp?.digitaleSoeknader);
 
     if (!socialHelpLinks || socialHelpLinks.length === 0) {
         return null;
@@ -16,11 +14,7 @@ export const SocialHelpLinks = ({ officeData }: DetailProps) => {
     return (
         <div>
             {socialHelpLinks.map((link) => (
-                <LenkeBase
-                    key={link.lenke}
-                    href={link.lenke}
-                    className={styles.singleLink}
-                >
+                <LenkeBase key={link.lenke} href={link.lenke} className={styles.singleLink}>
                     {link.lenketekst}
                 </LenkeBase>
             ))}

--- a/src/components/parts/office-editorial-detail/details/SocialHelpPayoutInformation.tsx
+++ b/src/components/parts/office-editorial-detail/details/SocialHelpPayoutInformation.tsx
@@ -1,4 +1,5 @@
 import { Alert } from '@navikt/ds-react';
+
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { DetailProps } from 'components/parts/office-editorial-detail/OfficeEditorialDetail';
 
@@ -8,14 +9,7 @@ export const SocialHelpPayoutInformation = ({ officeData }: DetailProps) => {
     if (!payoutInformation) {
         return null;
     }
-    const payoutInformatioWithBreaks = payoutInformation.replaceAll(
-        '\n',
-        '<br/>'
-    );
+    const payoutInformatioWithBreaks = payoutInformation.replaceAll('\n', '<br/>');
 
-    return (
-        <Alert variant="info">
-            {<ParsedHtml htmlProps={payoutInformatioWithBreaks} />}
-        </Alert>
-    );
+    return <Alert variant="info">{<ParsedHtml htmlProps={payoutInformatioWithBreaks} />}</Alert>;
 };

--- a/src/components/parts/office-editorial-detail/details/SocialHelpPostalInformation.tsx
+++ b/src/components/parts/office-editorial-detail/details/SocialHelpPostalInformation.tsx
@@ -1,10 +1,10 @@
 import { Alert } from '@navikt/ds-react';
+
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { DetailProps } from 'components/parts/office-editorial-detail/OfficeEditorialDetail';
 
 export const SocialHelpPostalInformation = ({ officeData }: DetailProps) => {
-    const postalInfo =
-        officeData.brukerkontakt?.sosialhjelp?.papirsoeknadInformasjon;
+    const postalInfo = officeData.brukerkontakt?.sosialhjelp?.papirsoeknadInformasjon;
 
     if (!postalInfo) {
         return null;

--- a/src/components/parts/page-header/PageHeaderPart.tsx
+++ b/src/components/parts/page-header/PageHeaderPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PageHeaderProps } from 'types/component-props/parts/page-header';
 import { PageHeader } from 'components/_common/headers/page-header/PageHeader';
 import { classNames } from 'utils/classnames';
@@ -13,19 +14,11 @@ export const PageHeaderPart = (props: PageHeaderProps) => {
     const audience = data?.audience;
 
     const isProviderSubPage =
-        type === ContentType.FrontPageNested &&
-        getAudience(audience) === Audience.PROVIDER;
+        type === ContentType.FrontPageNested && getAudience(audience) === Audience.PROVIDER;
 
     return (
-        <div
-            className={classNames(
-                style.wrapper,
-                isProviderSubPage && style.providerSubPage
-            )}
-        >
-            <PageHeader className={classNames(style.pageHeader)}>
-                {config.title}
-            </PageHeader>
+        <div className={classNames(style.wrapper, isProviderSubPage && style.providerSubPage)}>
+            <PageHeader className={classNames(style.pageHeader)}>{config.title}</PageHeader>
         </div>
     );
 };

--- a/src/components/parts/page-navigation-menu/PageNavigationMenuPart.tsx
+++ b/src/components/parts/page-navigation-menu/PageNavigationMenuPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PageNavigationMenuProps } from 'types/component-props/parts/page-navigation-menu';
 import { PageNavigationMenu } from 'components/_common/page-navigation-menu/PageNavigationMenu';
 

--- a/src/components/parts/payout-dates/PayoutDatesPart.tsx
+++ b/src/components/parts/payout-dates/PayoutDatesPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { PayoutDatesPartProps } from 'types/component-props/parts/payout-dates';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PayoutDates } from 'components/_common/payout-dates/PayoutDates';
@@ -9,9 +10,7 @@ export const PayoutDatesPart = ({ config }: PayoutDatesPartProps) => {
         return (
             <EditorHelp
                 type={'help'}
-                text={
-                    'Klikk her og velg et sett med utbetalingsdatoer i panelet til høyre'
-                }
+                text={'Klikk her og velg et sett med utbetalingsdatoer i panelet til høyre'}
             />
         );
     }

--- a/src/components/parts/product-card-micro/ProductCardMicro.tsx
+++ b/src/components/parts/product-card-micro/ProductCardMicro.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
+
 import { MicroCards } from 'components/_common/card/MicroCard';
-import {
-    ProductCardMicroProps,
-    TargetPage,
-} from 'types/component-props/parts/product-card';
+import { ProductCardMicroProps, TargetPage } from 'types/component-props/parts/product-card';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 
 export const ProductCardMicroPart = ({ config }: ProductCardMicroProps) => {
     if (!config?.card_list || config.card_list.length === 0) {
-        return (
-            <EditorHelp
-                text={'Velg minst én lenke for å aktivere mikrokortene'}
-            />
-        );
+        return <EditorHelp text={'Velg minst én lenke for å aktivere mikrokortene'} />;
     }
 
     const { card_list, header } = config;

--- a/src/components/parts/product-card/ProductCard.tsx
+++ b/src/components/parts/product-card/ProductCard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
+
 import { usePageContentProps } from 'store/pageContext';
 import { PartType } from 'types/component-props/parts';
-import {
-    ProductCardMiniProps,
-    ProductCardProps,
-} from 'types/component-props/parts/product-card';
+import { ProductCardMiniProps, ProductCardProps } from 'types/component-props/parts/product-card';
 import { getCardProps } from 'components/_common/card/card-utils';
 import { MiniCard } from 'components/_common/card/MiniCard';
 import { LargeCard } from 'components/_common/card/LargeCard';
@@ -18,11 +16,7 @@ export const ProductCardPart = ({
 
     if (!config?.targetPage) {
         return (
-            <EditorHelp
-                text={
-                    'Velg en produktside eller livssituasjon for å aktivere kortet'
-                }
-            />
+            <EditorHelp text={'Velg en produktside eller livssituasjon for å aktivere kortet'} />
         );
     }
 

--- a/src/components/parts/product-details/ProductDetailsPart.tsx
+++ b/src/components/parts/product-details/ProductDetailsPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ProductDetailsProps } from 'types/component-props/parts/product-details';
 import { ComponentMapper } from 'components/ComponentMapper';
 import { ExpandableComponentWrapper } from 'components/_common/expandable/ExpandableComponentWrapper';
@@ -8,16 +9,9 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { translator } from 'translations';
 import { PageContextProvider } from 'store/pageContext';
 
-export const ProductDetailsPart = ({
-    config,
-    pageProps,
-}: ProductDetailsProps) => {
+export const ProductDetailsPart = ({ config, pageProps }: ProductDetailsProps) => {
     if (!config?.detailType) {
-        return (
-            <EditorHelp
-                text={'Velg hvilken produktdetalj-type som skal vises'}
-            />
-        );
+        return <EditorHelp text={'Velg hvilken produktdetalj-type som skal vises'} />;
     }
 
     const detailTypeStrings = translator('productDetailTypes', 'no');
@@ -34,9 +28,7 @@ export const ProductDetailsPart = ({
                     config.detailType === ProductDetailType.PROCESSING_TIMES &&
                     processingTimeHelptext
                 }`}
-                globalWarningText={
-                    'Komponent for produktdetaljer mangler innhold'
-                }
+                globalWarningText={'Komponent for produktdetaljer mangler innhold'}
                 type={'error'}
             />
         );

--- a/src/components/parts/provider-card/ProviderCardPart.tsx
+++ b/src/components/parts/provider-card/ProviderCardPart.tsx
@@ -1,5 +1,6 @@
-import { LargeCard } from 'components/_common/card/LargeCard';
 import React from 'react';
+
+import { LargeCard } from 'components/_common/card/LargeCard';
 import { CardType } from 'types/card';
 import { TilbyderkortPartProps } from 'types/component-props/parts/tilbyderkort';
 import { getSelectableLinkProps } from 'utils/links-from-content';

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
+import { ReadMore } from '@navikt/ds-react';
+
 import { ReadMorePartProps } from 'types/component-props/parts/read-more';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { ReadMore } from '@navikt/ds-react';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { useShortcuts, Shortcuts } from 'utils/useShortcuts';
@@ -16,23 +17,15 @@ export const ReadMorePart = ({ config }: ReadMorePartProps) => {
     });
 
     if (!config?.html || !config?.title) {
-        return (
-            <EditorHelp
-                text={'Legg inn tittel og beskrivelse for "les mer".'}
-                type={'error'}
-            />
-        );
+        return <EditorHelp text={'Legg inn tittel og beskrivelse for "les mer".'} type={'error'} />;
     }
 
     const openChangeHandler = (isOpen: boolean, _title: string) => {
         setIsOpen(isOpen);
-        logAmplitudeEvent(
-            isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND,
-            {
-                tittel: _title,
-                opprinnelse: 'lesmer',
-            }
-        );
+        logAmplitudeEvent(isOpen ? AnalyticsEvents.ACC_COLLAPSE : AnalyticsEvents.ACC_EXPAND, {
+            tittel: _title,
+            opprinnelse: 'lesmer',
+        });
     };
 
     const { title, html } = config;

--- a/src/components/parts/related-situations/RelatedSituationsPart.tsx
+++ b/src/components/parts/related-situations/RelatedSituationsPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { RelatedSituations } from 'components/_common/relatedSituations/RelatedSituations';
 import { RelatedSituationsProps } from 'types/component-props/parts/related-situations';

--- a/src/components/parts/user-tests/UserTestsPart.tsx
+++ b/src/components/parts/user-tests/UserTestsPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { UserTestsPartProps } from 'types/component-props/parts/user-tests';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { UserTests } from 'components/_common/user-tests/UserTests';
@@ -8,10 +9,5 @@ export const UserTestsPart = ({ config }: UserTestsPartProps) => {
         return <EditorHelp text={'Velg en test-gruppering'} type={'error'} />;
     }
 
-    return (
-        <UserTests
-            tests={config.tests}
-            selectedTestIds={config.selectedTestIds}
-        />
-    );
+    return <UserTests tests={config.tests} selectedTestIds={config.selectedTestIds} />;
 };

--- a/src/components/parts/uxsignals-widget/UxSignalsWidgetPart.tsx
+++ b/src/components/parts/uxsignals-widget/UxSignalsWidgetPart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { UxSignalsWidgetPartProps } from 'types/component-props/parts/uxsignals-widget';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { UxSignalsWidget } from 'components/_common/uxsignals-widget/UxSignalsWidget';
@@ -6,10 +7,7 @@ import { UxSignalsWidget } from 'components/_common/uxsignals-widget/UxSignalsWi
 export const UxSignalsWidgetPart = ({ config }: UxSignalsWidgetPartProps) => {
     if (!config?.embedCode) {
         return (
-            <EditorHelp
-                text={'Tom UXSignals komponent, sett inn en embed-kode'}
-                type={'error'}
-            />
+            <EditorHelp text={'Tom UXSignals komponent, sett inn en embed-kode'} type={'error'} />
         );
     }
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
+import { useRouter } from 'next/compat/router';
+
 import { make404Props } from 'utils/make-error-props';
 import { PageBase } from 'components/PageBase';
-import { useRouter } from 'next/compat/router';
 import { logger } from 'srcCommon/logger';
 
 const loopDetectionParam = 'error';

--- a/src/pages/[...pathRouter].tsx
+++ b/src/pages/[...pathRouter].tsx
@@ -1,4 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
+
 import { PageBase } from 'components/PageBase';
 import Config from 'config';
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';
@@ -57,12 +58,8 @@ const getStaticPathsRegular: GetStaticPaths = async () => {
     };
 };
 
-export const getStaticProps = isFailover
-    ? getStaticPropsFailover
-    : getStaticPropsRegular;
+export const getStaticProps = isFailover ? getStaticPropsFailover : getStaticPropsRegular;
 
-export const getStaticPaths = isFailover
-    ? getStaticPathsFailover
-    : getStaticPathsRegular;
+export const getStaticPaths = isFailover ? getStaticPathsFailover : getStaticPathsRegular;
 
 export default PageBase;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
-import type { AppProps } from 'next/app';
 import { initializeFaro } from '@grafana/faro-web-sdk';
 import { Provider } from 'react-redux';
+
+import type { AppProps } from 'next/app';
 import { store } from 'store/store';
 import { PageProps } from 'components/PageBase';
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import Document, {
-    DocumentContext,
-    Head,
-    Html,
-    Main,
-    NextScript,
-} from 'next/document';
-import { Language } from 'translations';
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 import { DocumentInitialProps } from 'next/dist/pages/_document';
+import { DecoratorComponents } from '@navikt/nav-dekoratoren-moduler/ssr';
+
+import { Language } from 'translations';
 import { DocumentParameter } from 'components/_common/metatags/DocumentParameterMetatags';
 import { getDecoratorComponents } from 'utils/decorator/decorator-utils-serverside';
-import { DecoratorComponents } from '@navikt/nav-dekoratoren-moduler/ssr';
 
 type DocumentProps = {
     language: Language;
@@ -21,12 +16,8 @@ type DocumentProps = {
 // The 'head'-field of the document initialProps contains data from <head> (meta-tags etc)
 // We use this to pass certain data from our page content via meta tags from the
 // DocumentParameterMetatags component
-const getDocumentParameter = (
-    initialProps: DocumentInitialProps,
-    name: DocumentParameter
-) => {
-    return initialProps.head?.find((element) => element?.props?.name === name)
-        ?.props?.content;
+const getDocumentParameter = (initialProps: DocumentInitialProps, name: DocumentParameter) => {
+    return initialProps.head?.find((element) => element?.props?.name === name)?.props?.content;
 };
 
 class MyDocument extends Document<DocumentProps> {
@@ -38,10 +29,7 @@ class MyDocument extends Document<DocumentProps> {
             DocumentParameter.DecoratorParams
         );
 
-        const language = getDocumentParameter(
-            initialProps,
-            DocumentParameter.HtmlLang
-        );
+        const language = getDocumentParameter(initialProps, DocumentParameter.HtmlLang);
 
         const decoratorDisabled = getDocumentParameter(
             initialProps,
@@ -49,10 +37,7 @@ class MyDocument extends Document<DocumentProps> {
         );
 
         const isLegacyContentType =
-            getDocumentParameter(
-                initialProps,
-                DocumentParameter.LegacyContentType
-            ) === 'true';
+            getDocumentParameter(initialProps, DocumentParameter.LegacyContentType) === 'true';
 
         const Decorator =
             !decoratorDisabled &&
@@ -74,11 +59,7 @@ class MyDocument extends Document<DocumentProps> {
         return (
             <Html lang={language || 'no'}>
                 <Head>{Decorator && <Decorator.Styles />}</Head>
-                <body
-                    className={
-                        isLegacyContentType ? 'legacyContentType' : undefined
-                    }
-                >
+                <body className={isLegacyContentType ? 'legacyContentType' : undefined}>
                     {Decorator && <Decorator.Header />}
                     <Main />
                     {Decorator && <Decorator.Footer />}

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { v4 as uuid } from 'uuid';
+import { NextApiResponse, NextPageContext } from 'next';
+
 import { makeErrorProps } from 'utils/make-error-props';
 import { PageBase } from 'components/PageBase';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
-import { v4 as uuid } from 'uuid';
 import { logPageLoadError } from 'utils/errors';
 import { fetchWithTimeout } from 'srcCommon/fetch-utils';
-import { NextApiResponse, NextPageContext } from 'next';
 import { logger } from 'srcCommon/logger';
 
 const isFailoverInstance = process.env.IS_FAILOVER_INSTANCE === 'true';
@@ -27,8 +28,7 @@ const getClientsideProps = (path?: string) => {
     }
 
     try {
-        const contentProps = JSON.parse(nextData)?.props
-            ?.pageProps as ContentProps;
+        const contentProps = JSON.parse(nextData)?.props?.pageProps as ContentProps;
         if (contentProps.type !== ContentType.Error) {
             logger.error(
                 `Unexpected __NEXT_DATA__ contentProps on ${path} - ${contentProps._id} ${contentProps.type}`

--- a/src/pages/api/component-preview.tsx
+++ b/src/pages/api/component-preview.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import { Provider } from 'react-redux';
+import { NextApiRequest, NextApiResponse } from 'next';
+
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { ComponentMapper } from 'components/ComponentMapper';
-import { Provider } from 'react-redux';
 import { mockStore } from 'store/store';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { PageContextProvider } from 'store/pageContext';
 import { apiErrorHandler } from 'utils/api-error-handler';
-import { NextApiRequest, NextApiResponse } from 'next';
 
 const postHandler = async (req: NextApiRequest, res: NextApiResponse) =>
     apiErrorHandler(req, res, async () => {
@@ -45,10 +46,7 @@ const postHandler = async (req: NextApiRequest, res: NextApiResponse) =>
         const html = ReactDOMServer.renderToStaticMarkup(
             <PageContextProvider content={contentProps}>
                 <Provider store={mockStore}>
-                    <ComponentMapper
-                        componentProps={props}
-                        pageProps={contentProps}
-                    />
+                    <ComponentMapper componentProps={props} pageProps={contentProps} />
                 </Provider>
             </PageContextProvider>
         );

--- a/src/pages/api/internal/isReady.ts
+++ b/src/pages/api/internal/isReady.ts
@@ -1,9 +1,7 @@
-import { fetchAndSetCacheKey } from 'utils/fetch/fetch-cache-key';
-import {
-    clearImageManifest,
-    processImageManifest,
-} from 'utils/fetch/fetch-images';
 import { NextApiHandler } from 'next';
+
+import { fetchAndSetCacheKey } from 'utils/fetch/fetch-cache-key';
+import { clearImageManifest, processImageManifest } from 'utils/fetch/fetch-images';
 
 let ready = false;
 let waiting = false;

--- a/src/pages/api/jsonCache.ts
+++ b/src/pages/api/jsonCache.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { LRUCache } from 'lru-cache';
+
 import { fetchJson } from 'srcCommon/fetch-utils';
 import { logger } from 'srcCommon/logger';
 
@@ -11,9 +12,7 @@ const cache = new LRUCache({
 
 const validUrlPattern = new RegExp(/^\/_\/attachment\/inline\/.+\.json$/i);
 
-const validateUrl = (
-    fileUrl: NextApiRequest['query'][string]
-): fileUrl is string =>
+const validateUrl = (fileUrl: NextApiRequest['query'][string]): fileUrl is string =>
     typeof fileUrl === 'string' && validUrlPattern.test(fileUrl);
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -32,20 +31,18 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         return res.status(200).send(cachedItem);
     }
 
-    const fetchedItem = await fetchJson<string>(`${xpOrigin}${url}`).then(
-        (response) => {
-            if (!response) {
-                return null;
-            }
-
-            // XP does not decode JSON file content
-            try {
-                return JSON.parse(response);
-            } catch (e) {
-                return response;
-            }
+    const fetchedItem = await fetchJson<string>(`${xpOrigin}${url}`).then((response) => {
+        if (!response) {
+            return null;
         }
-    );
+
+        // XP does not decode JSON file content
+        try {
+            return JSON.parse(response);
+        } catch (e) {
+            return response;
+        }
+    });
 
     if (!fetchedItem) {
         logger.info(`JSON file not found: ${url}`);

--- a/src/pages/api/rss.ts
+++ b/src/pages/api/rss.ts
@@ -1,7 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { fetchJson } from 'srcCommon/fetch-utils';
 import Cache from 'node-cache';
 import RSS from 'rss';
+
+import { fetchJson } from 'srcCommon/fetch-utils';
 import { apiErrorHandler } from 'utils/api-error-handler';
 import { logger } from 'srcCommon/logger';
 
@@ -34,11 +35,7 @@ const saveToCache = (xml: string): void => {
 };
 
 const fetchRSSFeedAndUpdateCache = async (url: string) => {
-    const jsonFeed = await fetchJson<FeedItem[]>(
-        url,
-        millisecondsToFetchTimeout,
-        fetchOptions
-    );
+    const jsonFeed = await fetchJson<FeedItem[]>(url, millisecondsToFetchTimeout, fetchOptions);
     if (!jsonFeed) {
         logger.error('Error while fetching RSS data');
         return null;
@@ -83,9 +80,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) =>
         const rssFeed = await getRSSFeedFromCache();
 
         if (!rssFeed) {
-            return res
-                .status(503)
-                .send('Server error: RSS-feed is currently unavailable');
+            return res.status(503).send('Server error: RSS-feed is currently unavailable');
         }
 
         res.setHeader('Content-Type', 'application/xml');

--- a/src/pages/api/sitemap.ts
+++ b/src/pages/api/sitemap.ts
@@ -1,6 +1,7 @@
+import Cache from 'node-cache';
+
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { fetchJson } from 'srcCommon/fetch-utils';
-import Cache from 'node-cache';
 import { apiErrorHandler } from 'utils/api-error-handler';
 import { logger } from 'srcCommon/logger';
 
@@ -113,9 +114,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) =>
         res.setHeader('X-Robots-Tag', 'noindex');
 
         if (!sitemapContent) {
-            return res
-                .status(503)
-                .send('Server error: sitemap is currently unavailable');
+            return res.status(503).send('Server error: sitemap is currently unavailable');
         }
 
         res.setHeader('Content-Type', 'application/xml');

--- a/src/pages/archive/[[...archiveRouter]].tsx
+++ b/src/pages/archive/[[...archiveRouter]].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+
 import { PageBase } from 'components/PageBase';
 import { getFirstElementIfArray } from 'utils/arrays';
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';

--- a/src/pages/draft/[[...draftRouter]].tsx
+++ b/src/pages/draft/[[...draftRouter]].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';
 import { PageBase } from 'components/PageBase';
 import { ContentProps } from 'types/content-props/_content-common';

--- a/src/pages/editor/site-info.tsx
+++ b/src/pages/editor/site-info.tsx
@@ -1,11 +1,8 @@
-import {
-    GetServerSideProps,
-    GetServerSidePropsContext,
-    NextApiRequest,
-} from 'next';
-import { SiteInfo } from 'components/_editor-only/site-info/SiteInfo';
+import { GetServerSideProps, GetServerSidePropsContext, NextApiRequest } from 'next';
 import express from 'express';
 import util from 'util';
+
+import { SiteInfo } from 'components/_editor-only/site-info/SiteInfo';
 
 const parseReqBody = util.promisify(express.json({ limit: '10MB' }));
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
-import { PageBase } from 'components/PageBase';
 import { GetStaticProps } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
+
+import { PageBase } from 'components/PageBase';
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';
 import Config from 'config';
 import { logger } from 'srcCommon/logger';
@@ -8,9 +9,7 @@ import { logger } from 'srcCommon/logger';
 const isFailover = process.env.IS_FAILOVER_INSTANCE === 'true';
 
 const isDevBuild =
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD &&
-    !isFailover &&
-    process.env.ENV !== 'prod';
+    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD && !isFailover && process.env.ENV !== 'prod';
 
 // The build workflow on GHA does not have access to our dev-backend, so we just return not found for this page on build
 const getStaticPropsBuildDev: GetStaticProps = async () => {
@@ -37,9 +36,7 @@ const getStaticPropsNormal: GetStaticProps = async () => {
     };
 };
 
-export const getStaticProps = isDevBuild
-    ? getStaticPropsBuildDev
-    : getStaticPropsNormal;
+export const getStaticProps = isDevBuild ? getStaticPropsBuildDev : getStaticPropsNormal;
 
 export default PageBase;
 

--- a/src/pages/utkast/[[...utkastRouter]].tsx
+++ b/src/pages/utkast/[[...utkastRouter]].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+
 import { fetchPageProps } from 'utils/fetch/fetch-page-props';
 import { PageBase } from 'components/PageBase';
 

--- a/src/store/hooks/useOverviewFilters.ts
+++ b/src/store/hooks/useOverviewFilters.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+
 import { useAppDispatch, useAppSelector } from 'store/store';
 import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
@@ -44,8 +45,7 @@ const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
     const isTaxonomyMatching = (item: ItemType) =>
         taxonomyFilter === ProductTaxonomy.ALL ||
         item.taxonomy.includes(taxonomyFilter) ||
-        (taxonomyFilter === ProductTaxonomy.OTHER &&
-            item.type === 'no.nav.navno:guide-page');
+        (taxonomyFilter === ProductTaxonomy.OTHER && item.type === 'no.nav.navno:guide-page');
 
     const itemsMatchingToggleFilters = filterableItems.filter(
         (item: ItemType) => isAreaMatching(item) && isTaxonomyMatching(item)
@@ -55,11 +55,9 @@ const _getFilteredList = async <ItemType extends OverviewFilterableItem>({
         return itemsMatchingToggleFilters;
     }
 
-    return getFuseSearchFunc(itemsMatchingToggleFilters, fuseOptions).then(
-        (fuseSearchFunc) => {
-            return fuseSearchFunc(textFilterActual);
-        }
-    );
+    return getFuseSearchFunc(itemsMatchingToggleFilters, fuseOptions).then((fuseSearchFunc) => {
+        return fuseSearchFunc(textFilterActual);
+    });
 };
 
 export const useOverviewFilters = () => {
@@ -75,9 +73,7 @@ export const useOverviewFilters = () => {
         taxonomyFilter === overviewFiltersInitialState.taxonomyFilter;
 
     const getFilteredList = useCallback(
-        <ItemType extends OverviewFilterableItem>(
-            props: FilteredListProps<ItemType>
-        ) => {
+        <ItemType extends OverviewFilterableItem>(props: FilteredListProps<ItemType>) => {
             return _getFilteredList({ ...props, filters: filtersState });
         },
         [filtersState]
@@ -89,8 +85,7 @@ export const useOverviewFilters = () => {
     );
 
     const setTaxonomyFilter = useCallback(
-        (taxonomy: ProductTaxonomy) =>
-            dispatch(setTaxonomyFilterAction({ taxonomy })),
+        (taxonomy: ProductTaxonomy) => dispatch(setTaxonomyFilterAction({ taxonomy })),
         [dispatch]
     );
 
@@ -99,10 +94,7 @@ export const useOverviewFilters = () => {
         [dispatch]
     );
 
-    const resetFilters = useCallback(
-        () => dispatch(resetOverviewFiltersAction()),
-        [dispatch]
-    );
+    const resetFilters = useCallback(() => dispatch(resetOverviewFiltersAction()), [dispatch]);
 
     return {
         hasDefaultFilters,

--- a/src/store/pageContext.tsx
+++ b/src/store/pageContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext } from 'react';
+
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 
 const PageContext = createContext<ContentProps>({
@@ -13,18 +14,14 @@ const PageContext = createContext<ContentProps>({
 });
 
 const PageContextProvider: React.FC<any> = ({ children, content }) => {
-    return (
-        <PageContext.Provider value={content}>{children}</PageContext.Provider>
-    );
+    return <PageContext.Provider value={content}>{children}</PageContext.Provider>;
 };
 
 const usePageContentProps = () => {
     const context = useContext(PageContext);
 
     if (!context) {
-        throw new Error(
-            'usePageContentProps must be used within a PageContextProvider'
-        );
+        throw new Error('usePageContentProps must be used within a PageContextProvider');
     }
 
     return context;

--- a/src/store/slices/authState.ts
+++ b/src/store/slices/authState.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { MeldekortStatusResponse } from 'utils/fetch/fetch-meldekort-status';
 
 export type AuthStateType = 'loggedIn' | 'loggedOut' | 'waiting';
@@ -27,24 +28,18 @@ export const authStateSlice = createSlice({
                 state.name = action.payload.name;
             }
         },
-        setMeldekortInfo: (
-            state,
-            action: PayloadAction<MeldekortStatusResponse>
-        ) => {
+        setMeldekortInfo: (state, action: PayloadAction<MeldekortStatusResponse>) => {
             if (action.payload) {
                 state.meldekortStatus = {
                     ...action.payload,
-                    isMeldekortBruker:
-                        !!action.payload.nesteInnsendingAvMeldekort,
+                    isMeldekortBruker: !!action.payload.nesteInnsendingAvMeldekort,
                 };
             }
         },
     },
 });
 
-export const {
-    setAuthState: setAuthStateAction,
-    setMeldekortInfo: setMeldekortStatusAction,
-} = authStateSlice.actions;
+export const { setAuthState: setAuthStateAction, setMeldekortInfo: setMeldekortStatusAction } =
+    authStateSlice.actions;
 
 export default authStateSlice.reducer;

--- a/src/store/slices/filteredContent.ts
+++ b/src/store/slices/filteredContent.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { RootState } from 'store/store';
 
+import type { RootState } from 'store/store';
 import {
     FilteredContentState,
     FilterSelectionPayload,
@@ -25,26 +25,18 @@ export const filteredContentSlice = createSlice({
             );
             state[pageId].selectedFilters = updatedFilters;
         },
-        clearFiltersForPage: (
-            state,
-            action: PayloadAction<ClearFiltersPayload>
-        ) => {
+        clearFiltersForPage: (state, action: PayloadAction<ClearFiltersPayload>) => {
             const { pageId } = action.payload;
             state[pageId].selectedFilters = [];
         },
-        toggleFilterSelection: (
-            state,
-            action: PayloadAction<FilterSelectionPayload>
-        ) => {
+        toggleFilterSelection: (state, action: PayloadAction<FilterSelectionPayload>) => {
             const { pageId, filterId } = action.payload;
             const filtersForPage = state[pageId] || {
                 ...defaultFiltersForPage,
             };
             const { selectedFilters } = filtersForPage;
 
-            const updatedSelectedFilters: string[] = selectedFilters.includes(
-                filterId
-            )
+            const updatedSelectedFilters: string[] = selectedFilters.includes(filterId)
                 ? selectedFilters.filter((item) => item !== filterId)
                 : [...selectedFilters, filterId];
 
@@ -53,10 +45,7 @@ export const filteredContentSlice = createSlice({
                 selectedFilters: updatedSelectedFilters,
             };
         },
-        setAvailableFilters: (
-            state,
-            action: PayloadAction<AvailableFiltersPayload>
-        ) => {
+        setAvailableFilters: (state, action: PayloadAction<AvailableFiltersPayload>) => {
             const { pageId, availableFilters } = action.payload;
             const filtersForPage = state[pageId] || {
                 ...defaultFiltersForPage,
@@ -74,19 +63,13 @@ export const {
     toggleFilterSelection: toggleFilterSelectionAction,
 } = filteredContentSlice.actions;
 
-export const selectedFiltersAtPage = (
-    state: RootState,
-    pageId: string
-): string[] => {
+export const selectedFiltersAtPage = (state: RootState, pageId: string): string[] => {
     const pageFilters = state.contentFilters[pageId] || defaultFiltersForPage;
 
     return pageFilters.selectedFilters || [];
 };
 
-export const availableFiltersAtPage = (
-    state: RootState,
-    pageId: string
-): Category[] => {
+export const availableFiltersAtPage = (state: RootState, pageId: string): Category[] => {
     const pageFilters = state.contentFilters[pageId] || defaultFiltersForPage;
 
     return pageFilters.availableFilters || [];

--- a/src/store/slices/gvEditorState.ts
+++ b/src/store/slices/gvEditorState.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { GlobalValueItem } from 'types/content-props/global-values-props';
 import { GVMessageProps } from 'components/pages/global-values-page/components/messages/GVMessages';
 
@@ -39,12 +40,8 @@ export const gvEditorStateSlice = createSlice({
         setMessages: (state, action: PayloadAction<GvMessagesPayload>) => {
             state.messages = action.payload.messages;
         },
-        setItemEditState: (
-            state,
-            action: PayloadAction<GvItemStatePayload>
-        ) => {
-            state.itemsEditState[action.payload.key] =
-                action.payload.isEditMode;
+        setItemEditState: (state, action: PayloadAction<GvItemStatePayload>) => {
+            state.itemsEditState[action.payload.key] = action.payload.isEditMode;
         },
         setEditorEnabled: (state, action: PayloadAction<boolean>) => {
             state.editorEnabled = action.payload;

--- a/src/store/slices/overviewFilters.ts
+++ b/src/store/slices/overviewFilters.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
 
@@ -25,10 +26,7 @@ const overviewFiltersSlice = createSlice({
             const { area } = action.payload;
             return { ...state, areaFilter: area };
         },
-        setTaxonomy: (
-            state,
-            action: PayloadAction<{ taxonomy: ProductTaxonomy }>
-        ) => {
+        setTaxonomy: (state, action: PayloadAction<{ taxonomy: ProductTaxonomy }>) => {
             const { taxonomy } = action.payload;
             return { ...state, taxonomyFilter: taxonomy };
         },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useSelector, useDispatch } from 'react-redux';
+
+import overviewFilters from 'store/slices/overviewFilters';
+
 import contentFilters from './slices/filteredContent';
 import gvEditorState from './slices/gvEditorState';
 import authState from './slices/authState';
-import overviewFilters from 'store/slices/overviewFilters';
 
 const options = {
     reducer: {

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -44,8 +44,7 @@ const taxonomies: {
     [ThemedArticlePageTaxonomy.COMPLAINT_RIGHTS]: 'Klagerettigheter',
     [ThemedArticlePageTaxonomy.USER_SUPPORT]: 'Brukerstøtte',
     [ThemedArticlePageTaxonomy.ABOUT_NAV]: 'Om NAV',
-    [ThemedArticlePageTaxonomy.MEMBERSHIP_NATIONAL_INSURANCE]:
-        'Medlemskap i folketrygden',
+    [ThemedArticlePageTaxonomy.MEMBERSHIP_NATIONAL_INSURANCE]: 'Medlemskap i folketrygden',
     [ThemedArticlePageTaxonomy.RECRUITMENT]: 'Rekruttering',
     [ToolsPageTaxonomy.CALCULATOR]: 'Kalkulator',
     [ToolsPageTaxonomy.NAVIGATOR]: 'Veiviser',
@@ -74,8 +73,7 @@ const productDetailTypes: { [key in ProductDetailType]: string } = {
 
 export const translationsBundleNb = {
     errors: {
-        componentError:
-            'Det oppsto en feil ved lasting av dette innholdselementet',
+        componentError: 'Det oppsto en feil ved lasting av dette innholdselementet',
     },
     localeNames: {
         no: 'norsk (bokmål)',
@@ -101,8 +99,7 @@ export const translationsBundleNb = {
     },
     filteredContent: {
         noFiltersSelected: 'Ingen filtre er valgt, så alt innhold vises.',
-        filtersSelected:
-            'Vi har fjernet innhold som ikke er relevant i situasjonen din.',
+        filtersSelected: 'Vi har fjernet innhold som ikke er relevant i situasjonen din.',
         customizeContent: 'Tilpass innhold',
         showingInformationFor: 'Viser informasjon for:',
     },
@@ -146,31 +143,25 @@ export const translationsBundleNb = {
             'Hjelp i nødssituasjoner, for eksempel midlertidig botilbud eller økonomisk sosialhjelp',
         OKONOMI_GJELD: 'Økonomi- og gjeldsrådgivning',
         TILGANGPC: 'Tilgang til PC',
-        HJELPDIGITALETJENESTER:
-            'Hjelp til å bruke digitale tjenester hvis du trenger det',
+        HJELPDIGITALETJENESTER: 'Hjelp til å bruke digitale tjenester hvis du trenger det',
         BARNEVERNTJENESTE: 'Barneverntjeneste',
         FLYKTNINGTJENESTE: 'Flyktningtjeneste',
         FENGSEL_OPPFOLGING: 'Oppfølging av personer i fengsel',
         RUS_OPPFOLGING: 'Oppfølging av personer med rusproblemer',
-        PSYKISK_HELSE_OPPFOLGING:
-            'Oppfølging av personer med psykiske helseproblemer',
+        PSYKISK_HELSE_OPPFOLGING: 'Oppfølging av personer med psykiske helseproblemer',
         STARTLAN: 'Startlån og tilskudd fra kommunen',
         SJOFARTSOPPGAVER: 'Utstedelse av sjøfartsbok og formidling av sjøfolk',
         AKTIVITETSKORTET: 'Aktivitetskortet for barn og unge',
         BOSTOTTE_HUSBANKEN: 'Bostøtte fra Husbanken',
         BOSTOTTE_KOMMUNEN: 'Bostøtte fra kommunen',
-        PRIVATOKONOMI_FORVALTNING:
-            'Frivillig og tvungen forvaltning av privatøkonomi',
+        PRIVATOKONOMI_FORVALTNING: 'Frivillig og tvungen forvaltning av privatøkonomi',
         INTROPROGRAMMET: 'Introduksjonsprogrammet',
         KOMMUNAL_BOLIG: 'Kommunal bolig',
         KOMMUNAL_TILLEGGSPENSJON: 'Kommunal tilleggspensjon',
-        KOMMUNALT_FRIKORT_HELSETJENESTER:
-            'Kommunalt frikort for helsetjenester',
+        KOMMUNALT_FRIKORT_HELSETJENESTER: 'Kommunalt frikort for helsetjenester',
         LEDSAGERBEVIS: 'Ledsagerbevis',
-        PARKERING_FORFLYTNINGSHEMMEDE:
-            'Parkeringstillatelse for forflytningshemmede',
-        REDUSERT_FORELDREBETALING:
-            'Redusert foreldrebetaling i barnehage eller SFO',
+        PARKERING_FORFLYTNINGSHEMMEDE: 'Parkeringstillatelse for forflytningshemmede',
+        REDUSERT_FORELDREBETALING: 'Redusert foreldrebetaling i barnehage eller SFO',
         SKJENKEBEVILLING: 'Skjenkebevilling',
         STOTTEKONTAKT: 'Støttekontakt',
         TILRETTELAGT_TRANSPORT: 'Tilrettelagt transport (TT-kort)',
@@ -254,13 +245,11 @@ export const translationsBundleNb = {
         },
         aidcentral: {
             title: 'Finn din hjelpemiddelsentral',
-            ingress:
-                'Finn kontaktinformasjon og les om inn- og utlevering av hjelpemidler.',
+            ingress: 'Finn kontaktinformasjon og les om inn- og utlevering av hjelpemidler.',
         },
         call: {
             title: 'Ring oss på 55 55 33 33',
-            ingress:
-                'Hverdager 9-15. Vi kan ringe deg tilbake hvis ventetiden er over 5 minutter.',
+            ingress: 'Hverdager 9-15. Vi kan ringe deg tilbake hvis ventetiden er over 5 minutter.',
         },
         shared: {
             closed: 'Stengt',
@@ -279,8 +268,7 @@ export const translationsBundleNb = {
         appointmentOnly: 'Kun timeavtale',
         specialOpeningHours: 'Spesielle åpningstider',
         address: 'Adresse',
-        youCanMakeAppointment:
-            'Du kan avtale møte med veilederen din utenom disse åpningstidene.',
+        youCanMakeAppointment: 'Du kan avtale møte med veilederen din utenom disse åpningstidene.',
         location: 'Beliggenhet',
         postalAddress: 'Postadresse',
         orgNumber: 'Organisasjonsnummer',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,4 +1,3 @@
-import { PartialTranslations } from './default';
 import { MenuListItemKey } from 'types/menu-list-items';
 import {
     ProductTaxonomy,
@@ -7,6 +6,8 @@ import {
     ToolsPageTaxonomy,
 } from 'types/taxonomies';
 import { Area } from 'types/areas';
+
+import { PartialTranslations } from './default';
 
 const taxonomies: {
     [key in Taxonomy]?: string;
@@ -76,8 +77,7 @@ export const translationsBundleEn: PartialTranslations = {
     linkPanels: { label: 'Link panels' },
     filteredContent: {
         noFiltersSelected: 'No filters are selected. Showing all content.',
-        filtersSelected:
-            'We have hidden content not relevant for your situation.',
+        filtersSelected: 'We have hidden content not relevant for your situation.',
         customizeContent: 'Customize content',
         showingInformationFor: 'Showing information for:',
     },
@@ -92,26 +92,20 @@ export const translationsBundleEn: PartialTranslations = {
         FLYKTNINGTJENESTE: 'Refugee service',
         FENGSEL_OPPFOLGING: 'Follow-up of people in prison',
         RUS_OPPFOLGING: 'Follow-up of people with substance abuse problems',
-        PSYKISK_HELSE_OPPFOLGING:
-            'Follow-up of people with mental health problems',
+        PSYKISK_HELSE_OPPFOLGING: 'Follow-up of people with mental health problems',
         STARTLAN: 'Start-up loans and grants from the municipality',
-        SJOFARTSOPPGAVER:
-            'Issuance of sjøfartsbok and dissemination of seafarers',
+        SJOFARTSOPPGAVER: 'Issuance of sjøfartsbok and dissemination of seafarers',
         AKTIVITETSKORTET: 'Activity card for child and youth',
         BOSTOTTE_HUSBANKEN: 'Housing benefits from Husbanken',
         BOSTOTTE_KOMMUNEN: 'Housing benefits from from the municipality',
-        PRIVATOKONOMI_FORVALTNING:
-            'Voluntary and compulsory management of private finances',
+        PRIVATOKONOMI_FORVALTNING: 'Voluntary and compulsory management of private finances',
         INTROPROGRAMMET: 'Introductory program',
         KOMMUNAL_BOLIG: 'Public housing',
         KOMMUNAL_TILLEGGSPENSJON: 'Public pension supplement',
-        KOMMUNALT_FRIKORT_HELSETJENESTER:
-            'Public health services for hjemmetjenesten',
+        KOMMUNALT_FRIKORT_HELSETJENESTER: 'Public health services for hjemmetjenesten',
         LEDSAGERBEVIS: 'Accompanying person certificate',
-        PARKERING_FORFLYTNINGSHEMMEDE:
-            'Parking permit for people with reduced mobility',
-        REDUSERT_FORELDREBETALING:
-            'Reduced parental contribution for child care',
+        PARKERING_FORFLYTNINGSHEMMEDE: 'Parking permit for people with reduced mobility',
+        REDUSERT_FORELDREBETALING: 'Reduced parental contribution for child care',
         SKJENKEBEVILLING: 'Alcohol permit',
         STOTTEKONTAKT: 'Støttekontakt',
         TILRETTELAGT_TRANSPORT: 'Arranged transport (TT card)',
@@ -273,8 +267,7 @@ export const translationsBundleEn: PartialTranslations = {
         },
         call: {
             title: 'Call us at +47 55 55 33 33',
-            ingress:
-                'Weekdays 9-15. We can call you back if the wait time is more than 5 minutes.',
+            ingress: 'Weekdays 9-15. We can call you back if the wait time is more than 5 minutes.',
         },
         shared: {
             closed: 'Closed',
@@ -325,8 +318,7 @@ export const translationsBundleEn: PartialTranslations = {
     providerAudience: {
         administrator: 'bankruptcy administrators',
         doctor: 'physicians, dentists or other healthcare professional',
-        municipality_employed:
-            'employed in the municipality or county municipality',
+        municipality_employed: 'employed in the municipality or county municipality',
         optician: 'opticians or ophthalmologists',
         measures_organizer: 'organizers of labour market measures',
         aid_supplier: 'assistive technology providers',

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -2,11 +2,7 @@ import { translationsBundleSe as se } from './se';
 import { translationsBundleEn as en } from './en';
 import { translationsBundlePl as pl } from './pl';
 import { translationsBundleNn as nn } from './nn';
-import {
-    translationsBundleNb as defaultPack,
-    Translations,
-    PartialTranslations,
-} from './default';
+import { translationsBundleNb as defaultPack, Translations, PartialTranslations } from './default';
 
 export type Language = 'no' | 'nn' | 'en' | 'se' | 'pl' | 'uk' | 'ru';
 

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -43,8 +43,7 @@ const taxonomies: {
     [ThemedArticlePageTaxonomy.COMPLAINT_RIGHTS]: 'Klagerettar',
     [ThemedArticlePageTaxonomy.USER_SUPPORT]: 'Brukarstøtte',
     [ThemedArticlePageTaxonomy.ABOUT_NAV]: 'Om NAV',
-    [ThemedArticlePageTaxonomy.MEMBERSHIP_NATIONAL_INSURANCE]:
-        'Medlemskap i folketrygda',
+    [ThemedArticlePageTaxonomy.MEMBERSHIP_NATIONAL_INSURANCE]: 'Medlemskap i folketrygda',
     [ThemedArticlePageTaxonomy.RECRUITMENT]: 'Rekruttering',
     [ToolsPageTaxonomy.CALCULATOR]: 'Kalkulator',
     [ToolsPageTaxonomy.NAVIGATOR]: 'Vegvisar',
@@ -83,8 +82,7 @@ export const translationsBundleNn: PartialTranslations = {
     },
     filteredContent: {
         noFiltersSelected: 'Ingen filter er valde, så vi viser alt innhald.',
-        filtersSelected:
-            'Vi har fjerna innhald som ikkje er relevant i situasjonen din.',
+        filtersSelected: 'Vi har fjerna innhald som ikkje er relevant i situasjonen din.',
         customizeContent: 'Tilpass innhald',
         showingInformationFor: 'Viser informasjon for:',
     },
@@ -120,29 +118,25 @@ export const translationsBundleNn: PartialTranslations = {
             'Hjelp i nødssituasjonar, til dømes mellombels butilbod eller økonomisk sosialhjelp',
         OKONOMI_GJELD: 'Økonomi- og gjeldsrådgiving',
         TILGANGPC: 'Tilgang til PC',
-        HJELPDIGITALETJENESTER:
-            'Hjelp til å bruke digitale tenester dersom du treng det',
+        HJELPDIGITALETJENESTER: 'Hjelp til å bruke digitale tenester dersom du treng det',
         BARNEVERNTJENESTE: 'Barnevernteneste',
         FLYKTNINGTJENESTE: 'Flyktningtenesta',
         FENGSEL_OPPFOLGING: 'Oppfølging av personar i fengsel',
         RUS_OPPFOLGING: 'Oppfølging av personar med rusproblem',
-        PSYKISK_HELSE_OPPFOLGING:
-            'Oppfølging av personar med psykiske helseproblem',
+        PSYKISK_HELSE_OPPFOLGING: 'Oppfølging av personar med psykiske helseproblem',
         STARTLAN: 'Startlån og tilskot frå kommunen',
         SJOFARTSOPPGAVER: 'Utskriving av sjøfartsbok og formidling av sjøfolk',
         AKTIVITETSKORTET: 'Aktivitetskortet for barn og unge',
         BOSTOTTE_HUSBANKEN: 'Bustøtte frå Husbanken',
         BOSTOTTE_KOMMUNEN: 'Bustøtte frå kommunen',
-        PRIVATOKONOMI_FORVALTNING:
-            'Frivillig og tvungen forvaltning av privatøkonomi',
+        PRIVATOKONOMI_FORVALTNING: 'Frivillig og tvungen forvaltning av privatøkonomi',
         INTROPROGRAMMET: 'Introduksjonsprogrammet',
         KOMMUNAL_BOLIG: 'Kommunal bustad',
         KOMMUNAL_TILLEGGSPENSJON: 'Kommunal tilleggspensjon',
         KOMMUNALT_FRIKORT_HELSETJENESTER: 'Kommunalt frikort for helsetenester',
         LEDSAGERBEVIS: 'Følgjebevis',
         PARKERING_FORFLYTNINGSHEMMEDE: 'Parkeringsløyve for forflyttingshemma',
-        REDUSERT_FORELDREBETALING:
-            'Redusert foreldrebetaling i barnehage eller SFO',
+        REDUSERT_FORELDREBETALING: 'Redusert foreldrebetaling i barnehage eller SFO',
         SKJENKEBEVILLING: 'Skjenkeløyve',
         STOTTEKONTAKT: 'Støttekontakt',
         TILRETTELAGT_TRANSPORT: 'Tilrettelagt transport (TT-kort)',
@@ -183,8 +177,7 @@ export const translationsBundleNn: PartialTranslations = {
         appointmentOnly: 'Kun timeavtale',
         specialOpeningHours: 'Spesielle åpningstider',
         address: 'Adresse',
-        youCanMakeAppointment:
-            'Du kan avtale møte med rettleiaren din utanom desse opningstidene.',
+        youCanMakeAppointment: 'Du kan avtale møte med rettleiaren din utanom desse opningstidene.',
         location: 'Plassering',
         postalAddress: 'Postadresse',
         orgNumber: 'Organisasjonsnummer',
@@ -254,13 +247,11 @@ export const translationsBundleNn: PartialTranslations = {
         },
         aidcentral: {
             title: 'Finn din hjelpemiddelsentral',
-            ingress:
-                'Finn kontaktinformasjon og les om inn- og utlevering av hjelpemidler.',
+            ingress: 'Finn kontaktinformasjon og les om inn- og utlevering av hjelpemidler.',
         },
         call: {
             title: 'Ring oss på 55 55 33 33',
-            ingress:
-                'Kvardagar 9-15. Vi kan ringe deg tilbake viss ventetida er over 5 minutt.',
+            ingress: 'Kvardagar 9-15. Vi kan ringe deg tilbake viss ventetida er over 5 minutt.',
         },
         shared: {
             closed: 'Stengt',

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -1,5 +1,6 @@
-import { PartialTranslations } from './default';
 import { MenuListItemKey } from 'types/menu-list-items';
+
+import { PartialTranslations } from './default';
 
 export const translationsBundlePl: PartialTranslations = {
     relatedContent: {

--- a/src/translations/se.ts
+++ b/src/translations/se.ts
@@ -1,5 +1,6 @@
-import { PartialTranslations } from './default';
 import { MenuListItemKey } from 'types/menu-list-items';
+
+import { PartialTranslations } from './default';
 
 export const translationsBundleSe: PartialTranslations = {
     header: {

--- a/src/types/component-props/_component-common.ts
+++ b/src/types/component-props/_component-common.ts
@@ -1,7 +1,8 @@
-import { PartType } from './parts';
-import { LayoutProps } from './layouts';
 import { ContentProps } from 'types/content-props/_content-common';
 import { RenderOnAuthStateMixin } from 'types/component-props/_mixins';
+
+import { PartType } from './parts';
+import { LayoutProps } from './layouts';
 
 export enum ComponentType {
     Page = 'page',

--- a/src/types/component-props/layouts.ts
+++ b/src/types/component-props/layouts.ts
@@ -1,8 +1,7 @@
-import {
-    ComponentCommonProps,
-    ComponentProps,
-    ComponentType,
-} from './_component-common';
+import { TwoColsPageProps } from 'types/component-props/pages/two-cols-page';
+import { ProductDetailsPageProps } from 'types/component-props/pages/product-details-layout';
+
+import { ComponentCommonProps, ComponentProps, ComponentType } from './_component-common';
 import { FlexColsLayoutProps } from './layouts/flex-cols';
 import { FixedColsLayoutProps } from './layouts/fixed-cols';
 import { LegacyLayoutProps } from './layouts/legacy-layout';
@@ -14,8 +13,6 @@ import { ProductPageFlexColsLayoutProps } from './layouts/product-flex-cols';
 import { IndexPageProps } from './pages/index-page';
 import { AreapageSituationsProps } from './layouts/areapage-situations';
 import { FrontpageLoggedinSectionLayoutProps } from './layouts/frontpage-loggedin-section';
-import { TwoColsPageProps } from 'types/component-props/pages/two-cols-page';
-import { ProductDetailsPageProps } from 'types/component-props/pages/product-details-layout';
 
 export enum LayoutType {
     Fixed1Col = 'no.nav.navno:dynamic-1-col',
@@ -46,13 +43,12 @@ export type Regions<RegionNames extends string> = {
     [Name in RegionNames]: RegionProps<Name>;
 };
 
-export type LayoutCommonProps<RegionNames extends string = string> =
-    ComponentCommonProps & {
-        type: ComponentType.Layout | ComponentType.Page;
-        descriptor: LayoutType;
-        regions: Regions<RegionNames>;
-        config?: any;
-    };
+export type LayoutCommonProps<RegionNames extends string = string> = ComponentCommonProps & {
+    type: ComponentType.Layout | ComponentType.Page;
+    descriptor: LayoutType;
+    regions: Regions<RegionNames>;
+    config?: any;
+};
 
 export type LayoutProps =
     | LegacyLayoutProps

--- a/src/types/component-props/layouts/areapage-situations.ts
+++ b/src/types/component-props/layouts/areapage-situations.ts
@@ -1,8 +1,4 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 
 export interface AreapageSituationsProps extends LayoutCommonProps {

--- a/src/types/component-props/layouts/fixed-cols.ts
+++ b/src/types/component-props/layouts/fixed-cols.ts
@@ -1,8 +1,4 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 import { LayoutCommonConfigMixin } from 'types/component-props/_mixins';
 
@@ -10,10 +6,7 @@ type DynamicColRegions = 'dynamic-1' | 'dynamic-2' | 'dynamic-3';
 
 export interface FixedColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;
-    descriptor:
-        | LayoutType.Fixed1Col
-        | LayoutType.Fixed2Col
-        | LayoutType.Fixed3Col;
+    descriptor: LayoutType.Fixed1Col | LayoutType.Fixed2Col | LayoutType.Fixed3Col;
     regions: Regions<DynamicColRegions>;
     config: {
         distribution: string;

--- a/src/types/component-props/layouts/flex-cols.ts
+++ b/src/types/component-props/layouts/flex-cols.ts
@@ -1,13 +1,6 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
-import {
-    HeaderWithAnchorMixin,
-    LayoutCommonConfigMixin,
-} from 'types/component-props/_mixins';
+import { HeaderWithAnchorMixin, LayoutCommonConfigMixin } from 'types/component-props/_mixins';
 
 export interface FlexColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;

--- a/src/types/component-props/layouts/frontpage-loggedin-section.ts
+++ b/src/types/component-props/layouts/frontpage-loggedin-section.ts
@@ -1,8 +1,4 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 import { LinkSelectable } from 'types/component-props/_mixins';
 

--- a/src/types/component-props/layouts/legacy-layout.ts
+++ b/src/types/component-props/layouts/legacy-layout.ts
@@ -1,17 +1,10 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 
 type LegacyRegions = 'first' | 'second';
 
 export interface LegacyLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout | ComponentType.Page;
-    descriptor:
-        | LayoutType.LegacyMain
-        | LayoutType.LegacyMain1Col
-        | LayoutType.MainPage;
+    descriptor: LayoutType.LegacyMain | LayoutType.LegacyMain1Col | LayoutType.MainPage;
     regions: Regions<LegacyRegions>;
 }

--- a/src/types/component-props/layouts/product-flex-cols.ts
+++ b/src/types/component-props/layouts/product-flex-cols.ts
@@ -1,8 +1,4 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 import { HeaderWithAnchorMixin } from 'types/component-props/_mixins';
 

--- a/src/types/component-props/layouts/section-with-header.ts
+++ b/src/types/component-props/layouts/section-with-header.ts
@@ -1,13 +1,6 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
-import {
-    HeaderWithAnchorMixin,
-    LayoutCommonConfigMixin,
-} from 'types/component-props/_mixins';
+import { HeaderWithAnchorMixin, LayoutCommonConfigMixin } from 'types/component-props/_mixins';
 import { XpImageProps } from 'types/media';
 import { OptionSetSingle } from 'types/util-types';
 

--- a/src/types/component-props/layouts/situation-flex-cols.ts
+++ b/src/types/component-props/layouts/situation-flex-cols.ts
@@ -1,12 +1,9 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 import { HeaderWithAnchorMixin } from 'types/component-props/_mixins';
-import { FlexColsLayoutProps } from './flex-cols';
 import { OptionSetSingle } from 'types/util-types';
+
+import { FlexColsLayoutProps } from './flex-cols';
 
 export interface SituationPageFlexColsLayoutProps extends LayoutCommonProps {
     type: ComponentType.Layout;
@@ -17,9 +14,6 @@ export interface SituationPageFlexColsLayoutProps extends LayoutCommonProps {
             products: { priority: 'primary' | 'secondary' | 'tertiary' };
             provider: {};
         }>;
-    } & Pick<
-        FlexColsLayoutProps['config'],
-        'justifyContent' | 'numCols' | 'bgColor'
-    > &
+    } & Pick<FlexColsLayoutProps['config'], 'justifyContent' | 'numCols' | 'bgColor'> &
         HeaderWithAnchorMixin;
 }

--- a/src/types/component-props/pages/index-page.ts
+++ b/src/types/component-props/pages/index-page.ts
@@ -1,8 +1,5 @@
 import { LayoutCommonProps, LayoutType } from 'types/component-props/layouts';
-import {
-    ComponentProps,
-    ComponentType,
-} from 'types/component-props/_component-common';
+import { ComponentProps, ComponentType } from 'types/component-props/_component-common';
 
 type Regions = 'contentTop' | 'contentBottom';
 

--- a/src/types/component-props/pages/page-with-side-menus.ts
+++ b/src/types/component-props/pages/page-with-side-menus.ts
@@ -1,8 +1,5 @@
 import { LayoutCommonProps, LayoutType } from 'types/component-props/layouts';
-import {
-    ComponentProps,
-    ComponentType,
-} from 'types/component-props/_component-common';
+import { ComponentProps, ComponentType } from 'types/component-props/_component-common';
 import { AnchorLink } from 'types/component-props/parts/page-navigation-menu';
 
 type Regions =

--- a/src/types/component-props/pages/product-details-layout.ts
+++ b/src/types/component-props/pages/product-details-layout.ts
@@ -1,19 +1,10 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 
-export type ProductDetailsPageRegionName =
-    | 'intro'
-    | 'main'
-    | 'main_complaint'
-    | 'outro';
+export type ProductDetailsPageRegionName = 'intro' | 'main' | 'main_complaint' | 'outro';
 
-export type ProductDetailsPageProps =
-    LayoutCommonProps<ProductDetailsPageRegionName> & {
-        type: ComponentType.Page;
-        descriptor: LayoutType.ProductDetailsPage;
-        regions: Regions<ProductDetailsPageRegionName>;
-    };
+export type ProductDetailsPageProps = LayoutCommonProps<ProductDetailsPageRegionName> & {
+    type: ComponentType.Page;
+    descriptor: LayoutType.ProductDetailsPage;
+    regions: Regions<ProductDetailsPageRegionName>;
+};

--- a/src/types/component-props/pages/single-col-page.ts
+++ b/src/types/component-props/pages/single-col-page.ts
@@ -1,8 +1,5 @@
 import { LayoutCommonProps, LayoutType } from 'types/component-props/layouts';
-import {
-    ComponentProps,
-    ComponentType,
-} from 'types/component-props/_component-common';
+import { ComponentProps, ComponentType } from 'types/component-props/_component-common';
 
 type Regions = 'pageContent';
 

--- a/src/types/component-props/pages/two-cols-page.ts
+++ b/src/types/component-props/pages/two-cols-page.ts
@@ -1,8 +1,4 @@
-import {
-    LayoutCommonProps,
-    LayoutType,
-    Regions,
-} from 'types/component-props/layouts';
+import { LayoutCommonProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 
 type RegionName = 'mainCol' | 'sideCol';

--- a/src/types/component-props/parts.ts
+++ b/src/types/component-props/parts.ts
@@ -70,7 +70,4 @@ export type PartLegacyType =
     | PartType.PublishingCalendar
     | PartType.PublishingCalendarEntry;
 
-export type PartCurrentType = Exclude<
-    PartType,
-    PartLegacyType | PartDeprecatedType
->;
+export type PartCurrentType = Exclude<PartType, PartLegacyType | PartDeprecatedType>;

--- a/src/types/component-props/parts/button.ts
+++ b/src/types/component-props/parts/button.ts
@@ -1,9 +1,6 @@
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
-import {
-    LinkSelectable,
-    RenderOnAuthStateMixin,
-} from 'types/component-props/_mixins';
+import { LinkSelectable, RenderOnAuthStateMixin } from 'types/component-props/_mixins';
 import { XpImageProps } from 'types/media';
 
 type ButtonPartSizePropLegacy = 'normal' | 'kompakt' | 'mini';

--- a/src/types/component-props/parts/contact-option.ts
+++ b/src/types/component-props/parts/contact-option.ts
@@ -1,9 +1,6 @@
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
-import {
-    AudienceOptions,
-    RenderOnAuthStateMixin,
-} from 'types/component-props/_mixins';
+import { AudienceOptions, RenderOnAuthStateMixin } from 'types/component-props/_mixins';
 import { OptionSetSingle } from 'types/util-types';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { DayName } from 'utils/datetime';

--- a/src/types/component-props/parts/header.ts
+++ b/src/types/component-props/parts/header.ts
@@ -1,10 +1,7 @@
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
 import { HeadingTag } from 'types/typo-style';
-import {
-    HeaderCommonConfig,
-    RenderOnAuthStateMixin,
-} from 'types/component-props/_mixins';
+import { HeaderCommonConfig, RenderOnAuthStateMixin } from 'types/component-props/_mixins';
 
 export interface HeaderProps extends PartComponentProps {
     descriptor: PartType.Header;

--- a/src/types/component-props/parts/loggedin-card.ts
+++ b/src/types/component-props/parts/loggedin-card.ts
@@ -14,9 +14,6 @@ export interface LoggedinCardProps extends PartComponentProps {
     };
 }
 
-export type LoggedInCardTypeProps = Omit<
-    LoggedinCardProps['config']['card'],
-    '_selected'
->;
+export type LoggedInCardTypeProps = Omit<LoggedinCardProps['config']['card'], '_selected'>;
 
 export type LoggedInCardTypes = keyof LoggedInCardTypeProps;

--- a/src/types/component-props/parts/micro-card.ts
+++ b/src/types/component-props/parts/micro-card.ts
@@ -1,9 +1,6 @@
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
-import {
-    ProductPageProps,
-    SituationPageProps,
-} from 'types/content-props/dynamic-page-props';
+import { ProductPageProps, SituationPageProps } from 'types/content-props/dynamic-page-props';
 
 export interface MicroCardProps extends PartComponentProps {
     descriptor: PartType.ProductCardMicro;

--- a/src/types/component-props/parts/payout-dates.ts
+++ b/src/types/component-props/parts/payout-dates.ts
@@ -1,10 +1,7 @@
 import { PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
 import { PayoutDatesData } from 'types/content-props/payout-dates';
-import {
-    ExpandableMixin,
-    RenderOnAuthStateMixin,
-} from 'types/component-props/_mixins';
+import { ExpandableMixin, RenderOnAuthStateMixin } from 'types/component-props/_mixins';
 
 export interface PayoutDatesPartProps extends PartComponentProps {
     descriptor: PartType.PayoutDates;

--- a/src/types/component-props/parts/product-details.ts
+++ b/src/types/component-props/parts/product-details.ts
@@ -1,7 +1,4 @@
-import {
-    ComponentProps,
-    PartComponentProps,
-} from 'types/component-props/_component-common';
+import { ComponentProps, PartComponentProps } from 'types/component-props/_component-common';
 import { PartType } from 'types/component-props/parts';
 import {
     ExpandableMixin,

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -8,8 +8,8 @@ import { AudienceOptions } from 'types/component-props/_mixins';
 import { TemplateProps } from 'types/content-props/template-props';
 import { SiteProps } from 'types/content-props/site-props';
 import { FormsOverviewProps } from 'types/content-props/forms-overview';
-
 import { OverviewPageProps } from 'types/content-props/overview-props';
+
 import { ExternalLinkProps } from './external-link-props';
 import { InternalLinkProps } from './internal-link-props';
 import { ContentListProps } from './content-list-props';
@@ -19,7 +19,6 @@ import { ErrorProps } from './error-props';
 import { LargeTableProps } from './large-table-props';
 import { SectionPageProps } from './section-page-props';
 import { TransportPageProps } from './transport-page-props';
-
 import { MainArticleChapterProps } from './main-article-chapter-props';
 import { OfficeInformationProps } from './office-information-props';
 import { UrlProps } from './url-props';
@@ -41,15 +40,11 @@ import { PublishingCalendarProps, PublishingCalendarEntryProps } from './publish
 import { AnimatedIconsProps } from './animated-icons';
 import { GlobalCaseTimeSetProps, GlobalValuesProps } from './global-values-props';
 import { ContactInformationProps } from './contact-information-props';
-
 import { PayoutDatesProps } from './payout-dates';
-
 import { FragmentPageProps } from './fragment-page-props';
 import { AreaPageProps, FrontPageNestedProps, FrontPageProps } from './index-pages-props';
-
 import { FormDetailsPageProps } from './form-details';
 import { FormIntermediateStepPageProps } from './form-intermediate-step';
-
 import { FallbackPageProps } from './fallback-page-props';
 
 export enum ContentType {

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -1,3 +1,15 @@
+import { DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
+
+import { Language } from 'translations';
+import { LayoutProps } from 'types/component-props/layouts';
+import { MediaType } from 'types/media';
+import { LanguageProps, LayerLocale } from 'types/language';
+import { AudienceOptions } from 'types/component-props/_mixins';
+import { TemplateProps } from 'types/content-props/template-props';
+import { SiteProps } from 'types/content-props/site-props';
+import { FormsOverviewProps } from 'types/content-props/forms-overview';
+
+import { OverviewPageProps } from 'types/content-props/overview-props';
 import { ExternalLinkProps } from './external-link-props';
 import { InternalLinkProps } from './internal-link-props';
 import { ContentListProps } from './content-list-props';
@@ -7,8 +19,7 @@ import { ErrorProps } from './error-props';
 import { LargeTableProps } from './large-table-props';
 import { SectionPageProps } from './section-page-props';
 import { TransportPageProps } from './transport-page-props';
-import { Language } from 'translations';
-import { LayoutProps } from 'types/component-props/layouts';
+
 import { MainArticleChapterProps } from './main-article-chapter-props';
 import { OfficeInformationProps } from './office-information-props';
 import { UrlProps } from './url-props';
@@ -26,33 +37,19 @@ import {
     ToolsPageProps,
     PressLandingPageProps,
 } from './dynamic-page-props';
-import {
-    PublishingCalendarProps,
-    PublishingCalendarEntryProps,
-} from './publishing-calendar-props';
-import { DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
+import { PublishingCalendarProps, PublishingCalendarEntryProps } from './publishing-calendar-props';
 import { AnimatedIconsProps } from './animated-icons';
-import {
-    GlobalCaseTimeSetProps,
-    GlobalValuesProps,
-} from './global-values-props';
+import { GlobalCaseTimeSetProps, GlobalValuesProps } from './global-values-props';
 import { ContactInformationProps } from './contact-information-props';
-import { MediaType } from 'types/media';
+
 import { PayoutDatesProps } from './payout-dates';
-import { LanguageProps, LayerLocale } from 'types/language';
+
 import { FragmentPageProps } from './fragment-page-props';
-import {
-    AreaPageProps,
-    FrontPageNestedProps,
-    FrontPageProps,
-} from './index-pages-props';
-import { AudienceOptions } from 'types/component-props/_mixins';
-import { TemplateProps } from 'types/content-props/template-props';
-import { SiteProps } from 'types/content-props/site-props';
+import { AreaPageProps, FrontPageNestedProps, FrontPageProps } from './index-pages-props';
+
 import { FormDetailsPageProps } from './form-details';
 import { FormIntermediateStepPageProps } from './form-intermediate-step';
-import { FormsOverviewProps } from 'types/content-props/forms-overview';
-import { OverviewPageProps } from 'types/content-props/overview-props';
+
 import { FallbackPageProps } from './fallback-page-props';
 
 export enum ContentType {
@@ -205,5 +202,5 @@ type SpecificContentProps =
     | FormsOverviewProps
     | FallbackPageProps;
 
-export type ContentProps<Type extends ContentType = ContentType> =
-    ContentCommonProps<Type> & SpecificContentProps;
+export type ContentProps<Type extends ContentType = ContentType> = ContentCommonProps<Type> &
+    SpecificContentProps;

--- a/src/types/content-props/animated-icons.ts
+++ b/src/types/content-props/animated-icons.ts
@@ -1,5 +1,6 @@
-import { ContentType } from './_content-common';
 import { XpImageProps } from 'types/media';
+
+import { ContentType } from './_content-common';
 
 export type AnimatedIcon = {
     icon?: XpImageProps;

--- a/src/types/content-props/calculator-props.ts
+++ b/src/types/content-props/calculator-props.ts
@@ -1,5 +1,6 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { CalculatorData } from 'types/component-props/parts/calculator';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 
 export type CalculatorProps = ContentCommonProps & {
     type: ContentType.ContactInformationPage;

--- a/src/types/content-props/contact-information-props.ts
+++ b/src/types/content-props/contact-information-props.ts
@@ -1,8 +1,5 @@
-import {
-    WriteData,
-    TelephoneData,
-    ChatData,
-} from 'types/component-props/parts/contact-option';
+import { WriteData, TelephoneData, ChatData } from 'types/component-props/parts/contact-option';
+
 import { ContentType, ContentCommonProps } from './_content-common';
 
 export interface ContactInformationData {

--- a/src/types/content-props/content-list-props.ts
+++ b/src/types/content-props/content-list-props.ts
@@ -1,9 +1,6 @@
-import {
-    ContentType,
-    ContentCommonProps,
-    ContentProps,
-} from './_content-common';
 import { DateTimeKey } from 'types/datetime';
+
+import { ContentType, ContentCommonProps, ContentProps } from './_content-common';
 
 export type ContentListData = {
     sectionContents?: ContentProps[];

--- a/src/types/content-props/dynamic-page-props.ts
+++ b/src/types/content-props/dynamic-page-props.ts
@@ -1,12 +1,13 @@
-import { ContentCommonProps, ContentType } from './_content-common';
 import { AlternativeAudience, ProductDataMixin } from 'types/component-props/_mixins';
 import { ThemedArticlePageTaxonomy, ToolsPageTaxonomy } from 'types/taxonomies';
-import { OfficeDetailsData } from './office-details-props';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
-import { ContentListProps } from './content-list-props';
 import { PageWithSideMenusProps } from 'types/component-props/pages/page-with-side-menus';
 import { SingleColPageProps } from 'types/component-props/pages/single-col-page';
 import { LayoutProps } from 'types/component-props/layouts';
+
+import { ContentListProps } from './content-list-props';
+import { OfficeDetailsData } from './office-details-props';
+import { ContentCommonProps, ContentType } from './_content-common';
 import { ProductDetailType } from './product-details';
 
 export type DynamicPageProps = ContentCommonProps & {

--- a/src/types/content-props/fallback-page-props.ts
+++ b/src/types/content-props/fallback-page-props.ts
@@ -1,5 +1,6 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { EmptyObject } from 'types/util-types';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 
 export type FallbackPageProps = ContentCommonProps & {
     type: ContentType.FallbackPage;

--- a/src/types/content-props/form-details.ts
+++ b/src/types/content-props/form-details.ts
@@ -1,7 +1,8 @@
 import { OptionSetSingle } from 'types/util-types';
-import { ContentCommonProps, ContentType } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { LinkSelectable } from 'types/component-props/_mixins';
+
+import { ContentCommonProps, ContentType } from './_content-common';
 import { AlertData } from './alerts';
 
 export type FormComplaintTypes = 'complaint' | 'appeal';

--- a/src/types/content-props/form-intermediate-step.ts
+++ b/src/types/content-props/form-intermediate-step.ts
@@ -1,7 +1,8 @@
 import { ProcessedHtmlProps } from 'types/processed-html-props';
-import { ContentCommonProps, ContentType } from './_content-common';
 import { Taxonomy } from 'types/taxonomies';
 import { OptionSetSingle } from 'types/util-types';
+
+import { ContentCommonProps, ContentType } from './_content-common';
 import { AnimatedIconsProps } from './animated-icons';
 
 export type FormIntermediateStep_StepData<

--- a/src/types/content-props/forms-overview.ts
+++ b/src/types/content-props/forms-overview.ts
@@ -1,7 +1,4 @@
-import {
-    ContentCommonProps,
-    ContentType,
-} from 'types/content-props/_content-common';
+import { ContentCommonProps, ContentType } from 'types/content-props/_content-common';
 import { EmptyObject, OptionSetSingle } from 'types/util-types';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { TwoColsPageProps } from 'types/component-props/pages/two-cols-page';
@@ -9,9 +6,7 @@ import { Area } from 'types/areas';
 import { ProductTaxonomy } from 'types/taxonomies';
 import { ProviderAudience } from 'types/component-props/_mixins';
 
-type ContentTypeInFormOverviewPages =
-    | ContentType.ProductPage
-    | ContentType.GuidePage;
+type ContentTypeInFormOverviewPages = ContentType.ProductPage | ContentType.GuidePage;
 
 export type FormDetailsListItemProps = {
     title: string;

--- a/src/types/content-props/fragment-page-props.ts
+++ b/src/types/content-props/fragment-page-props.ts
@@ -1,5 +1,6 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { ComponentProps } from 'types/component-props/_component-common';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 
 export type FragmentPageProps = ContentCommonProps & {
     type: ContentType.Fragment;

--- a/src/types/content-props/index-pages-props.ts
+++ b/src/types/content-props/index-pages-props.ts
@@ -1,12 +1,9 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { Area } from 'types/areas';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { IndexPageProps } from 'types/component-props/pages/index-page';
-import {
-    AudienceOptions,
-    ColorMixin,
-    LinkSelectable,
-} from 'types/component-props/_mixins';
+import { AudienceOptions, ColorMixin, LinkSelectable } from 'types/component-props/_mixins';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 import { SituationPageProps } from './dynamic-page-props';
 import { AnimatedIconsProps } from './animated-icons';
 import { OverviewPageProps } from './overview-props';
@@ -45,10 +42,7 @@ export type FrontPageNestedProps = ContentCommonProps & {
     page: IndexPageProps;
 };
 
-export type OtherRefsProps =
-    | OverviewPageProps
-    | FormsOverviewProps
-    | ExternalLinkProps;
+export type OtherRefsProps = OverviewPageProps | FormsOverviewProps | ExternalLinkProps;
 
 export type AreaPageData = {
     area: Area;

--- a/src/types/content-props/large-table-props.ts
+++ b/src/types/content-props/large-table-props.ts
@@ -1,5 +1,6 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 
 export type LargeTableData = {
     text?: ProcessedHtmlProps;

--- a/src/types/content-props/main-article-props.ts
+++ b/src/types/content-props/main-article-props.ts
@@ -1,8 +1,9 @@
-import { MainArticleChapterNavigationData } from './main-article-chapter-props';
-import { ContentType, ContentCommonProps } from './_content-common';
 import { MenuListItems } from 'types/menu-list-items';
 import { XpImageProps } from 'types/media';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+
+import { ContentType, ContentCommonProps } from './_content-common';
+import { MainArticleChapterNavigationData } from './main-article-chapter-props';
 
 export type Picture = Partial<{
     target: XpImageProps;

--- a/src/types/content-props/office-information-props.ts
+++ b/src/types/content-props/office-information-props.ts
@@ -56,10 +56,7 @@ type ContactInfo = {
     postadresse: LegacyOfficeAddress;
     besoeksadresse: LegacyOfficeAddress;
     spesielleOpplysninger: string;
-    publikumsmottak:
-        | LegacyOfficeAudienceReception[]
-        | LegacyOfficeAudienceReception
-        | undefined;
+    publikumsmottak: LegacyOfficeAudienceReception[] | LegacyOfficeAudienceReception | undefined;
 };
 
 export type OfficeInformationData = {

--- a/src/types/content-props/overview-props.ts
+++ b/src/types/content-props/overview-props.ts
@@ -1,7 +1,4 @@
-import {
-    ContentCommonProps,
-    ContentType,
-} from 'types/content-props/_content-common';
+import { ContentCommonProps, ContentType } from 'types/content-props/_content-common';
 import { LayoutProps } from 'types/component-props/layouts';
 import { Audience, ProductDataMixin } from 'types/component-props/_mixins';
 import { ProductDetailType as OverviewType } from 'types/content-props/product-details';

--- a/src/types/content-props/page-list-props.ts
+++ b/src/types/content-props/page-list-props.ts
@@ -1,9 +1,6 @@
-import {
-    ContentType,
-    ContentCommonProps,
-    ContentProps,
-} from './_content-common';
 import { MenuListItems } from 'types/menu-list-items';
+
+import { ContentType, ContentCommonProps, ContentProps } from './_content-common';
 
 export type PageListData = Partial<{
     ingress: string;

--- a/src/types/content-props/section-page-props.ts
+++ b/src/types/content-props/section-page-props.ts
@@ -1,9 +1,6 @@
-import {
-    ContentType,
-    ContentCommonProps,
-    ContentProps,
-} from './_content-common';
 import { LinkPanel } from 'types/link-panel';
+
+import { ContentType, ContentCommonProps, ContentProps } from './_content-common';
 import { ContentListProps } from './content-list-props';
 
 export type SectionPageData = {

--- a/src/types/content-props/transport-page-props.ts
+++ b/src/types/content-props/transport-page-props.ts
@@ -1,5 +1,6 @@
-import { ContentType, ContentCommonProps } from './_content-common';
 import { LinkPanel } from 'types/link-panel';
+
+import { ContentType, ContentCommonProps } from './_content-common';
 
 export type TransportPageData = Partial<{
     ingress: string;

--- a/src/types/content-props/video.ts
+++ b/src/types/content-props/video.ts
@@ -1,5 +1,6 @@
-import { ContentCommonProps, ContentType } from './_content-common';
 import { RasterImage } from 'types/media';
+
+import { ContentCommonProps, ContentType } from './_content-common';
 
 export type VideoData = {
     accountId: string;

--- a/src/types/datetime.ts
+++ b/src/types/datetime.ts
@@ -1,5 +1,1 @@
-export type DateTimeKey =
-    | 'createdTime'
-    | 'modifiedTime'
-    | 'publish.from'
-    | 'publish.first';
+export type DateTimeKey = 'createdTime' | 'modifiedTime' | 'publish.from' | 'publish.first';

--- a/src/types/macro-props/chevron-link-external.ts
+++ b/src/types/macro-props/chevron-link-external.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { ExternalLinkMixin } from 'types/component-props/_mixins';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroChevronLinkExternalProps extends MacroPropsCommon {
     name: MacroType.ChevronLinkExternal;

--- a/src/types/macro-props/chevron-link-internal.ts
+++ b/src/types/macro-props/chevron-link-internal.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { InternalLinkMixin } from 'types/component-props/_mixins';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroChevronLinkInternalProps extends MacroPropsCommon {
     name: MacroType.ChevronLinkInternal;

--- a/src/types/macro-props/form-details.ts
+++ b/src/types/macro-props/form-details.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { FormDetailsData } from 'types/content-props/form-details';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroFormDetailsProps extends MacroPropsCommon {
     name: MacroType.PayoutDates;

--- a/src/types/macro-props/html-fragment.ts
+++ b/src/types/macro-props/html-fragment.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroHtmlFragmentProps extends MacroPropsCommon {
     name: MacroType.HtmlFragment;

--- a/src/types/macro-props/payout-dates.ts
+++ b/src/types/macro-props/payout-dates.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { PayoutDatesData } from 'types/content-props/payout-dates';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroPayoutDatesProps extends MacroPropsCommon {
     name: MacroType.PayoutDates;

--- a/src/types/macro-props/product-card-micro.ts
+++ b/src/types/macro-props/product-card-micro.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { TargetPage } from 'types/component-props/parts/product-card';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroProductCardMicroProps extends MacroPropsCommon {
     name: MacroType.ProductCardMicro;

--- a/src/types/macro-props/product-card-mini.ts
+++ b/src/types/macro-props/product-card-mini.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { ProductCardMiniProps } from 'types/component-props/parts/product-card';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroProductCardMiniProps extends MacroPropsCommon {
     name: MacroType.ProductCardMini;

--- a/src/types/macro-props/saksbehandlingstid.ts
+++ b/src/types/macro-props/saksbehandlingstid.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { GlobalCaseTimeUnit } from 'types/content-props/global-values-props';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroSaksbehandlingstidProps extends MacroPropsCommon {
     name: MacroType.Saksbehandlingstid;

--- a/src/types/macro-props/video.ts
+++ b/src/types/macro-props/video.ts
@@ -1,5 +1,6 @@
-import { MacroPropsCommon, MacroType } from './_macros-common';
 import { VideoData } from 'types/content-props/video';
+
+import { MacroPropsCommon, MacroType } from './_macros-common';
 
 export interface MacroVideoProps extends MacroPropsCommon {
     name: MacroType.Video;

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,4 +1,5 @@
 import { XpResponseProps } from 'utils/fetch/fetch-content';
+
 import { ContentAndMediaCommonProps } from './content-props/_content-common';
 
 export enum MediaType {
@@ -40,7 +41,5 @@ export type RasterImage = {
 
 export type XpImageProps = VectorImage | RasterImage;
 
-export const isMediaContent = (
-    content: XpResponseProps
-): content is MediaProps =>
+export const isMediaContent = (content: XpResponseProps): content is MediaProps =>
     Object.values(MediaType).includes(content.type as MediaType);

--- a/src/types/taxonomies.ts
+++ b/src/types/taxonomies.ts
@@ -28,7 +28,4 @@ export enum ToolsPageTaxonomy {
     NAVIGATOR = 'navigator',
 }
 
-export type Taxonomy =
-    | ProductTaxonomy
-    | ThemedArticlePageTaxonomy
-    | ToolsPageTaxonomy;
+export type Taxonomy = ProductTaxonomy | ThemedArticlePageTaxonomy | ToolsPageTaxonomy;

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -11,7 +11,7 @@ export enum AnalyticsEvents {
     CHAT_OPEN = 'chat-åpnet',
     CALL = 'ring-oss',
     VIDEO_START = 'video start',
-    VIDEO_STOP = 'video stopp'
+    VIDEO_STOP = 'video stopp',
 }
 
 export function logAmplitudeEvent(

--- a/src/utils/api-error-handler.ts
+++ b/src/utils/api-error-handler.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+
 import { logger } from 'srcCommon/logger';
 
 export const apiErrorHandler = async (

--- a/src/utils/appearance.ts
+++ b/src/utils/appearance.ts
@@ -1,4 +1,5 @@
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
+
 import { getContentLanguages } from './languages';
 
 const contentTypeWithWhiteBackground: ReadonlySet<ContentType> = new Set([
@@ -49,8 +50,5 @@ export const hasWhiteHeader = (content: ContentProps) => {
 
 export const shouldPushUpwards = (content: ContentProps) => {
     const { breadcrumbs } = content;
-    return (
-        (breadcrumbs && breadcrumbs.length > 0) ||
-        getContentLanguages(content).length > 0
-    );
+    return (breadcrumbs && breadcrumbs.length > 0) || getContentLanguages(content).length > 0;
 };

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -4,9 +4,7 @@ export const removeDuplicates = <Type>(
 ) =>
     isEqualPredicate
         ? array.filter((aItem, aIndex) => {
-              const bIndex = array.findIndex((bItem) =>
-                  isEqualPredicate(aItem, bItem)
-              );
+              const bIndex = array.findIndex((bItem) => isEqualPredicate(aItem, bItem));
               return aIndex === bIndex;
           })
         : array.filter((item, index) => array.indexOf(item) === index);

--- a/src/utils/classnames.ts
+++ b/src/utils/classnames.ts
@@ -4,8 +4,7 @@ export const BEM = (block: string) => (element?: string, mod?: string) =>
 export const classNames = (...classNames: unknown[]) =>
     classNames
         .reduce<string>(
-            (acc, className) =>
-                typeof className === 'string' ? `${acc} ${className}` : acc,
+            (acc, className) => (typeof className === 'string' ? `${acc} ${className}` : acc),
             ''
         )
         .trim();

--- a/src/utils/content-types.ts
+++ b/src/utils/content-types.ts
@@ -12,5 +12,4 @@ const legacyContentTypes: ReadonlySet<ContentType> = new Set([
     ContentType.TransportPage,
 ]);
 
-export const isLegacyContentType = (type: ContentType) =>
-    legacyContentTypes.has(type);
+export const isLegacyContentType = (type: ContentType) => legacyContentTypes.has(type);

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -4,6 +4,7 @@ import 'dayjs/locale/en';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+
 import { ContentProps } from 'types/content-props/_content-common';
 
 dayjs.extend(localizedFormat);
@@ -60,16 +61,10 @@ export const formatDate = ({
         format = 'L';
     }
 
-    return datetime
-        ? dayjs(datetime).locale(currentLocale).format(format)
-        : datetime;
+    return datetime ? dayjs(datetime).locale(currentLocale).format(format) : datetime;
 };
 
-export const formatDateTime = (
-    datetime: string,
-    locale: string = 'nb',
-    short = false
-) => {
+export const formatDateTime = (datetime: string, locale: string = 'nb', short = false) => {
     return datetime
         ? dayjs(datetime)
               .locale(locale)
@@ -77,8 +72,7 @@ export const formatDateTime = (
         : datetime;
 };
 
-export const getCurrentDateAndTime = () =>
-    new Date().toISOString().split(/[TZ.]/);
+export const getCurrentDateAndTime = () => new Date().toISOString().split(/[TZ.]/);
 
 export const getCurrentISODate = (): string => {
     return getCurrentDateAndTime()[0];
@@ -88,9 +82,8 @@ export const getUtcTimeFromLocal = (datetime: string) => {
     return dayjs(datetime).utc().format();
 };
 
-export const getPublishedDateTime = (
-    content: Pick<ContentProps, 'publish' | 'createdTime'>
-) => content.publish?.from || content.publish?.first || content.createdTime;
+export const getPublishedDateTime = (content: Pick<ContentProps, 'publish' | 'createdTime'>) =>
+    content.publish?.from || content.publish?.first || content.createdTime;
 
 export const isCurrentTimeInRange = (start?: string, end?: string) => {
     const now = dayjs();

--- a/src/utils/decorator/decorator-utils.ts
+++ b/src/utils/decorator/decorator-utils.ts
@@ -1,9 +1,10 @@
+import { DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
+
 import { Language } from 'translations';
 import { getContentLanguages } from 'utils/languages';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { LanguageProps } from 'types/language';
 import { stripXpPathPrefix } from 'utils/urls';
-import { DecoratorParams } from '@navikt/nav-dekoratoren-moduler';
 import { Audience, getAudience } from 'types/component-props/_mixins';
 import { hasWhiteHeader } from 'utils/appearance';
 
@@ -80,15 +81,11 @@ export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
     const audience = data?.audience ? getAudience(data.audience) : undefined;
 
     const rolePathSegment = _path.split('/')[2];
-    const context = audience
-        ? audienceToRoleContext[audience]
-        : pathToRoleContext[rolePathSegment];
+    const context = audience ? audienceToRoleContext[audience] : pathToRoleContext[rolePathSegment];
     const decoratorLanguage = getDecoratorLangFromXpLang(language);
     const feedbackEnabled = data?.feedbackToggle;
     const chatbotDisabled =
-        data?.chatbotToggle === false ||
-        editorView === 'edit' ||
-        editorView === 'inline';
+        data?.chatbotToggle === false || editorView === 'edit' || editorView === 'inline';
 
     return {
         ...defaultParams,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,9 @@
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { isContentTypeImplemented } from 'components/ContentMapper';
-import { stripLineBreaks } from './string';
 import { ErrorProps } from 'types/content-props/error-props';
 import { logger } from 'srcCommon/logger';
+
+import { stripLineBreaks } from './string';
 
 export const logPageLoadError = (errorId: string, message: string) =>
     logger.error(`[Page load error] ${errorId} - ${stripLineBreaks(message)}`);

--- a/src/utils/fetch/fetch-cache-content.ts
+++ b/src/utils/fetch/fetch-cache-content.ts
@@ -13,20 +13,14 @@ type JsonCacheItem = {
     };
 };
 
-export const fetchPageCacheContent = async (
-    path: string
-): Promise<ContentProps | null> => {
+export const fetchPageCacheContent = async (path: string): Promise<ContentProps | null> => {
     if (!path) {
         return null;
     }
 
-    const jsonCacheUrl = `${urlPrefix}${stripXpPathPrefix(
-        path.split('#')[0]
-    )}.json`;
+    const jsonCacheUrl = `${urlPrefix}${stripXpPathPrefix(path.split('#')[0])}.json`;
 
-    return fetchJson<JsonCacheItem>(jsonCacheUrl, undefined, undefined, 2).then(
-        (cacheItem) => {
-            return cacheItem?.pageProps?.content || null;
-        }
-    );
+    return fetchJson<JsonCacheItem>(jsonCacheUrl, undefined, undefined, 2).then((cacheItem) => {
+        return cacheItem?.pageProps?.content || null;
+    });
 };

--- a/src/utils/fetch/fetch-cache-key.ts
+++ b/src/utils/fetch/fetch-cache-key.ts
@@ -19,9 +19,7 @@ type GetCacheKeyResponse = {
 // used on newly spun up containers.
 export const fetchAndSetCacheKey = async (retries = 5): Promise<void> => {
     if (!retries || retries < 0) {
-        logger.error(
-            'Failed to fetch cache key from revalidator-proxy, no more retries remaining'
-        );
+        logger.error('Failed to fetch cache key from revalidator-proxy, no more retries remaining');
         return;
     }
 
@@ -41,9 +39,7 @@ export const fetchAndSetCacheKey = async (retries = 5): Promise<void> => {
             }
         })
         .catch((e) => {
-            logger.error(
-                `Error while fetching cache key, ${retries} retries remaining - ${e}`
-            );
+            logger.error(`Error while fetching cache key, ${retries} retries remaining - ${e}`);
             return fetchAndSetCacheKey(retries - 1);
         });
 };

--- a/src/utils/fetch/fetch-content.ts
+++ b/src/utils/fetch/fetch-content.ts
@@ -1,12 +1,13 @@
+import { v4 as uuid } from 'uuid';
+import { PHASE_PRODUCTION_BUILD } from 'next/constants';
+
 import { ContentProps } from 'types/content-props/_content-common';
 import { makeErrorProps } from 'utils/make-error-props';
 import { stripXpPathPrefix, xpServiceUrl } from 'utils/urls';
 import { fetchWithTimeout, objectToQueryString } from 'srcCommon/fetch-utils';
 import { MediaProps } from 'types/media';
-import { v4 as uuid } from 'uuid';
 import { logPageLoadError } from 'utils/errors';
 import { stripLineBreaks } from 'utils/string';
-import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import { logger } from 'srcCommon/logger';
 import { RedisCache } from 'srcCommon/redis';
 
@@ -103,11 +104,7 @@ const fetchSiteContentVersion = async ({
     });
 };
 
-const fetchSiteContentArchive = async ({
-    idOrPath,
-    locale,
-    time,
-}: FetchSiteContentArgs) => {
+const fetchSiteContentArchive = async ({ idOrPath, locale, time }: FetchSiteContentArgs) => {
     const params = objectToQueryString({
         id: idOrPath,
         ...(locale && { locale }),
@@ -149,12 +146,8 @@ const fetchAndHandleErrorsBuildtime = async (
     });
 };
 
-const isCachableRequest = ({
-    isDraft,
-    isArchived,
-    time,
-    isPreview,
-}: FetchSiteContentArgs) => !(isDraft || isArchived || time || isPreview);
+const isCachableRequest = ({ isDraft, isArchived, time, isPreview }: FetchSiteContentArgs) =>
+    !(isDraft || isArchived || time || isPreview);
 
 const fetchAndHandleErrorsRuntime = async (
     props: FetchSiteContentArgs
@@ -163,9 +156,7 @@ const fetchAndHandleErrorsRuntime = async (
     const { idOrPath } = props;
 
     if (isCachable) {
-        const cachedResponse = await redisCache.getResponse(
-            stripXpPathPrefix(idOrPath)
-        );
+        const cachedResponse = await redisCache.getResponse(stripXpPathPrefix(idOrPath));
         if (cachedResponse) {
             logger.info(`Response cache hit for ${idOrPath}`);
             return cachedResponse;
@@ -180,9 +171,7 @@ const fetchAndHandleErrorsRuntime = async (
         return makeErrorProps(idOrPath, undefined, 500, errorId);
     }
 
-    const isJson = res.headers
-        ?.get('content-type')
-        ?.includes?.('application/json');
+    const isJson = res.headers?.get('content-type')?.includes?.('application/json');
 
     if (res.ok && isJson) {
         const json = await res.json();
@@ -200,9 +189,7 @@ const fetchAndHandleErrorsRuntime = async (
         return makeErrorProps(idOrPath, undefined, 500, errorId);
     }
 
-    const errorMsg = isJson
-        ? (await res.json()).message || res.statusText
-        : res.statusText;
+    const errorMsg = isJson ? (await res.json()).message || res.statusText : res.statusText;
 
     if (res.status === 404) {
         // If we get an unexpected 404-error from the sitecontent-service (meaning the service itself

--- a/src/utils/fetch/fetch-images.ts
+++ b/src/utils/fetch/fetch-images.ts
@@ -1,13 +1,13 @@
 import fs, { readFileSync } from 'fs';
 import pLimit from 'p-limit';
+
 import { removeDuplicates } from 'utils/arrays';
 import { logger } from 'srcCommon/logger';
 
 // Limit concurrent fetches
 const limit = pLimit(5);
 
-const manifestDir =
-    (typeof process.env !== 'undefined' && process.env.IMAGE_CACHE_DIR) || '.';
+const manifestDir = (typeof process.env !== 'undefined' && process.env.IMAGE_CACHE_DIR) || '.';
 
 const manifestFile = `${manifestDir}/image-manifest`;
 
@@ -54,9 +54,7 @@ export const processImageManifest = async () => {
                     if (res.ok) {
                         return true;
                     }
-                    logger.error(
-                        `Bad response for image ${url} - ${res.status} ${res.statusText}`
-                    );
+                    logger.error(`Bad response for image ${url} - ${res.status} ${res.statusText}`);
                     return false;
                 })
                 .catch((e) => {

--- a/src/utils/fetch/fetch-innloggingsstatus.ts
+++ b/src/utils/fetch/fetch-innloggingsstatus.ts
@@ -12,13 +12,9 @@ type InnloggingsstatusResponse =
     | { authenticated: false };
 
 export const fetchAndSetInnloggingsstatus = () =>
-    fetchJson<InnloggingsstatusResponse>(
-        process.env.INNLOGGINGSSTATUS_URL,
-        5000,
-        {
-            credentials: 'include',
-        }
-    ).then((res) => {
+    fetchJson<InnloggingsstatusResponse>(process.env.INNLOGGINGSSTATUS_URL, 5000, {
+        credentials: 'include',
+    }).then((res) => {
         if (!res) {
             logger.error('Failed to fetch innloggingsstatus');
             store.dispatch(setAuthStateAction({ authState: 'loggedOut' }));

--- a/src/utils/fetch/fetch-page-props.ts
+++ b/src/utils/fetch/fetch-page-props.ts
@@ -5,7 +5,6 @@ import {
     sanitizeLegacyUrl,
     stripXpPathPrefix,
 } from 'utils/urls';
-import { fetchPage } from './fetch-content';
 import { isMediaContent } from 'types/media';
 import { errorHandler, isNotFound } from 'utils/errors';
 import { ContentType } from 'types/content-props/_content-common';
@@ -17,6 +16,8 @@ import {
 } from 'utils/redirects';
 import { errorMessageURIError, makeErrorProps } from 'utils/make-error-props';
 import { logger } from 'srcCommon/logger';
+
+import { fetchPage } from './fetch-content';
 
 type FetchPagePropsArgs = {
     routerQuery?: string | string[];
@@ -54,13 +55,7 @@ export const fetchPageProps = async ({
     const idOrPath = routerQueryToXpPathOrId(routerQuery || '');
 
     if (!isValidIdOrPath(idOrPath)) {
-        return errorHandler(
-            makeErrorProps(
-                stripXpPathPrefix(idOrPath),
-                errorMessageURIError,
-                400
-            )
-        );
+        return errorHandler(makeErrorProps(stripXpPathPrefix(idOrPath), errorMessageURIError, 400));
     }
 
     const content = await fetchPage({

--- a/src/utils/fetch/fetch-prerender-paths.ts
+++ b/src/utils/fetch/fetch-prerender-paths.ts
@@ -6,9 +6,7 @@ const excludedPaths: ReadonlySet<string> = new Set([
     '/', // This is already rendered by /index.tsx
 ]);
 
-export const fetchPrerenderPaths = async (
-    retries = 3
-): Promise<string[] | null> =>
+export const fetchPrerenderPaths = async (retries = 3): Promise<string[] | null> =>
     fetchJson<string[]>(`${xpServiceUrl}/sitecontentPaths`, 60000, {
         headers: {
             secret: process.env.SERVICE_SECRET,
@@ -27,9 +25,7 @@ export const fetchPrerenderPaths = async (
             }
 
             if (retries > 0) {
-                logger.warn(
-                    `Failed to fetch paths to prerender, ${retries} retries left`
-                );
+                logger.warn(`Failed to fetch paths to prerender, ${retries} retries left`);
                 return fetchPrerenderPaths(retries - 1);
             }
 

--- a/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
+++ b/src/utils/fetch/useSWRImmutableOnScrollIntoView.ts
@@ -32,9 +32,7 @@ export const useSWRImmutableOnScrollIntoView = <FetchResponse>({
     fetchFunc,
     elementId,
 }: Props<FetchResponse>) => {
-    const [isScrolledIntoView, setIsScrolledIntoView] = useState(
-        isNearOrAboveViewport(elementId)
-    );
+    const [isScrolledIntoView, setIsScrolledIntoView] = useState(isNearOrAboveViewport(elementId));
 
     const result = useSWRImmutable(isScrolledIntoView ? url : null, fetchFunc);
 

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -6,5 +6,4 @@ export const getContentLanguages = (content: ContentProps): LanguageProps[] =>
 
 const norwegianLanguagesSet: ReadonlySet<string> = new Set(['no', 'nn', 'nb']);
 
-export const isNorwegianLanguage = (language: string) =>
-    norwegianLanguagesSet.has(language);
+export const isNorwegianLanguage = (language: string) => norwegianLanguagesSet.has(language);

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,5 +1,6 @@
-import { getInternalRelativePath, isAppUrl } from './urls';
 import { NextRouter } from 'next/router';
+
+import { getInternalRelativePath, isAppUrl } from './urls';
 
 const elementIsAnchor = (element: HTMLElement): element is HTMLAnchorElement =>
     element.tagName?.toLowerCase() === 'a';
@@ -9,9 +10,7 @@ const getLinkHref = (element: HTMLElement | null): string | null => {
         return null;
     }
     if (elementIsAnchor(element)) {
-        return !element.href || element.href.includes('#')
-            ? null
-            : element.href;
+        return !element.href || element.href.includes('#') ? null : element.href;
     }
     return getLinkHref(element.parentElement);
 };

--- a/src/utils/make-error-props.ts
+++ b/src/utils/make-error-props.ts
@@ -29,9 +29,7 @@ export const makeErrorProps = (
     errorId?: string
 ): ErrorProps => {
     const publicMessage =
-        errorMessageByMessage(errorMessage) ||
-        errorMessageByCode[errorCode] ||
-        errorMessageDefault;
+        errorMessageByMessage(errorMessage) || errorMessageByCode[errorCode] || errorMessageDefault;
     const title = `Feil: ${publicMessage}`;
     const time = Date.now().toString();
 
@@ -55,5 +53,4 @@ export const makeErrorProps = (
     };
 };
 
-export const make404Props = (idOrPath = '') =>
-    makeErrorProps(idOrPath, 'Fant ikke siden', 404);
+export const make404Props = (idOrPath = '') => makeErrorProps(idOrPath, 'Fant ikke siden', 404);

--- a/src/utils/match-media.ts
+++ b/src/utils/match-media.ts
@@ -9,16 +9,12 @@ const matchMediaLegacy = (mql: MediaQueryList) => {
     }
 
     // @ts-ignore
-    mql.addEventListener = (
-        _: string,
-        callback: (e: MediaQueryListEvent) => void
-    ) => mql.addListener(callback);
+    mql.addEventListener = (_: string, callback: (e: MediaQueryListEvent) => void) =>
+        mql.addListener(callback);
 
     // @ts-ignore
-    mql.removeEventListener = (
-        _: string,
-        callback: (e: MediaQueryListEvent) => void
-    ) => mql.removeListener(callback);
+    mql.removeEventListener = (_: string, callback: (e: MediaQueryListEvent) => void) =>
+        mql.removeListener(callback);
 
     return mql;
 };

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -2,10 +2,7 @@ const isRecord = (obj: unknown): obj is Record<string, unknown> =>
     !!(obj && typeof obj === 'object' && !Array.isArray(obj));
 
 // Get a nested object value from an array of keys
-export const getNestedValueFromKeyArray = (
-    obj: unknown,
-    keys: string[]
-): unknown => {
+export const getNestedValueFromKeyArray = (obj: unknown, keys: string[]): unknown => {
     if (keys.length === 0 || !isRecord(obj)) {
         return null;
     }
@@ -21,9 +18,6 @@ export const getNestedValueFromKeyArray = (
 };
 
 // Get a nested object value from a dot-delimited string of keys
-export const getNestedValueFromKeyString = (
-    obj: Record<string, any>,
-    keysString: string
-) => {
+export const getNestedValueFromKeyString = (obj: Record<string, any>, keysString: string) => {
     return getNestedValueFromKeyArray(obj, keysString.split('.'));
 };

--- a/src/utils/react-children.ts
+++ b/src/utils/react-children.ts
@@ -1,6 +1,8 @@
-import { Children, isValidElement, ReactElement, ReactNode } from "react";
+import { Children, isValidElement, ReactElement, ReactNode } from 'react';
 
-export const hasChildren = (element: ReactNode): element is ReactElement<{ children: ReactNode | ReactNode[] }> =>
+export const hasChildren = (
+    element: ReactNode
+): element is ReactElement<{ children: ReactNode | ReactNode[] }> =>
     isValidElement<{ children?: ReactNode[] }>(element) && Boolean(element.props.children);
 
 export const childToString = (child?: ReactNode): string => {

--- a/src/utils/react.ts
+++ b/src/utils/react.ts
@@ -1,5 +1,4 @@
 import { useLayoutEffect } from 'react';
 
 // Hack to prevent irrelevant React warning for useLayoutEffect server-side
-export const useLayoutEffectClientSide =
-    typeof window !== 'undefined' ? useLayoutEffect : () => {};
+export const useLayoutEffectClientSide = typeof window !== 'undefined' ? useLayoutEffect : () => {};

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -1,7 +1,8 @@
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
+import { ProductDataMixin } from 'types/component-props/_mixins';
+
 import { stripXpPathPrefix } from './urls';
 import { getInternalLinkUrl } from './links-from-content';
-import { ProductDataMixin } from 'types/component-props/_mixins';
 
 const redirectTypes: { [type in ContentType]?: boolean } = {
     [ContentType.InternalLink]: true,
@@ -13,18 +14,13 @@ type ContentWithExternalProductUrl = ContentProps & {
     data: Pick<ProductDataMixin, 'externalProductUrl'>;
 };
 
-const hasExternalProductUrl = (
-    content: ContentProps
-): content is ContentWithExternalProductUrl => {
-    return !!(content as ContentWithExternalProductUrl).data
-        ?.externalProductUrl;
+const hasExternalProductUrl = (content: ContentProps): content is ContentWithExternalProductUrl => {
+    return !!(content as ContentWithExternalProductUrl).data?.externalProductUrl;
 };
 
 const getTargetPath = (content: ContentProps) => {
     if (hasExternalProductUrl(content)) {
-        return content.isDraft || content.isPagePreview
-            ? null
-            : content.data.externalProductUrl;
+        return content.isDraft || content.isPagePreview ? null : content.data.externalProductUrl;
     }
 
     switch (content.type) {
@@ -38,16 +34,13 @@ const getTargetPath = (content: ContentProps) => {
             // we want to redirect to the actual content page. This is provided as a way
             // to gradually migrate individual pages from the chapter structure
             const { article } = content.data;
-            return article && article.type !== ContentType.MainArticle
-                ? article._path
-                : null;
+            return article && article.type !== ContentType.MainArticle ? article._path : null;
         default:
             return null;
     }
 };
 
-export const isRedirectType = (content: ContentProps) =>
-    redirectTypes[content.type];
+export const isRedirectType = (content: ContentProps) => redirectTypes[content.type];
 
 export const getTargetIfRedirect = (contentData: ContentProps) => {
     const targetPath = getTargetPath(contentData);
@@ -55,10 +48,7 @@ export const getTargetIfRedirect = (contentData: ContentProps) => {
 };
 
 // Used for redirect from a next.js data fetch function
-export const redirectPageProps = (
-    destination: string,
-    isPermanent: boolean
-) => ({
+export const redirectPageProps = (destination: string, isPermanent: boolean) => ({
     props: {},
     redirect: {
         // Decode then (re)encode to ensure the destination is not double-encoded
@@ -69,10 +59,7 @@ export const redirectPageProps = (
 });
 
 export const isPermanentRedirect = (content: ContentProps) => {
-    if (
-        content.type === ContentType.InternalLink ||
-        content.type === ContentType.ExternalLink
-    ) {
+    if (content.type === ContentType.InternalLink || content.type === ContentType.ExternalLink) {
         return !!content.data.permanentRedirect;
     }
 

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -1,6 +1,5 @@
 const hasScrollOptionsSupport =
-    typeof document !== 'undefined' &&
-    'scrollBehavior' in document.documentElement.style;
+    typeof document !== 'undefined' && 'scrollBehavior' in document.documentElement.style;
 
 const scrollToCurrent = (position: number) => {
     window.scrollTo({
@@ -12,9 +11,7 @@ const scrollToLegacy = (position: number) => {
     window.scrollTo(0, position);
 };
 
-export const windowScrollTo = hasScrollOptionsSupport
-    ? scrollToCurrent
-    : scrollToLegacy;
+export const windowScrollTo = hasScrollOptionsSupport ? scrollToCurrent : scrollToLegacy;
 
 export const smoothScrollToTarget = (targetId: string, offset = 0) => {
     const targetElement = document.getElementById(targetId);

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,9 +1,7 @@
 import { ContentProps } from 'types/content-props/_content-common';
 
 const getLastUpdatedUnixTime = (content: ContentProps) =>
-    new Date(
-        content.modifiedTime.split('.')[0] || content.createdTime.split('.')[0]
-    ).getTime();
+    new Date(content.modifiedTime.split('.')[0] || content.createdTime.split('.')[0]).getTime();
 
 export const sortContentByLastModified = (a: ContentProps, b: ContentProps) =>
     getLastUpdatedUnixTime(b) - getLastUpdatedUnixTime(a);

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,10 +1,7 @@
 import { Language, translator } from 'translations';
 import { Taxonomy } from 'types/taxonomies';
 
-export const joinWithConjunction = (
-    joinableArray: string[],
-    language: Language
-): string => {
+export const joinWithConjunction = (joinableArray: string[], language: Language): string => {
     if (!Array.isArray(joinableArray)) {
         return '';
     }
@@ -37,10 +34,7 @@ export const getConjunction = ({
     }
 };
 
-export const getTranslatedTaxonomies = (
-    taxonomies: Taxonomy[],
-    language: Language
-): string[] => {
+export const getTranslatedTaxonomies = (taxonomies: Taxonomy[], language: Language): string[] => {
     if (!Array.isArray(taxonomies)) {
         return [];
     }
@@ -89,11 +83,7 @@ export const capitalize = (str: string) =>
         })
         .join(' ');
 
-export const shortenText = (
-    text: string,
-    maxLength: number,
-    maxOverflowLength: number = 0
-) => {
+export const shortenText = (text: string, maxLength: number, maxOverflowLength: number = 0) => {
     if (!!text && text.length > maxLength + maxOverflowLength) {
         return text.substring(0, maxLength) + '...';
     }

--- a/src/utils/urls.test.ts
+++ b/src/utils/urls.test.ts
@@ -1,9 +1,4 @@
-import {
-    adminOrigin,
-    stripXpPathPrefix,
-    xpContentPathPrefix,
-    xpDraftPathPrefix,
-} from 'utils/urls';
+import { adminOrigin, stripXpPathPrefix, xpContentPathPrefix, xpDraftPathPrefix } from 'utils/urls';
 
 describe('stripXpPathPrefix', () => {
     test('Should strip content path prefix', () => {
@@ -16,9 +11,7 @@ describe('stripXpPathPrefix', () => {
     test('Should strip admin preview path prefixes', () => {
         const desiredUrl = '/foo/bar';
 
-        const url = stripXpPathPrefix(
-            `${adminOrigin}${xpDraftPathPrefix}${desiredUrl}`
-        );
+        const url = stripXpPathPrefix(`${adminOrigin}${xpDraftPathPrefix}${desiredUrl}`);
         expect(url).toEqual(desiredUrl);
     });
 

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -5,8 +5,7 @@ export const appOriginProd = 'https://www.nav.no';
 export const xpContentPathPrefix = '/www.nav.no';
 export const xpServicePath = '/_/service/no.nav.navno';
 export const xpDraftPathPrefix = `/admin/site/preview/default/draft${xpContentPathPrefix}`;
-export const editorPathPrefix =
-    '/admin/tool/com.enonic.app.contentstudio/main/default/edit';
+export const editorPathPrefix = '/admin/tool/com.enonic.app.contentstudio/main/default/edit';
 
 export const xpOrigin = process.env.XP_ORIGIN;
 export const appOrigin = process.env.APP_ORIGIN;
@@ -37,15 +36,10 @@ const internalPaths = [
 ];
 
 const relativeAppUrlPattern = '^\\/(?!_\\/)'; // /_/* is used for Enonic XP services and assets
-const absoluteAppUrlPattern = `^${internalUrlPrefix}($|\\/(${internalPaths.join(
-    '|'
-)}))`;
+const absoluteAppUrlPattern = `^${internalUrlPrefix}($|\\/(${internalPaths.join('|')}))`;
 
 // Matches both relative and absolute urls which points to any content internal to the app
-const appUrlPattern = new RegExp(
-    `(${absoluteAppUrlPattern})|(${relativeAppUrlPattern})`,
-    'i'
-);
+const appUrlPattern = new RegExp(`(${absoluteAppUrlPattern})|(${relativeAppUrlPattern})`, 'i');
 export const isAppUrl = (url: string) => !!(url && appUrlPattern.test(url));
 
 // Matches urls which can be cached by next-image
@@ -53,22 +47,19 @@ const validImageUrlPattern = new RegExp(
     `^((${appOrigin}|${appOriginProd})?\\/)|((${xpOrigin})?(\\/_\\/))`,
     'i'
 );
-export const isValidImageUrl = (url: string) =>
-    url && validImageUrlPattern.test(url);
+export const isValidImageUrl = (url: string) => url && validImageUrlPattern.test(url);
 
 // Matches urls pointing directly to XP (/_/*)
 const xpUrlPattern = new RegExp(`${internalUrlPrefix}/_`, 'i');
 export const isXpUrl = (url: string) => url && xpUrlPattern.test(url);
 
-export const isInternalUrl = (url: string) =>
-    url && (isAppUrl(url) || isXpUrl(url));
+export const isInternalUrl = (url: string) => url && (isAppUrl(url) || isXpUrl(url));
 
 // Matches urls which should have the nofollow flag
 const nofollowPattern = new RegExp(`^(${appOrigin})?(\\/sok($|\\?|\\/))`, 'i');
 export const isNofollowUrl = (url: string) => nofollowPattern.test(url);
 
-export const stripXpPathPrefix = (path: string) =>
-    path?.replace(xpPathPrefixPattern, '');
+export const stripXpPathPrefix = (path: string) => path?.replace(xpPathPrefixPattern, '');
 
 export const getInternalRelativePath = (url: string, isEditorView: boolean) => {
     const relativePath = url.replace(internalUrlPrefixPattern, '');
@@ -80,10 +71,7 @@ export const getInternalRelativePath = (url: string, isEditorView: boolean) => {
     return relativePath || '/';
 };
 
-export const getRelativePathIfInternal = (
-    url: string,
-    isEditorView: boolean
-) => {
+export const getRelativePathIfInternal = (url: string, isEditorView: boolean) => {
     if (!isInternalUrl(url)) {
         return url;
     }
@@ -104,10 +92,7 @@ export const getInternalAbsoluteUrl = (url: string, isEditorView: boolean) => {
 
 // Media url must always be absolute, to prevent internal nextjs routing loopbacks on redirects
 export function getMediaUrl(url: string, isEditorView: boolean): string;
-export function getMediaUrl(
-    url: string | undefined,
-    isEditorView: boolean
-): string | undefined;
+export function getMediaUrl(url: string | undefined, isEditorView: boolean): string | undefined;
 export function getMediaUrl(url: string | undefined, isEditorView: boolean) {
     return url?.replace(
         internalUrlPrefixPattern,
@@ -115,14 +100,10 @@ export function getMediaUrl(url: string | undefined, isEditorView: boolean) {
     );
 }
 
-export const getPublicPathname = (content: ContentProps) =>
-    stripXpPathPrefix(content._path);
+export const getPublicPathname = (content: ContentProps) => stripXpPathPrefix(content._path);
 
 export const isUUID = (id: string) =>
-    id &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-        id
-    );
+    id && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
 
 export const sanitizeLegacyUrl = (url: string) =>
     url
@@ -135,16 +116,13 @@ export const sanitizeLegacyUrl = (url: string) =>
 
 // Requests from content-studio can be either a path or UUID, we check for both
 export const routerQueryToXpPathOrId = (routerQuery: string | string[]) => {
-    const possibleId =
-        typeof routerQuery === 'string' ? routerQuery : routerQuery[0];
+    const possibleId = typeof routerQuery === 'string' ? routerQuery : routerQuery[0];
 
     if (isUUID(possibleId)) {
         return possibleId;
     }
 
-    const path = `/${
-        typeof routerQuery === 'string' ? routerQuery : routerQuery.join('/')
-    }`;
+    const path = `/${typeof routerQuery === 'string' ? routerQuery : routerQuery.join('/')}`;
 
     return `${xpContentPathPrefix}${path}`;
 };

--- a/src/utils/useClient.ts
+++ b/src/utils/useClient.ts
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+
 import { useIsClientSide } from './useIsClientSide';
 
 export const useClient = () => {

--- a/src/utils/usePublicUrl.ts
+++ b/src/utils/usePublicUrl.ts
@@ -1,10 +1,6 @@
-import {
-    getInternalRelativePath,
-    isAppUrl,
-    isInternalUrl,
-    stripXpPathPrefix,
-} from './urls';
 import { usePageContentProps } from 'store/pageContext';
+
+import { getInternalRelativePath, isAppUrl, isInternalUrl, stripXpPathPrefix } from './urls';
 
 type ReturnValue = {
     url: string;

--- a/src/utils/useStickyScroll.ts
+++ b/src/utils/useStickyScroll.ts
@@ -12,9 +12,7 @@ export const useScrollPosition = (element: HTMLElement | null) => {
     const scrollBackToElement = () => {
         if (element) {
             const targetScrollPosition =
-                element.getBoundingClientRect().top +
-                window.scrollY -
-                scrollPositionRef.current;
+                element.getBoundingClientRect().top + window.scrollY - scrollPositionRef.current;
 
             const scrollOptions: ScrollToOptions = {
                 top: targetScrollPosition,

--- a/srcCommon/cache-key.ts
+++ b/srcCommon/cache-key.ts
@@ -1,2 +1,1 @@
-export const pathToCacheKey = (path: string) =>
-    path === '/' ? '/index' : path;
+export const pathToCacheKey = (path: string) => (path === '/' ? '/index' : path);

--- a/srcCommon/logger.ts
+++ b/srcCommon/logger.ts
@@ -2,8 +2,7 @@ import pino, { LoggerOptions } from 'pino';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 
 const isBuildPhase =
-    typeof process.env !== 'undefined' &&
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
+    typeof process.env !== 'undefined' && process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
 
 const options: LoggerOptions =
     process.env.ENV === 'localhost' || isBuildPhase

--- a/srcCommon/redis.ts
+++ b/srcCommon/redis.ts
@@ -1,8 +1,9 @@
 import { createClient, RedisClientOptions } from 'redis';
-import { logger } from 'srcCommon/logger';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
-import { TIME_24_HOURS_IN_MS, TIME_72_HOURS_IN_MS } from 'srcCommon/constants';
 import { CacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
+
+import { logger } from 'srcCommon/logger';
+import { TIME_24_HOURS_IN_MS, TIME_72_HOURS_IN_MS } from 'srcCommon/constants';
 import { pathToCacheKey } from 'srcCommon/cache-key';
 
 // TODO: share XP response props with next-app for a proper type here

--- a/srcCommon/redis.ts
+++ b/srcCommon/redis.ts
@@ -16,11 +16,7 @@ const clientOptions: RedisClientOptions = {
 } as const;
 
 const validateClientOptions = () => {
-    const isValid = !!(
-        clientOptions.url &&
-        clientOptions.username &&
-        clientOptions.password
-    );
+    const isValid = !!(clientOptions.url && clientOptions.username && clientOptions.password);
 
     if (!isValid) {
         logger.error(`Client options for Redis has missing parameters!`);
@@ -75,9 +71,7 @@ class RedisCacheImpl {
             })
             .then((result) => (result ? JSON.parse(result) : result))
             .catch((e) => {
-                logger.error(
-                    `Error getting render cache value for key ${key} - ${e}`
-                );
+                logger.error(`Error getting render cache value for key ${key} - ${e}`);
                 return Promise.resolve(null);
             });
     }
@@ -108,11 +102,7 @@ class RedisCacheImpl {
     }
 
     public async setRender(key: string, data: CacheHandlerValue) {
-        return this.set(
-            this.getFullKey(key, this.renderCacheKeyPrefix),
-            this.renderCacheTTL,
-            data
-        );
+        return this.set(this.getFullKey(key, this.renderCacheKeyPrefix), this.renderCacheTTL, data);
     }
 
     public async setResponse(key: string, data: XpResponseProps) {
@@ -157,7 +147,6 @@ export const RedisCache =
         ? RedisCacheImpl
         : RedisCacheDummy;
 
-export const getRenderCacheKeyPrefix = (buildId: string) =>
-    `${process.env.ENV}:render:${buildId}`;
+export const getRenderCacheKeyPrefix = (buildId: string) => `${process.env.ENV}:render:${buildId}`;
 
 export const getResponseCacheKeyPrefix = () => `${process.env.ENV}:xp-response`;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Legger til eslint-regel for rekkefølge på imports. Mitt forslag er grupperinger i denne rekkefølgen, med newline mellom hver gruppe:
  1. Eksterne/innebygde moduler
  2. Alle typer interne moduler, med unntak av "siblings" (altså moduler i samme mappe)
  3. Siblings
  4. SCSS modules

Kjører også eslint --fix og prettier --write så vi slipper at denne og andre nylige linting-endringer forurenser PR'ene fremover.