### PR TITLE
Fjerner innstillinger for varehylle i flex-cols

### DIFF
--- a/src/components/layouts/LayoutContainer.tsx
+++ b/src/components/layouts/LayoutContainer.tsx
@@ -12,7 +12,6 @@ type Props = {
     pageProps: ContentProps;
     layoutProps: LayoutComponentProps;
     layoutStyle?: React.CSSProperties;
-    modifiers?: string[];
     children: React.ReactNode;
 } & React.HTMLAttributes<HTMLDivElement>;
 
@@ -20,7 +19,6 @@ export const LayoutContainer = ({
     pageProps,
     layoutProps,
     layoutStyle,
-    modifiers,
     children,
     ...divElementProps
 }: Props) => {
@@ -44,7 +42,6 @@ export const LayoutContainer = ({
             className={classNames(
                 style.layout,
                 bem(layoutName),
-                ...(modifiers ? modifiers.map((mod) => bem(layoutName, mod)) : []),
                 paddingConfig === 'fullWidth' && style.fullwidth,
                 paddingConfig === 'standard' && style.standard,
                 config.bgColor?.color && style.bg,

--- a/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
@@ -20,7 +20,7 @@ export const SituationPageFlexColsLayout = ({ pageProps, layoutProps }: Props) =
     }
 
     const { config } = layoutProps;
-    const { title, numCols, justifyContent, anchorId, toggleCopyButton, shelf } = config;
+    const { title, numCols, justifyContent, anchorId, toggleCopyButton } = config;
 
     const regionStyle = {
         ...(justifyContent && { justifyContent }),
@@ -32,20 +32,11 @@ export const SituationPageFlexColsLayout = ({ pageProps, layoutProps }: Props) =
 
     const colCount = typeof numCols === 'number' ? numCols : calculateColCount();
 
-    const buildModifiers = () => {
-        if (!shelf?._selected) {
-            return [];
-        }
-
-        return [shelf._selected];
-    };
-
     return (
         <LayoutContainer
             className={`${style.layoutSituationOrProduct} ${style.layoutSituation}`}
             pageProps={pageProps}
             layoutProps={layoutProps}
-            modifiers={buildModifiers()}
         >
             {title && (
                 <Header

--- a/src/types/component-props/layouts/situation-flex-cols.ts
+++ b/src/types/component-props/layouts/situation-flex-cols.ts
@@ -8,11 +8,6 @@ export interface SituationPageFlexColsLayoutProps extends LayoutBaseProps {
     type: ComponentType.Layout;
     descriptor: LayoutType.SituationPageFlexCols;
     regions: Regions<'flexcols'>;
-    config: {
-        shelf: OptionSetSingle<{
-            products: { priority: 'primary' | 'secondary' | 'tertiary' };
-            provider: {};
-        }>;
-    } & Pick<FlexColsLayoutProps['config'], 'justifyContent' | 'numCols' | 'bgColor'> &
+    config: Pick<FlexColsLayoutProps['config'], 'justifyContent' | 'numCols' | 'bgColor'> &
         HeaderWithAnchorMixin;
 }

--- a/src/types/component-props/layouts/situation-flex-cols.ts
+++ b/src/types/component-props/layouts/situation-flex-cols.ts
@@ -1,7 +1,6 @@
 import { LayoutBaseProps, LayoutType, Regions } from 'types/component-props/layouts';
 import { ComponentType } from 'types/component-props/_component-common';
 import { HeaderWithAnchorMixin } from 'types/component-props/_mixins';
-import { OptionSetSingle } from 'types/util-types';
 import { FlexColsLayoutProps } from './flex-cols';
 
 export interface SituationPageFlexColsLayoutProps extends LayoutBaseProps {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Intensjonen med innstillingen var å kunne angi at en flex-col er en varehylle og hvilken type varehylle den er. Jeg har søkt igjennom og gjort en query etter sider hvor denne funksjonen er brukt, og finner ingen. Har også bekreftet med Tuva at den kan fjernes.

Den faktiske stylingen som skulle angi forskjellig bakgrunnsfarge på varehyllen ser også til å ha falt ut iløpet av året, så denne funksjonen hadde ikke fungert som tenkt uansett.

## Testing
Testes i dev.