### PR TITLE
Legger til korrekt tagline for hjelpemiddelsentral

### DIFF
--- a/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.module.scss
+++ b/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.module.scss
@@ -56,6 +56,7 @@
     text-align: left;
     white-space: nowrap;
     display: flex;
+    text-transform: uppercase;
 
     @media #{common.$mq-screen-mobile} {
         margin-bottom: 0.5rem;

--- a/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.tsx
+++ b/src/components/pages/office-branch-page/office-page-header/OfficePageHeader.tsx
@@ -4,6 +4,7 @@ import { AudienceReception } from '@navikt/nav-office-reception-info';
 import { classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { joinWithConjunction } from 'utils/string';
+import { Language, translator } from 'translations';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 
 import style from './OfficePageHeader.module.scss';
@@ -16,6 +17,7 @@ type Props = {
 export const OfficePageHeader = ({ officeDetails }: Props) => {
     const { navn, brukerkontakt } = officeDetails;
     const { language } = usePageContentProps();
+    const officeTranslations = translator('office', language);
 
     const getSubtitle = (publikumsmottak: AudienceReception[]) => {
         if (!Array.isArray(publikumsmottak) || publikumsmottak.length < 2) {
@@ -35,6 +37,11 @@ export const OfficePageHeader = ({ officeDetails }: Props) => {
 
     const subTitle = getSubtitle(brukerkontakt?.publikumsmottak);
 
+    const tagline =
+        officeDetails.type === 'HMS'
+            ? officeTranslations('taglineHMS')
+            : officeTranslations('taglineOffice');
+
     return (
         <div className={classNames(style.officePageHeader)}>
             <div className={style.content}>
@@ -43,7 +50,7 @@ export const OfficePageHeader = ({ officeDetails }: Props) => {
                 </Heading>
                 <div className={style.taglineWrapper}>
                     <BodyShort size="small" className={style.taglineLabel}>
-                        {'NAV-KONTOR'}
+                        {tagline}
                     </BodyShort>
                     {subTitle && (
                         <>

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -277,6 +277,8 @@ export const translationsBundleNb = {
         phoneInformation:
             'Telefontid hverdager kl. 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
         alternativeContacts: 'Andre kontaktopplysninger:',
+        taglineOffice: 'NAV-kontor',
+        taglineHMS: 'Hjelpemiddelsentral',
     },
     dateTime: {
         weekDayNames: {

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -154,6 +154,8 @@ export const translationsBundleEn: PartialTranslations = {
         phoneInformation:
             'Phone hours, weekdays at 9-15. NAV call center will assist you or connect you with your NAV office.',
         alternativeContacts: 'Other contact options:',
+        taglineOffice: 'NAV office',
+        taglineHMS: 'Assistive technology centre',
     },
     dateTime: {
         weekDayNames: {

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -186,6 +186,8 @@ export const translationsBundleNn: PartialTranslations = {
         phoneInformation:
             'Telefontid kvardagar kl 9–15. NAV Kontaktsenter kan hjelpe deg, eller sette deg i kontakt med NAV-kontoret ditt.',
         alternativeContacts: 'Andre kontaktopplysningar:',
+        taglineOffice: 'NAV-kontor',
+        taglineHMS: 'Hjelpemiddelsentral',
     },
     overview: {
         noHits: 'Ingen treff med dei valde filtera.',


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sjekker kontortype og setter korrekt tagline, enten "NAV-KONTOR eller HJELPEMIDDELSENTRAL"

![Screenshot 2024-04-16 at 16 48 07](https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/d3abcf30-6f49-4d5d-8dac-b1dac21be5d1)

