### PR TITLE
Fikser styling-bug forårsaket av feil CSS-spesifisitet

### DIFF
--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -7,66 +7,66 @@ $sectionGutterLarge: 1.5rem;
 $sectionGutterSmall: 0.75rem;
 $verticalMargin: 1.75rem;
 
-.topRow {
-    display: flex;
-    flex-direction: column;
-
-    @media #{common.$mq-screen-tablet-and-desktop} {
-        flex-direction: row;
-        margin-top: 3rem;
-    }
-}
-
-.leftCol,
-.rightCol {
-    width: 100%;
-    max-width: $sectionMaxWidth;
-
-    @media #{common.$mq-screen-tablet-and-desktop} {
-        width: $sideMenusMaxWidth;
-        max-width: $sideMenusMaxWidth;
-    }
-}
-
-.leftCol {
-    @media #{common.$mq-screen-tablet-and-desktop} {
-        margin-right: $sectionGutterSmall;
-
-        :global(.region__topPageContent) {
-            display: none;
-        }
-    }
-
-    @media #{common.$mq-screen-desktop} {
-        margin-right: $sectionGutterLarge;
-    }
-}
-
-.mainCol {
-    max-width: 100%;
-
-    :global(.region__topPageContent) {
-        display: none;
-
-        @media #{common.$mq-screen-tablet-and-desktop} {
-            display: flex;
-        }
-    }
-}
-
-.rightCol {
-    @media #{common.$mq-screen-tablet-and-desktop} {
-        margin-left: $sectionGutterSmall;
-    }
-
-    @media #{common.$mq-screen-desktop-large} {
-        margin-left: $sectionGutterLarge;
-    }
-}
-
 .pageWithSideMenus {
     max-width: common.px-to-rem(1080);
     margin: 0 auto;
+
+    .topRow {
+        display: flex;
+        flex-direction: column;
+
+        @media #{common.$mq-screen-tablet-and-desktop} {
+            flex-direction: row;
+            margin-top: 3rem;
+        }
+    }
+
+    .leftCol,
+    .rightCol {
+        width: 100%;
+        max-width: $sectionMaxWidth;
+
+        @media #{common.$mq-screen-tablet-and-desktop} {
+            width: $sideMenusMaxWidth;
+            max-width: $sideMenusMaxWidth;
+        }
+    }
+
+    .leftCol {
+        @media #{common.$mq-screen-tablet-and-desktop} {
+            margin-right: $sectionGutterSmall;
+
+            :global(.region__topPageContent) {
+                display: none;
+            }
+        }
+
+        @media #{common.$mq-screen-desktop} {
+            margin-right: $sectionGutterLarge;
+        }
+    }
+
+    .mainCol {
+        max-width: 100%;
+
+        :global(.region__topPageContent) {
+            display: none;
+
+            @media #{common.$mq-screen-tablet-and-desktop} {
+                display: flex;
+            }
+        }
+    }
+
+    .rightCol {
+        @media #{common.$mq-screen-tablet-and-desktop} {
+            margin-left: $sectionGutterSmall;
+        }
+
+        @media #{common.$mq-screen-desktop-large} {
+            margin-left: $sectionGutterLarge;
+        }
+    }
 
     :global(.region__intro) {
         margin-bottom: $verticalMargin;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -30,18 +30,18 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     // (prevents issues such as duplicate ids)
     const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
 
-    // useEffect(() => {
-    //     const updateLayout = () => {
-    //         setIsMobile(window.innerWidth < mobileWidthBreakpoint);
-    //     };
-    //
-    //     updateLayout();
-    //
-    //     mqlWidthBreakpoint.addEventListener('change', updateLayout);
-    //     return () => {
-    //         mqlWidthBreakpoint.removeEventListener('change', updateLayout);
-    //     };
-    // }, []);
+    useEffect(() => {
+        const updateLayout = () => {
+            setIsMobile(window.innerWidth < mobileWidthBreakpoint);
+        };
+
+        updateLayout();
+
+        mqlWidthBreakpoint.addEventListener('change', updateLayout);
+        return () => {
+            mqlWidthBreakpoint.removeEventListener('change', updateLayout);
+        };
+    }, []);
 
     if (!regions || !config) {
         return null;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -30,18 +30,18 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     // (prevents issues such as duplicate ids)
     const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
 
-    useEffect(() => {
-        const updateLayout = () => {
-            setIsMobile(window.innerWidth < mobileWidthBreakpoint);
-        };
-
-        updateLayout();
-
-        mqlWidthBreakpoint.addEventListener('change', updateLayout);
-        return () => {
-            mqlWidthBreakpoint.removeEventListener('change', updateLayout);
-        };
-    }, []);
+    // useEffect(() => {
+    //     const updateLayout = () => {
+    //         setIsMobile(window.innerWidth < mobileWidthBreakpoint);
+    //     };
+    //
+    //     updateLayout();
+    //
+    //     mqlWidthBreakpoint.addEventListener('change', updateLayout);
+    //     return () => {
+    //         mqlWidthBreakpoint.removeEventListener('change', updateLayout);
+    //     };
+    // }, []);
 
     if (!regions || !config) {
         return null;


### PR DESCRIPTION
Media query'ene for den mobil-spesifikke topContent regionen fungerte ikke, så vi får en litt stygg layout-shift der ved første render 😅 