### PR TITLE
Fikse feil i tabell i ekspanderbart

### DIFF
--- a/src/components/_common/expandable/Expandable.module.scss
+++ b/src/components/_common/expandable/Expandable.module.scss
@@ -100,4 +100,10 @@
             margin-bottom: var(--a-spacing-7);
         }
     }
+
+    // Only applicable when a table is inside an expandable. This is
+    // why this rule is not inside the DefaultHtmlStyling.module.scss.
+    table {
+        table-layout: fixed;
+    }
 }

--- a/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
+++ b/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
@@ -40,7 +40,8 @@
             font-weight: 800;
         }
 
-        li {
+        li:not(:last-child) {
+            // last-child-selector needed for specificity
             margin-bottom: var(--a-spacing-3);
         }
 

--- a/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
+++ b/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
@@ -40,11 +40,11 @@
             font-weight: 800;
         }
 
-        li:not(:last-child) {
+        li {
             margin-bottom: var(--a-spacing-3);
         }
 
-        li:last-of-type {
+        li:last-child {
             margin-bottom: 0;
         }
     }

--- a/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
+++ b/src/components/_common/parsed-html/DefaultHtmlStyling.module.scss
@@ -43,6 +43,10 @@
         li:not(:last-child) {
             margin-bottom: var(--a-spacing-3);
         }
+
+        li:last-of-type {
+            margin-bottom: 0;
+        }
     }
 
     ol li {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fikser layoutfeil i tabell med mye tekst i ene kolonnen når den er satt inn i ekspanderbart.
- Fikser margin-bottom-feil i siste li-element
