### PR TITLE
Hardkod og språkversjoner intern-menyer

### DIFF
--- a/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
+++ b/src/components/_common/page-navigation-menu/PageNavigationMenu.tsx
@@ -43,7 +43,6 @@ export const PageNavigationMenu = ({
             >
                 <Heading level="2" size="xsmall" spacing id={headingId} className={style.heading}>
                     {title}
-                    {/* TODO: skal være "Innhold på siden", ikke "Innhold". Settes redaksjonelt, men kunne kanskje hardkodes? */}
                 </Heading>
                 <ul aria-labelledby={headingId} className={style.list}>
                     {links.map((anchorLink) => (

--- a/src/components/_common/section-navigation/SectionNavigation.tsx
+++ b/src/components/_common/section-navigation/SectionNavigation.tsx
@@ -49,6 +49,7 @@ const getAnchorsFromComponents = (language: Language, region?: RegionProps) => {
 
 export const SectionNavigation = ({ introRegion, contentRegion }: SectionNavigationProps) => {
     const { language } = usePageContentProps();
+    const getLabel = translator('internalNavigation', language);
     const introAnchors = getAnchorsFromComponents(language, introRegion);
     const contentAnchors = getAnchorsFromComponents(language, contentRegion);
     const allAnchors = [...introAnchors, ...contentAnchors];
@@ -65,7 +66,7 @@ export const SectionNavigation = ({ introRegion, contentRegion }: SectionNavigat
         <PageNavigationMenu
             anchorLinks={allAnchors}
             analyticsComponent="Hopp til underkapittel"
-            title="I dette kapittelet" //TODO fiks språkversjonering. Antar at man ikke ønsker at denne skal kunne endres redaksjonelt? Samme med "Innhold på siden" i PageNavigationMenu.tsx?
+            title={getLabel('sectionNavigation')}
         />
     );
 };

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -7,6 +7,8 @@ import { PageNavigationMenu } from 'components/_common/page-navigation-menu/Page
 import { AlternativeAudience } from 'components/_common/alternativeAudience/AlternativeAudience';
 import { GeneralPageHeader } from 'components/_common/headers/general-page-header/GeneralPageHeader';
 import { PageUpdatedInfo } from 'components/_common/pageUpdatedInfo/PageUpdatedInfo';
+import { usePageContentProps } from 'store/pageContext';
+import { translator } from 'translations';
 
 import styles from './PageWithSideMenus.module.scss';
 
@@ -17,12 +19,14 @@ type Props = {
 
 export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
+    const { language } = usePageContentProps();
+    const getLabel = translator('internalNavigation', language);
 
     if (!regions || !config) {
         return null;
     }
 
-    const { leftMenuHeader, showInternalNav, anchorLinks } = config;
+    const { showInternalNav, anchorLinks } = config;
 
     const { pageContent, topPageContent, bottomRow } = regions;
 
@@ -45,7 +49,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                 {showInternalNav && (
                     <PageNavigationMenu
                         anchorLinks={anchorLinks}
-                        title={leftMenuHeader}
+                        title={getLabel('pageNavigationMenu')}
                         isChapterNavigation={true}
                     />
                 )}

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -363,6 +363,10 @@ export const translationsBundleNb = {
         otherOffers: 'Andre tilbud',
         moreInformation: 'Mer informasjon til deg som',
     },
+    internalNavigation: {
+        pageNavigationMenu: 'Innhold på siden',
+        sectionNavigation: 'I dette kapittelet',
+    },
 };
 
 export type Translations = typeof translationsBundleNb;

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -74,7 +74,7 @@ export const translationsBundleEn: PartialTranslations = {
         shortcuts: 'Shortcuts',
     },
     linkPanels: {
-        label: 'Link panels'
+        label: 'Link panels',
     },
     linkList: {
         label: 'List of links',
@@ -334,5 +334,9 @@ export const translationsBundleEn: PartialTranslations = {
         relatedAudience: 'There is also information on {name} for',
         otherOffers: 'Other options',
         moreInformation: 'More information for you who',
+    },
+    internalNavigation: {
+        pageNavigationMenu: 'Contents',
+        sectionNavigation: 'In this chapter',
     },
 };

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -334,4 +334,8 @@ export const translationsBundleNn: PartialTranslations = {
         otherOffers: 'Andre tilbod',
         moreInformation: 'Meir informasjon til deg som',
     },
+    internalNavigation: {
+        pageNavigationMenu: 'Innhald på sida',
+        sectionNavigation: 'I dette kapittelet',
+    },
 };


### PR DESCRIPTION
## Hva
- Hardkoder tittelen på innholdsmenyen til "Innhold på siden"
- Språkversjon bokmål, nynorsk og engelsk

## Hvorfor
- Endre fra "Innhold" til "Innhold på siden" på alle sidene. Vi har diskutert at vi antagelig kan hardkode disse tekstene.
- Det er kun to sider (som vil påvirkes) på andre språk. På disse to sidene er denne teksten på norsk i dag. https://www.nav.no/ukraina/uk og https://www.nav.no/ukraina/ru.
- (Vi burde vel fjerne muligheten for å legge inn egen tittel i enonic, da den ikke vil brukes lenger. Kanskje vi kan legge det til i todo-lista til etter lansering?)
