### PR TITLE
Tar hensyn til feil bruk av ekspanderbart panel

### DIFF
--- a/src/components/_common/expandable/Expandable.module.scss
+++ b/src/components/_common/expandable/Expandable.module.scss
@@ -17,6 +17,7 @@
             top: var(--decorator-sticky-offset, 0px);
         }
     }
+
     .header {
         background-color: #e6f0ff;
         border-radius: 22px;
@@ -59,6 +60,13 @@
         }
         &:after {
             display: none;
+        }
+    }
+
+    &.legacy {
+        .header {
+            width: 100%;
+            padding-left: var(--a-spacing-4);
         }
     }
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -15,7 +15,6 @@ type Props = {
     className?: string;
     children: React.ReactNode;
     expandableType?: 'processing_times' | 'payout_dates' | 'rates' | 'documentation_requirements';
-    isEditor?: boolean;
 };
 
 export const Expandable = ({
@@ -25,7 +24,6 @@ export const Expandable = ({
     children,
     className,
     expandableType,
-    isEditor,
 }: Props) => {
     const [isOpen, setIsOpen] = useState(false);
     const accordionRef = useRef<HTMLDivElement | null>(null);
@@ -103,10 +101,15 @@ export const Expandable = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [anchorId]);
 
+    // Adjust appearande in styling if not type was set for this content
+    // This is the wrong use of this component, but some legacy pages have still to
+    // be upradet editorial wise.
+    const isLegacyUsage = !expandableType;
+
     return (
         <ExpansionCard
             id={anchorId}
-            className={classNames(className, style.expandable)}
+            className={classNames(className, style.expandable, isLegacyUsage && style.legacy)}
             ref={accordionRef}
             onToggle={toggleExpandCollapse}
             open={isOpen}

--- a/src/components/_editor-only/site-info/custom-paths/SiteInfoCustomPaths.tsx
+++ b/src/components/_editor-only/site-info/custom-paths/SiteInfoCustomPaths.tsx
@@ -17,7 +17,7 @@ export const SiteInfoCustomPaths = ({ contentList }: Props) => {
     return (
         <div>
             <SiteInfoSubHeader text={"Kort-url'er"} />
-            <Expandable title={`Sider med kort-url (${contentList.length})`} isEditor>
+            <Expandable title={`Sider med kort-url (${contentList.length})`}>
                 <TextField
                     label={'Søk etter kort-url'}
                     size={'small'}

--- a/src/components/_editor-only/site-info/publish-info/content-list/SiteInfoPublishInfoList.tsx
+++ b/src/components/_editor-only/site-info/publish-info/content-list/SiteInfoPublishInfoList.tsx
@@ -16,7 +16,7 @@ export const SiteInfoPublishInfoList = ({ title, titleEmpty, contentList }: Prop
     const { length } = contentList;
 
     return length > 0 ? (
-        <Expandable title={`${title} (${length})`} className={style.wrapper} isEditor>
+        <Expandable title={`${title} (${length})`} className={style.wrapper}>
             {contentList.map((content, index) => {
                 return (
                     <Fragment key={content.id}>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter full bredde på ekspanderbart panel som ikke har fått satt noen type. Det indikerer at panelet er gammelt og bør få en oppdatering, men dersom flere paneler er satt etter hverandre ser det ihvertfall ikke så rotete ut.

