### PR TITLE
Unntak for h4 i individuelle parts

### DIFF
--- a/src/components/parts/html-area/HtmlAreaPart.module.scss
+++ b/src/components/parts/html-area/HtmlAreaPart.module.scss
@@ -2,6 +2,13 @@
 
 .htmlArea {
     margin-bottom: var(--a-spacing-9);
+
+    // Exception because product details are somehow
+    // build with h4 and html in separate parts rather than one large
+    // Formattert innhold-parts.
+    &:has(h4:last-child) {
+        margin-bottom: var(--a-spacing-3);
+    }
 }
 
 :global(.part__html-area):last-child {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Litt redaksjonelt pussig at h4 er plassert i egne parts og deretter paragrafene i en annen part. Dette skaper unormalt lang avstand ned til paragrafen.

Dette unntaket sjekker om en h4-tagg er siste child i en part og reduserer den omsluttende marginene for parten slik at den kommer nærmere neste part.