### PR TITLE
Fikser layoutfeil i oversiktssider, blant annet saksbehandlingstider

### DIFF
--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -63,6 +63,11 @@ $separator-attribs: 1px $color solid;
     height: 56px;
     flex-shrink: 0;
 
+    @media #{common.$mq-screen-mobile} {
+        width: 40px;
+        height: 40px;
+    }
+
     & > :first-child:not(:last-child) * {
         fill: $color;
     }

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -21,6 +21,10 @@ $separator-attribs: 1px $color solid;
     width: calc(100% + 1rem);
     border-radius: common.$border-radius-xlarge;
 
+    @media #{common.$mq-screen-mobile} {
+        padding: var(--a-spacing-3);
+    }
+
     &:after {
         display: none;
     }
@@ -51,6 +55,7 @@ $separator-attribs: 1px $color solid;
 
     :global(.navds-expansioncard__header-button) {
         align-self: center;
+        width: 20px;
     }
 }
 

--- a/src/components/_common/product-panel/ProductPanelExpandable.module.scss
+++ b/src/components/_common/product-panel/ProductPanelExpandable.module.scss
@@ -88,6 +88,7 @@ $separator-attribs: 1px $color solid;
     flex-direction: column;
     font-weight: var(--a-font-weight-bold);
     font-size: var(--a-font-size-heading-small);
+    word-break: break-word;
 }
 
 .subHeader {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ved spesielt lange ord i produkttittel så sprenger dette ut av layout. Denne fiksen foreslår:
- Justere ned størrelse på piktogram noe og redusere padding.
- Hvis det FORTSATT ikke er plass til et spesielt langt ord, så tvinges ordbryting. Det gjelder kun et fåtall ord.
- FIkser safari IOS feil hvor knapp får vokse for mye i bredden og dermed gjør alignment av chevrons ujevn. Settes til 20px.

![Screenshot 2024-04-18 at 14 40 54](https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/8897375c-4634-4fa6-90c5-f41c3ae82d6c)


## Testing
Testet i dev2
