### PR TITLE
Felles html-formattering og styling-fiks

### DIFF
--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -7,6 +7,7 @@ import { usePageContentProps } from 'store/pageContext';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartConfigAccordion } from 'components/parts/accordion/AccordionPart';
 
+import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import styles from './Accordion.module.scss';
 
 type AccordionProps = PartConfigAccordion;
@@ -73,7 +74,9 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                             {isValid && <div className={styles.headerTitle}>{item.title}</div>}
                         </DSAccordion.Header>
                         <DSAccordion.Content className={styles.content}>
-                            <ParsedHtml htmlProps={item.html} />
+                            <div className={defaultHtml.html}>
+                                <ParsedHtml htmlProps={item.html} />
+                            </div>
                         </DSAccordion.Content>
                     </DSAccordion.Item>
                 );

--- a/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
+++ b/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
@@ -32,6 +32,9 @@
 
         li::marker {
             color: rgb(153, 24, 94);
+            font-variant-caps: all-small-caps;
+            font-weight: 800;
+            font-size: 20px;
         }
 
         li:not(:last-child) {

--- a/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
+++ b/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
@@ -1,0 +1,47 @@
+.html {
+    word-break: break-word;
+
+    :global(.navds-body-long + .card) {
+        margin-top: -1.2rem;
+    }
+
+    img {
+        display: block;
+        max-width: 100%;
+        height: auto;
+    }
+
+    table {
+        float: none;
+        margin-bottom: 1.75rem;
+
+        th,
+        td {
+            font-size: 1.125rem;
+            line-height: 150%;
+            padding: 0.7rem;
+            vertical-align: top;
+        }
+    }
+
+    ul,
+    ol {
+        padding-left: 1.4rem;
+        margin-bottom: 1.75rem;
+        font-size: 1.125rem;
+
+        li::marker {
+            color: rgb(153, 24, 94);
+        }
+
+        li:not(:last-child) {
+            margin-bottom: 0.25rem;
+        }
+    }
+
+    // pull lists upward to text above if any.
+    :global(.navds-body-long + ul),
+    :global(.navds-body-long + ol) {
+        margin-top: -1rem;
+    }
+}

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -63,7 +63,8 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
             className={classNames(
                 style.container,
                 iconImgProps && style.withIcon,
-                isTemplateV2 && style.topMarker
+                isTemplateV2 && style.topMarker,
+                isEditorView && style.editorView
             )}
             pageProps={pageProps}
             layoutProps={layoutProps}

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -32,6 +32,11 @@ $defaultBgColor: white;
     }
 }
 
+.editorView {
+    outline: 1px gray dashed;
+    outline-offset: 15px;
+}
+
 .topMarker:before {
     background-color: rgb(230, 199, 216); // Finnes pr nå ikke i Aksel.
     content: '';

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayoutV2.module.scss
@@ -32,11 +32,6 @@ $defaultBgColor: white;
     }
 }
 
-.editorView {
-    outline: 1px gray dashed;
-    outline-offset: 15px;
-}
-
 .topMarker:before {
     background-color: rgb(230, 199, 216); // Finnes pr nå ikke i Aksel.
     content: '';
@@ -57,5 +52,6 @@ $defaultBgColor: white;
 }
 
 .editorViewBorder {
-    border: 1px dashed gray;
+    outline: 1px gray dashed;
+    outline-offset: 15px;
 }

--- a/src/components/parts/html-area/HtmlAreaPart.module.scss
+++ b/src/components/parts/html-area/HtmlAreaPart.module.scss
@@ -1,49 +1,5 @@
 @use 'common' as common;
 
-.htmlArea {
-    word-break: break-word;
-
-    :global(.navds-body-long + .card) {
-        margin-top: -1.2rem;
-    }
-
-    img {
-        display: block;
-        max-width: 100%;
-        height: auto;
-    }
-
-    table {
-        float: none;
-        margin-bottom: 1.75rem;
-
-        th,
-        td {
-            font-size: 1.125rem;
-            line-height: 150%;
-            padding: 0.7rem;
-            vertical-align: top;
-        }
-    }
-
-    ul,
-    ol {
-        padding-left: 1.4rem;
-        margin-bottom: 1.75rem;
-        font-size: 1.125rem;
-
-        li:not(:last-child) {
-            margin-bottom: 0.25rem;
-        }
-    }
-
-    // pull lists upward to text above if any.
-    :global(.navds-body-long + ul),
-    :global(.navds-body-long + ol) {
-        margin-top: -1rem;
-    }
-}
-
 :global(.part__html-area):last-child {
     .htmlArea > :last-child {
         margin-bottom: 0;

--- a/src/components/parts/html-area/HtmlAreaPart.tsx
+++ b/src/components/parts/html-area/HtmlAreaPart.tsx
@@ -6,7 +6,9 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { ExpandableMixin, FiltersMixin } from 'types/component-props/_mixins';
+import { classNames } from 'utils/classnames';
 
+import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import style from './HtmlAreaPart.module.scss';
 
 export type PartConfigHtmlArea = {
@@ -22,7 +24,7 @@ export const HtmlAreaPart = ({ config }: PartComponentProps<PartType.HtmlArea>) 
     return (
         <FilteredContent {...config}>
             <ExpandableComponentWrapper {...config}>
-                <div className={style.htmlArea}>
+                <div className={classNames(defaultHtml.html, style.htmlArea)}>
                     <ParsedHtml htmlProps={config.html} />
                 </div>
             </ExpandableComponentWrapper>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Flytter html-styling fra Formattert Innhold-komponenten (html-area) inn i felles styling slik at den kan brukes både av Formattert Innhold og Trekkspill (som også har html-area og som trenger samme formattering.
- Setter korrekt farge på bullets og lister.
- Bruker outline for å markere rammer for redaktørene.

