### PR TITLE
Justerer layout for single-col-page

### DIFF
--- a/src/components/layouts/legacy/LegacyLayout.module.scss
+++ b/src/components/layouts/legacy/LegacyLayout.module.scss
@@ -9,10 +9,10 @@
         max-width: 63.5rem;
         width: 100%;
 
-        margin-bottom: 1rem;
         margin-left: auto;
         margin-right: auto;
         padding-top: 2.25rem;
+        padding-bottom: 3rem;
 
         @media #{common.$mq-screen-mobile} {
             flex-direction: column;

--- a/src/components/layouts/single-col-page/SingleColPage.tsx
+++ b/src/components/layouts/single-col-page/SingleColPage.tsx
@@ -6,8 +6,6 @@ import Region from 'components/layouts/Region';
 import { GeneralPageHeader } from 'components/_common/headers/general-page-header/GeneralPageHeader';
 import { PageUpdatedInfo } from 'components/_common/pageUpdatedInfo/PageUpdatedInfo';
 
-import styles from '../page-with-side-menus/PageWithSideMenus.module.scss';
-
 type Props = {
     pageProps: ContentProps;
     layoutProps: SingleColPageProps;
@@ -32,20 +30,14 @@ export const SingleColPage = ({ pageProps, layoutProps }: Props) => {
     const showHeaderAndChangedate = hasGeneralComponents.has(pageProps.type);
 
     return (
-        <LayoutContainer
-            className={styles.pageWithSideMenus}
-            pageProps={pageProps}
-            layoutProps={layoutProps}
-        >
-            <div className={styles.mainContent}>
-                {showHeaderAndChangedate && (
-                    <GeneralPageHeader pageProps={pageProps} hideIngressOverride />
-                )}
-                <Region pageProps={pageProps} regionProps={regions.pageContent} />
-                {showHeaderAndChangedate && (
-                    <PageUpdatedInfo datetime={pageProps.modifiedTime} isSituationPage />
-                )}
-            </div>
+        <LayoutContainer pageProps={pageProps} layoutProps={layoutProps}>
+            {showHeaderAndChangedate && (
+                <GeneralPageHeader pageProps={pageProps} hideIngressOverride />
+            )}
+            <Region pageProps={pageProps} regionProps={regions.pageContent} />
+            {showHeaderAndChangedate && (
+                <PageUpdatedInfo datetime={pageProps.modifiedTime} isSituationPage />
+            )}
         </LayoutContainer>
     );
 };

--- a/src/components/pages/situation-page/SituationPage.module.scss
+++ b/src/components/pages/situation-page/SituationPage.module.scss
@@ -22,7 +22,7 @@ $margin: 2rem;
         justify-content: flex-start;
         align-self: center;
         width: 100%;
-        max-width: common.$contentMaxWidth;
+        max-width: 40rem;
 
         & > * {
             width: 100%;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Single-col-page brukes på endel flere sider, så vi bør kanskje droppe grid-tanketangen her og bare sette en maks-bredde og la innholdet flyte nedover. Ser ut til å brekke greit på tvers av skjermstørrelser også.