### PR TITLE
Vis "Andre tilbud" i meny

### DIFF
--- a/src/components/_common/relatedSituations/RelatedSituations.tsx
+++ b/src/components/_common/relatedSituations/RelatedSituations.tsx
@@ -28,7 +28,7 @@ export const RelatedSituations = ({ relatedSituations, title, description }: Pro
     return (
         <div
             className={classNames(style.relatedSituations, editorView === 'edit' && style.noMargin)}
-            id={getAnchorId(otherOffersTitle)}
+            id={getAnchorId(title || otherOffersTitle)}
         >
             <Heading level="3" size="medium" spacing>
                 {title || otherOffersTitle}

--- a/src/components/_common/relatedSituations/RelatedSituations.tsx
+++ b/src/components/_common/relatedSituations/RelatedSituations.tsx
@@ -23,15 +23,16 @@ export const RelatedSituations = ({ relatedSituations, title, description }: Pro
     const { language, editorView } = usePageContentProps();
 
     const getStringPart = translator('related', language);
-    const otherOffersTitle = getStringPart('otherOffers');
+    const defaultTitle = getStringPart('otherOffers');
+    const actualTitle = title || defaultTitle;
 
     return (
         <div
             className={classNames(style.relatedSituations, editorView === 'edit' && style.noMargin)}
-            id={getAnchorId(title || otherOffersTitle)}
+            id={getAnchorId(actualTitle)}
         >
             <Heading level="3" size="medium" spacing>
-                {title || otherOffersTitle}
+                {actualTitle}
             </Heading>
             <BodyLong className={style.description}>
                 {description || getStringPart('moreInformation')}

--- a/src/components/_common/relatedSituations/RelatedSituations.tsx
+++ b/src/components/_common/relatedSituations/RelatedSituations.tsx
@@ -19,13 +19,15 @@ export const RelatedSituations = ({ relatedSituations, title, description }: Pro
     const { language, editorView } = usePageContentProps();
 
     const getStringPart = translator('related', language);
+    const otherOffersTitle = getStringPart('otherOffers');
 
     return (
         <div
             className={classNames(style.relatedSituations, editorView === 'edit' && style.noMargin)}
+            id={otherOffersTitle.replace(/\s+/g, '-').toLowerCase()} // Replace spaces with hyphens and make lowercase
         >
             <Heading level="3" size="medium" spacing>
-                {title || getStringPart('otherOffers')}
+                {title || otherOffersTitle}
             </Heading>
             <BodyLong className={style.description}>
                 {description || getStringPart('moreInformation')}

--- a/src/components/_common/relatedSituations/RelatedSituations.tsx
+++ b/src/components/_common/relatedSituations/RelatedSituations.tsx
@@ -15,6 +15,10 @@ type Props = {
     description: string;
 };
 
+export const getAnchorId = (test: string) => {
+    return test.replace(/\s+/g, '-').toLowerCase(); // Replace spaces with hyphens and make lowercase
+};
+
 export const RelatedSituations = ({ relatedSituations, title, description }: Props) => {
     const { language, editorView } = usePageContentProps();
 
@@ -24,7 +28,7 @@ export const RelatedSituations = ({ relatedSituations, title, description }: Pro
     return (
         <div
             className={classNames(style.relatedSituations, editorView === 'edit' && style.noMargin)}
-            id={otherOffersTitle.replace(/\s+/g, '-').toLowerCase()} // Replace spaces with hyphens and make lowercase
+            id={getAnchorId(otherOffersTitle)}
         >
             <Heading level="3" size="medium" spacing>
                 {title || otherOffersTitle}

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -25,6 +25,10 @@ const getAnchorsFromComponents = (region?: RegionProps) => {
         return [];
     }
 
+    const { language } = usePageContentProps();
+    const getStringPart = translator('related', language);
+    const otherOffersTitle = getStringPart('otherOffers');
+
     return region.components.reduce<Anchor[]>((acc, component) => {
         if (
             component.type === ComponentType.Part &&
@@ -38,7 +42,16 @@ const getAnchorsFromComponents = (region?: RegionProps) => {
                 anchorId: component.config.anchorId as string,
                 title: component.config.title as string,
             });
+        } else if (
+            component.type === ComponentType.Part &&
+            component.descriptor === PartType.RelatedSituations
+        ) {
+            acc.push({
+                anchorId: otherOffersTitle.replace(/\s+/g, '-').toLowerCase() as string,
+                title: (component.config?.title || getStringPart('otherOffers')) as string,
+            });
         }
+
         return acc;
     }, []);
 };

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -26,7 +26,7 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
     }
 
     const getStringPart = translator('related', language);
-    const otherOffersTitle = getStringPart('otherOffers');
+    const defaultTitle = getStringPart('otherOffers');
 
     return region.components.reduce<Anchor[]>((acc, component) => {
         if (
@@ -45,9 +45,10 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
             component.type === ComponentType.Part &&
             component.descriptor === PartType.RelatedSituations
         ) {
+            const actualTitle = component.config?.title || defaultTitle;
             acc.push({
-                anchorId: getAnchorId(component.config?.title || otherOffersTitle),
-                title: component.config?.title || otherOffersTitle,
+                anchorId: getAnchorId(actualTitle),
+                title: actualTitle,
             });
         }
         return acc;

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -18,6 +18,7 @@ type SectionNavigationProps = {
 type Anchor = {
     anchorId: string;
     title: string;
+    isPartRelatedSituations?: boolean;
 };
 
 const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
@@ -40,7 +41,14 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
 
         if (component.descriptor === PartType.RelatedSituations) {
             const actualTitle = component.config?.title || defaultTitle;
-            return [...acc, { anchorId: getAnchorId(actualTitle), title: actualTitle }];
+            return [
+                ...acc,
+                {
+                    anchorId: getAnchorId(actualTitle),
+                    title: actualTitle,
+                    isPartRelatedSituations: true,
+                },
+            ];
         }
 
         return acc;
@@ -54,6 +62,10 @@ export const SectionNavigation = ({ introRegion, contentRegion }: SectionNavigat
     const allAnchors = [...introAnchors, ...contentAnchors];
 
     if (allAnchors.length === 0) {
+        return null;
+    }
+
+    if (allAnchors.length === 1 && allAnchors[0].isPartRelatedSituations) {
         return null;
     }
 

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -29,28 +29,20 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
     const defaultTitle = getStringPart('otherOffers');
 
     return region.components.reduce<Anchor[]>((acc, component) => {
-        if (
-            component.type === ComponentType.Part &&
-            component.descriptor === PartType.Header &&
-            component.config &&
-            component.config.titleTag === 'h3' &&
-            component.config.anchorId &&
-            component.config.title
-        ) {
-            acc.push({
-                anchorId: component.config.anchorId as string,
-                title: component.config.title as string,
-            });
-        } else if (
-            component.type === ComponentType.Part &&
-            component.descriptor === PartType.RelatedSituations
-        ) {
-            const actualTitle = component.config?.title || defaultTitle;
-            acc.push({
-                anchorId: getAnchorId(actualTitle),
-                title: actualTitle,
-            });
+        if (component.type !== ComponentType.Part) {
+            return acc;
         }
+
+        if (component.descriptor === PartType.Header && component.config?.titleTag === 'h3') {
+            const { anchorId, title } = component.config;
+            return anchorId && title ? [...acc, { anchorId, title }] : acc;
+        }
+
+        if (component.descriptor === PartType.RelatedSituations) {
+            const actualTitle = component.config?.title || defaultTitle;
+            return [...acc, { anchorId: getAnchorId(actualTitle), title: actualTitle }];
+        }
+
         return acc;
     }, []);
 };

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { ComponentType } from 'types/component-props/_component-common';
 import { RegionProps } from 'types/component-props/layouts';
 import { PartType } from 'types/component-props/parts';
-import { translator } from 'translations';
+import { Language, translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents } from 'utils/amplitude';
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
-import { getAnchorId } from '../relatedSituations/RelatedSituations';
+import { getAnchorId } from 'components/_common/relatedSituations/RelatedSituations';
 
 import styles from './SectionNavigation.module.scss';
 
@@ -20,12 +20,11 @@ type Anchor = {
     title: string;
 };
 
-const getAnchorsFromComponents = (region?: RegionProps) => {
+const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
     if (!region) {
         return [];
     }
 
-    const { language } = usePageContentProps();
     const getStringPart = translator('related', language);
     const otherOffersTitle = getStringPart('otherOffers');
 
@@ -47,19 +46,18 @@ const getAnchorsFromComponents = (region?: RegionProps) => {
             component.descriptor === PartType.RelatedSituations
         ) {
             acc.push({
-                anchorId: getAnchorId(otherOffersTitle),
+                anchorId: getAnchorId(otherOffersTitle) as string,
                 title: (component.config?.title || getStringPart('otherOffers')) as string,
             });
         }
-
         return acc;
     }, []);
 };
 
 export const SectionNavigation = ({ introRegion, contentRegion }: SectionNavigationProps) => {
     const { language } = usePageContentProps();
-    const introAnchors = getAnchorsFromComponents(introRegion);
-    const contentAnchors = getAnchorsFromComponents(contentRegion);
+    const introAnchors = getAnchorsFromComponents(language, introRegion);
+    const contentAnchors = getAnchorsFromComponents(language, contentRegion);
     const allAnchors = [...introAnchors, ...contentAnchors];
 
     if (allAnchors.length === 0) {

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -5,8 +5,8 @@ import { PartType } from 'types/component-props/parts';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents } from 'utils/amplitude';
-
 import { LenkeInline } from 'components/_common/lenke/LenkeInline';
+import { getAnchorId } from '../relatedSituations/RelatedSituations';
 
 import styles from './SectionNavigation.module.scss';
 
@@ -47,7 +47,7 @@ const getAnchorsFromComponents = (region?: RegionProps) => {
             component.descriptor === PartType.RelatedSituations
         ) {
             acc.push({
-                anchorId: otherOffersTitle.replace(/\s+/g, '-').toLowerCase() as string,
+                anchorId: getAnchorId(otherOffersTitle),
                 title: (component.config?.title || getStringPart('otherOffers')) as string,
             });
         }

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -46,8 +46,8 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
             component.descriptor === PartType.RelatedSituations
         ) {
             acc.push({
-                anchorId: getAnchorId(otherOffersTitle),
-                title: component.config?.title || getStringPart('otherOffers'),
+                anchorId: getAnchorId(component.config?.title || otherOffersTitle),
+                title: component.config?.title || otherOffersTitle,
             });
         }
         return acc;

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -46,8 +46,8 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
             component.descriptor === PartType.RelatedSituations
         ) {
             acc.push({
-                anchorId: getAnchorId(otherOffersTitle) as string,
-                title: (component.config?.title || getStringPart('otherOffers')) as string,
+                anchorId: getAnchorId(otherOffersTitle),
+                title: component.config?.title || getStringPart('otherOffers'),
             });
         }
         return acc;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Legger til visning av "Andre tilbud" i innholdsmenyen
- Setter passende ankerlenke dersom tittelen er overstyrt av redaktør. (f.eks. "Andre tilbud overstyrt" -> #andre-tilbud-overstyrt

## Testing

Testet selv lokalt og i dev

## Skjermbilde hvis relevant

<img width="328" alt="image" src="https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/fe1531a6-e8a2-4cc9-b9b6-1ef50975c5f6">

