### PR TITLE
Legger til sjekk av H4 for MacroFormDetails

### DIFF
--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -5,11 +5,11 @@ import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { InfoBox } from 'components/_common/info-box/InfoBox';
 import { AlertInContext } from 'components/_common/alert-in-context/AlertInContext';
+import { usePageContentProps } from 'store/pageContext';
+import { ContentType } from 'types/content-props/_content-common';
 import { FormDetailsButton } from './FormDetailsButton';
 
 import style from './FormDetails.module.scss';
-import { usePageContentProps } from 'store/pageContext';
-import { ContentType } from 'types/content-props/_content-common';
 
 export type FormDetailsComponentProps = {
     formDetails: FormDetailsData;
@@ -20,7 +20,6 @@ export type FormDetailsComponentProps = {
         showAddendums?: boolean;
         showApplications?: boolean;
         showComplaints?: boolean;
-        showTitleAsLevel4?: boolean;
     };
     className?: string;
     formNumberSelected?: string;

--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -8,6 +8,8 @@ import { AlertInContext } from 'components/_common/alert-in-context/AlertInConte
 import { FormDetailsButton } from './FormDetailsButton';
 
 import style from './FormDetails.module.scss';
+import { usePageContentProps } from 'store/pageContext';
+import { ContentType } from 'types/content-props/_content-common';
 
 export type FormDetailsComponentProps = {
     formDetails: FormDetailsData;
@@ -37,8 +39,9 @@ export const FormDetails = ({
         showAddendums = true,
         showApplications = true,
         showComplaints = true,
-        showTitleAsLevel4 = false, // Temporary solution until all product pages have been re-organized.
     } = displayConfig;
+
+    const pageProps = usePageContentProps();
 
     const { formNumbers, formType, languageDisclaimer, ingress, title, alerts } = formDetails;
 
@@ -61,6 +64,9 @@ export const FormDetails = ({
 
         return acc;
     }, []);
+
+    const showTitleAsLevel4 =
+        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
 
     const formNumberToHighlight =
         formNumberSelected &&

--- a/src/components/macros/form-details/MacroFormDetails.tsx
+++ b/src/components/macros/form-details/MacroFormDetails.tsx
@@ -1,10 +1,20 @@
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+import { usePageContentProps } from 'store/pageContext';
+import { ContentType } from 'types/content-props/_content-common';
 import { MacroFormDetailsProps } from 'types/macro-props/form-details';
 
 export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
+    const pageProps = usePageContentProps();
     const macroConfig = config?.form_details;
     const formDetailsData = macroConfig?.targetFormDetails?.data;
+
+    // This is a temporary solution to show the title as level 4 on product pages
+    // that have been re-organized as part of the Maler 2.0.
+    // When all product pages have been re-organized, we can remove the reference and
+    // config for showTitleAsLevel4.
+    const showTitleAsLevel4 =
+        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
 
     if (!macroConfig || !formDetailsData) {
         return (
@@ -21,6 +31,7 @@ export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
         showIngress: macroConfig.showIngress,
         showApplications: macroConfig.showApplications,
         showAddendums: macroConfig.showAddendums,
+        showTitleAsLevel4,
     };
 
     return <FormDetails formDetails={formDetailsData} displayConfig={displayConfig} />;

--- a/src/components/macros/form-details/MacroFormDetails.tsx
+++ b/src/components/macros/form-details/MacroFormDetails.tsx
@@ -1,20 +1,10 @@
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { usePageContentProps } from 'store/pageContext';
-import { ContentType } from 'types/content-props/_content-common';
 import { MacroFormDetailsProps } from 'types/macro-props/form-details';
 
 export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
-    const pageProps = usePageContentProps();
     const macroConfig = config?.form_details;
     const formDetailsData = macroConfig?.targetFormDetails?.data;
-
-    // This is a temporary solution to show the title as level 4 on product pages
-    // that have been re-organized as part of the Maler 2.0.
-    // When all product pages have been re-organized, we can remove the reference and
-    // config for showTitleAsLevel4.
-    const showTitleAsLevel4 =
-        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
 
     if (!macroConfig || !formDetailsData) {
         return (
@@ -31,7 +21,6 @@ export const MacroFormDetails = ({ config }: MacroFormDetailsProps) => {
         showIngress: macroConfig.showIngress,
         showApplications: macroConfig.showApplications,
         showAddendums: macroConfig.showAddendums,
-        showTitleAsLevel4,
     };
 
     return <FormDetails formDetails={formDetailsData} displayConfig={displayConfig} />;

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -21,26 +21,14 @@ export const FormDetailsPart = ({ config }: PartComponentProps<PartType.FormDeta
     const pageProps = usePageContentProps();
     const { targetFormDetails, ...displayConfig } = config;
 
-    // This is a temporary solution to show the title as level 4 on product pages
-    // that have been re-organized as part of the Maler 2.0.
-    // When all product pages have been re-organized, we can remove the reference and
-    // config for showTitleAsLevel4.
-    const showTitleAsLevel4 =
-        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
-
     if (!targetFormDetails) {
         return <EditorHelp text={'Velg hvilken skjemadetalj som skal vises'} />;
     }
     const formDetails = targetFormDetails.data;
 
-    const modifiedDisplayConfig = {
-        ...displayConfig,
-        showTitleAsLevel4,
-    };
-
     return (
         <FilteredContent {...config}>
-            <FormDetails formDetails={formDetails} displayConfig={modifiedDisplayConfig} />
+            <FormDetails formDetails={formDetails} displayConfig={displayConfig} />
         </FilteredContent>
     );
 };

--- a/src/components/parts/form-details/FormDetailsPart.tsx
+++ b/src/components/parts/form-details/FormDetailsPart.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { FormDetails } from 'components/_common/form-details/FormDetails';
 import { FilteredContent } from 'components/_common/filtered-content/FilteredContent';
-import { ContentType } from 'types/content-props/_content-common';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
-import { usePageContentProps } from 'store/pageContext';
 import { FormDetailsPageProps } from 'types/content-props/form-details';
 import { FiltersMixin } from 'types/component-props/_mixins';
 
@@ -18,7 +16,6 @@ export type PartConfigFormDetails = {
 } & FiltersMixin;
 
 export const FormDetailsPart = ({ config }: PartComponentProps<PartType.FormDetails>) => {
-    const pageProps = usePageContentProps();
     const { targetFormDetails, ...displayConfig } = config;
 
     if (!targetFormDetails) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
MacroFormDetails tar hensyn til om header for skjemadetaljen skal vises som h3 eller h4. Fungerer når skjemadetalj er satt inn som part, men macro er glemt.

![h3 til h4](https://github.com/navikt/nav-enonicxp-frontend/assets/1443997/684ac036-8cdd-4e83-b8bb-81214fe57c5d)

## Testing
Testes i dev.