### PR TITLE
bruk ny header på guidepage og temaartikkel

### DIFF
--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -28,6 +28,11 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
 
     const isProductPage = pageProps.type === ContentType.ProductPage;
 
+    const isNewLayoutPage =
+        pageProps.type === ContentType.ProductPage ||
+        pageProps.type === ContentType.GuidePage ||
+        pageProps.type === ContentType.ThemedArticlePage;
+
     return (
         <LayoutContainer
             className={styles.pageWithSideMenus}
@@ -35,8 +40,8 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
             layoutProps={layoutProps}
         >
             <div className={styles.mainContent}>
-                {isProductPage && <GeneralPageHeader pageProps={pageProps} />}
-                {!isProductPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
+                {isNewLayoutPage && <GeneralPageHeader pageProps={pageProps} />}
+                {!isNewLayoutPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
                 {isProductPage && <AlternativeAudience />}
                 {showInternalNav && (
                     <PageNavigationMenu

--- a/src/components/pages/guide-page/GuidePage.tsx
+++ b/src/components/pages/guide-page/GuidePage.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { GuidePageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
-import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 import style from './GuidePage.module.scss';
 
 export const GuidePage = (props: GuidePageProps) => {
     return (
         <article className={style.guidePage}>
-            <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
                 <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>

--- a/src/components/pages/themed-article-page/ThemedArticlePage.tsx
+++ b/src/components/pages/themed-article-page/ThemedArticlePage.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { ThemedArticlePageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
-import { ThemedPageHeader } from 'components/_common/headers/themed-page-header/ThemedPageHeader';
 
 import style from './ThemedArticlePage.module.scss';
 
 export const ThemedArticlePage = (props: ThemedArticlePageProps) => {
     return (
         <article className={style.themedArticlePage}>
-            <ThemedPageHeader contentProps={props} />
             <div className={style.content}>
                 <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- bruk ny header på guidepage og temaartikkel

<img width="924" alt="image" src="https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/9543b8cd-f23c-422d-b615-8780d327ef86">


