### PR TITLE
setter nosnippet i PageWrapper

### DIFF
--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -116,7 +116,10 @@ export const PageWrapper = (props: Props) => {
 
     return (
         <div className={hasWhitePage(content) ? styles.whiteBackground : styles.defaultBackground}>
-            <div className={styles.appContainer}>
+            <div
+                className={styles.appContainer}
+                data-nosnippet={content.data?.nosnippet ? 'true' : undefined}
+            >
                 <DocumentParameterMetatags content={content} />
                 <HeadWithMetatags content={content} />
                 <PageWarnings content={content} />

--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -37,23 +37,6 @@ const getDescription = (content: ContentProps) => {
 const shouldNotIndex = (content: ContentProps) =>
     content.isPagePreview || content.type === ContentType.Error || content.data?.noindex;
 
-const shouldNotSnippet = (content: ContentProps) => content.data?.nosnippet;
-
-const buildRobotsMeta = (content: ContentProps) => {
-    const noIndex = shouldNotIndex(content);
-    const noSnippet = shouldNotSnippet(content);
-
-    if (noIndex) {
-        return 'noindex, nofollow';
-    }
-
-    if (noSnippet) {
-        return 'index, follow, nosnippet';
-    }
-
-    return 'index, follow';
-};
-
 const getCanonicalUrl = (content: ContentProps) => {
     if (hasCanonicalUrl(content)) {
         return content.data.canonicalUrl;
@@ -72,13 +55,16 @@ export const HeadWithMetatags = ({ content, children }: Props) => {
     const description = getDescription(content).slice(0, descriptionMaxLength);
     const url = getCanonicalUrl(content);
     const noIndex = shouldNotIndex(content);
-    const robotsMeta = buildRobotsMeta(content);
     const imageUrl = `${appOrigin}/gfx/social-share-fallback.png`;
 
     return (
         <Head>
             <title>{title}</title>
-            <meta name={'robots'} content={robotsMeta} />
+            {noIndex ? (
+                <meta name={'robots'} content={'noindex, nofollow'} />
+            ) : (
+                <link rel={'canonical'} href={url} />
+            )}
             {!noIndex && <link rel={'canonical'} href={url} />}
             <meta property={'og:title'} content={title} />
             <meta property={'og:site_name'} content={'nav.no'} />


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter [data-nosnippet](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr) på innholdet, i steden for nosnippet på hele siden.
- (Se slack-diskusjon i issuet for mer info)

## Testing

Har testet selv lokalt. Tenker å teste google-søk de neste dagene etter prodsetting for å sjekke at det har ønsket effekt.

## Skjermbilde hvis relevant

Nåværende effekt, ingen snippet på Google:
![Screenshot 2024-04-30 at 10 28 57](https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/6f4705b6-d567-4e96-819c-08cc9a135151)

Ønsket effekt, Google bruker description meta tag:
![Screenshot 2024-04-30 at 10 33 38](https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/ddcd3e67-3bd8-4618-9c8d-54e0a987ec4e)

