### PR TITLE
Justering av layout for nye maler

### DIFF
--- a/src/common.scss
+++ b/src/common.scss
@@ -88,8 +88,7 @@ $versionSelectorMinHeight: 3rem;
         flex-shrink: 0;
         flex-basis: calc(percentage(1 / $numColsPlus1) + 1px);
         max-width: calc(
-            #{percentage(1 / $numCols)} - #{($marginX * ($numCols - 1)) /
-                $numCols} + 1px
+            #{percentage(1 / $numCols)} - #{($marginX * ($numCols - 1)) / $numCols} + 1px
         );
 
         &:not(:last-child) {
@@ -158,18 +157,6 @@ $versionSelectorMinHeight: 3rem;
 @mixin panel-focus-mixin($inset: true) {
     outline: unset;
     box-shadow: 0 0 0 3px if($inset, inset, null) $a-border-focus;
-}
-
-@mixin section-padding-mixin() {
-    padding: $sectionPaddingDesktop;
-
-    @media #{$mq-screen-tablet} {
-        padding: $sectionPaddingTablet;
-    }
-
-    @media #{$mq-screen-mobile} {
-        padding: $sectionPaddingMobile;
-    }
 }
 
 @mixin link-underline-mixin($underlineDefault: true) {

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -6,6 +6,11 @@
     width: 100%;
     padding-bottom: var(--a-spacing-8);
 
+    @media #{common.$mq-screen-mobile} {
+        margin: 0rem 1rem 0 1rem;
+        width: calc(100% - 2rem);
+    }
+
     .link {
         color: common.$a-text-action;
         text-decoration-thickness: 0.05em;

--- a/src/components/_common/contact-option/ContactOption.module.scss
+++ b/src/components/_common/contact-option/ContactOption.module.scss
@@ -6,11 +6,6 @@
     width: 100%;
     padding-bottom: var(--a-spacing-8);
 
-    @media #{common.$mq-screen-mobile} {
-        margin: 0rem 1rem 0 1rem;
-        width: calc(100% - 2rem);
-    }
-
     .link {
         color: common.$a-text-action;
         text-decoration-thickness: 0.05em;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -1,18 +1,15 @@
 @use 'common' as common;
 
-$sectionMaxWidth: common.px-to-rem(600);
-$sideMenusMaxWidth: common.px-to-rem(288);
-
-$sectionGutterLarge: 1.5rem;
 $sectionGutterSmall: 0.75rem;
 $verticalMargin: 1.75rem;
 
 .pageWithSideMenus {
-    max-width: common.px-to-rem(1080);
-    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr 40rem 1fr;
+    grid-template-rows: auto 1fr;
 
-    :global(.region__intro) {
-        margin-bottom: $verticalMargin;
+    @media #{common.$mq-screen-mobile} {
+        display: block;
     }
 
     :global(.region__pageContent),
@@ -20,39 +17,15 @@ $verticalMargin: 1.75rem;
         display: flex;
         flex-direction: column;
         margin-top: $verticalMargin;
-
-        & > * {
-            width: 100%;
-            max-width: $sectionMaxWidth;
-            margin-bottom: $verticalMargin;
-        }
-
-        @media #{common.$mq-screen-tablet-and-desktop} {
-            margin-top: 0;
-
-            // Ensure the first section is aligned with the menu if it has an icon
-            &:first-child {
-                :global(.layout__section-with-header--with-icon):first-child {
-                    margin-top: 0;
-                }
-            }
-        }
     }
+}
 
-    :global(.region__pageContent) {
-        & > :last-child {
-            margin-bottom: 0;
-        }
-    }
+.mainContent {
+    grid-column: 2;
+    grid-row: 1;
+}
 
-    :global(.region__bottomRow) {
-        max-width: 57rem;
-        margin-left: $sectionGutterSmall;
-        margin-right: $sectionGutterSmall;
-
-        @media #{common.$mq-screen-desktop} {
-            margin-left: 0;
-            margin-right: 0;
-        }
-    }
+.bottomContent {
+    grid-column: 1 / -1;
+    max-width: 80rem;
 }

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -10,6 +10,8 @@ $verticalMargin: 1.75rem;
 
     @media #{common.$mq-screen-mobile} {
         display: block;
+        margin: 0rem 1rem;
+        width: calc(100% - 2rem);
     }
 
     :global(.region__pageContent),

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -14,6 +14,10 @@ $verticalMargin: 1.75rem;
         width: calc(100% - 2rem);
     }
 
+    :global(.region__intro) {
+        margin-bottom: $verticalMargin;
+    }
+
     :global(.region__pageContent),
     :global(.region__topPageContent) {
         display: flex;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -16,7 +16,6 @@ $verticalMargin: 1.75rem;
     :global(.region__topPageContent) {
         display: flex;
         flex-direction: column;
-        margin-top: $verticalMargin;
     }
 }
 

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -24,7 +24,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
 
     const { pageContent, topPageContent, bottomRow } = regions;
 
-    const useGeneralPageHeader = pageProps.type === ContentType.ProductPage;
+    const isProductPage = pageProps.type === ContentType.ProductPage;
 
     return (
         <LayoutContainer
@@ -32,8 +32,8 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
             pageProps={pageProps}
             layoutProps={layoutProps}
         >
-            {useGeneralPageHeader && <GeneralPageHeader pageProps={pageProps} />}
-            <Region pageProps={pageProps} regionProps={topPageContent} />
+            {isProductPage && <GeneralPageHeader pageProps={pageProps} />}
+            {!isProductPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
             {showInternalNav && (
                 <PageNavigationMenu anchorLinks={anchorLinks} title={leftMenuHeader} />
             )}

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -32,13 +32,17 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
             pageProps={pageProps}
             layoutProps={layoutProps}
         >
-            {isProductPage && <GeneralPageHeader pageProps={pageProps} />}
-            {!isProductPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
-            {showInternalNav && (
-                <PageNavigationMenu anchorLinks={anchorLinks} title={leftMenuHeader} />
-            )}
-            <Region pageProps={pageProps} regionProps={pageContent} />
-            <Region pageProps={pageProps} regionProps={bottomRow} />
+            <div className={styles.mainContent}>
+                {isProductPage && <GeneralPageHeader pageProps={pageProps} />}
+                {!isProductPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
+                {showInternalNav && (
+                    <PageNavigationMenu anchorLinks={anchorLinks} title={leftMenuHeader} />
+                )}
+                <Region pageProps={pageProps} regionProps={pageContent} />
+            </div>
+            <div className={styles.bottomContent}>
+                <Region pageProps={pageProps} regionProps={bottomRow} />
+            </div>
         </LayoutContainer>
     );
 };

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
 import { SectionNavigation } from 'components/_common/section-navigation/SectionNavigation';
-import { ContentProps } from 'types/content-props/_content-common';
+import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
 import Region from 'components/layouts/Region';
 import { Header } from 'components/_common/headers/Header';
@@ -10,7 +10,8 @@ import { FilterBar } from 'components/_common/filter-bar/FilterBar';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { classNames } from 'utils/classnames';
 
-import style from './SectionWithHeaderLayout.module.scss';
+import styleV1 from './SectionWithHeaderLayout.module.scss';
+import styleV2 from './SectionWithHeaderLayoutV2.module.scss';
 
 type BorderProps = NonNullable<SectionWithHeaderProps['config']['border']>;
 
@@ -23,6 +24,15 @@ type Props = {
     pageProps: ContentProps;
     layoutProps: SectionWithHeaderProps;
 };
+
+const templateV2 = new Set([
+    ContentType.ProductPage,
+    ContentType.GenericPage,
+    ContentType.ThemedArticlePage,
+    ContentType.CurrentTopicPage,
+    ContentType.GuidePage,
+    ContentType.ToolsPage,
+]);
 
 export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
@@ -44,6 +54,8 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
     // Also make sure we always region if there are already components in it.
     const shouldShowIntroRegion =
         regions.intro?.components?.length > 0 || (shouldShowFilterBar && isEditorView);
+
+    const style = templateV2.has(pageProps.type) ? styleV2 : styleV1;
 
     return (
         <LayoutContainer

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -10,6 +10,7 @@ $defaultBgColor: white;
     display: inline-flex;
     flex-direction: column;
     width: 100%;
+    margin-top: 6rem;
 
     @media #{common.$mq-screen-mobile} {
         margin: 0 1rem;
@@ -33,10 +34,6 @@ $defaultBgColor: white;
             width: common.round-rem($iconSize);
         }
     }
-}
-
-.withIcon {
-    margin-top: 6rem;
 }
 
 .header {

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -12,11 +12,6 @@ $defaultBgColor: white;
     width: 100%;
     margin-top: 6rem;
 
-    @media #{common.$mq-screen-mobile} {
-        margin: 6rem 1rem 0 1rem;
-        width: calc(100% - 2rem);
-    }
-
     :global(.icon-container) {
         align-items: center;
         align-self: flex-start;

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -1,0 +1,48 @@
+@use 'common' as common;
+@use 'sass:math';
+
+$iconContainerRadius: common.px-to-rem(60px / 2);
+$iconContainerSize: $iconContainerRadius * 2;
+$defaultBgColor: white;
+
+.container {
+    background-color: $defaultBgColor;
+    display: inline-flex;
+    flex-direction: column;
+    width: 100%;
+
+    @media #{common.$mq-screen-mobile} {
+        margin: 0 1rem;
+        width: calc(100% - 2rem);
+    }
+
+    :global(.icon-container) {
+        align-items: center;
+        align-self: flex-start;
+        background-color: $defaultBgColor;
+        border-radius: 50%;
+        display: flex;
+        height: $iconContainerSize;
+        justify-content: center;
+        position: relative;
+        width: $iconContainerSize;
+
+        img {
+            $iconSize: $iconContainerRadius / math.sqrt(common.stripUnit($iconContainerRadius)) * 2;
+            height: common.round-rem($iconSize);
+            width: common.round-rem($iconSize);
+        }
+    }
+}
+
+.withIcon {
+    margin-top: 6rem;
+}
+
+.header {
+    margin-bottom: 1rem;
+}
+
+.headerWithIcon {
+    margin-top: 0.5rem;
+}

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -13,7 +13,7 @@ $defaultBgColor: white;
     margin-top: 6rem;
 
     @media #{common.$mq-screen-mobile} {
-        margin: 0 1rem;
+        margin: 6rem 1rem 0 1rem;
         width: calc(100% - 2rem);
     }
 

--- a/src/utils/appearance.ts
+++ b/src/utils/appearance.ts
@@ -5,6 +5,7 @@ const contentTypeWithWhiteBackground: ReadonlySet<ContentType> = new Set([
     ContentType.FormIntermediateStepPage,
     ContentType.FormsOverview,
     ContentType.MainArticle,
+    ContentType.ProductPage,
 ]);
 
 const contentTypesWithWhiteHeader: ReadonlySet<ContentType> = new Set([

--- a/src/utils/appearance.ts
+++ b/src/utils/appearance.ts
@@ -6,6 +6,9 @@ const contentTypeWithWhiteBackground: ReadonlySet<ContentType> = new Set([
     ContentType.FormsOverview,
     ContentType.MainArticle,
     ContentType.ProductPage,
+    ContentType.GuidePage,
+    ContentType.ToolsPage,
+    ContentType.ThemedArticlePage,
 ]);
 
 const contentTypesWithWhiteHeader: ReadonlySet<ContentType> = new Set([


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- section-padding-mixin() lå som duplikat i common-filen. Fjernet den ene.
- Setter inn sidecontaineren som grid slik at innhold kan plasseres i midten og kontaktkomponentene kan strekke seg utover.
- Forenkler endel styling på SectionHeaderLayout og introduserer forslagsvis en v2 av denne for å unngå at situasjonssider påvirkes i for stor grad.
