### PR TITLE
Juster avstand i varehylle-kort på mobil

### DIFF
--- a/src/components/_common/card/LargeCardV2.module.scss
+++ b/src/components/_common/card/LargeCardV2.module.scss
@@ -17,6 +17,7 @@
 
     @media #{common.$mq-screen-mobile-small} {
         flex-direction: column;
+        gap: 0.75rem;
     }
 
     &:hover {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Mindre avstand mellom ikon og tekst på liten skjerm
