### PR TITLE
Endrer visning av publisert-dato til publish.from i aktuelt-side

### DIFF
--- a/src/components/_common/headers/featured-header/FeaturedHeader.tsx
+++ b/src/components/_common/headers/featured-header/FeaturedHeader.tsx
@@ -15,10 +15,11 @@ type Props = {
 };
 
 export const FeaturedHeader = ({ contentProps }: Props) => {
-    const { displayName, createdTime, modifiedTime, data } = contentProps;
+    const { displayName, modifiedTime, data, publish, createdTime } = contentProps;
     const { language } = usePageContentProps();
     const pageTitle = data.title || displayName;
 
+    const publishFrom = publish?.from || createdTime;
     const getFeaturedTranslations = translator('currentTopic', language);
 
     const tagLineLabel = getFeaturedTranslations('tag');
@@ -31,7 +32,7 @@ export const FeaturedHeader = ({ contentProps }: Props) => {
                     {pageTitle}
                 </Heading>
             </header>
-            <DateLine createdTime={createdTime} modifiedTime={modifiedTime} language={language} />
+            <DateLine createdTime={publishFrom} modifiedTime={modifiedTime} language={language} />
         </>
     );
 };

--- a/src/components/_common/headers/featured-header/FeaturedHeader.tsx
+++ b/src/components/_common/headers/featured-header/FeaturedHeader.tsx
@@ -19,7 +19,7 @@ export const FeaturedHeader = ({ contentProps }: Props) => {
     const { language } = usePageContentProps();
     const pageTitle = data.title || displayName;
 
-    const publishFrom = publish?.from || createdTime;
+    const publishFrom = publish?.from ?? createdTime;
     const getFeaturedTranslations = translator('currentTopic', language);
 
     const tagLineLabel = getFeaturedTranslations('tag');

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart.tsx
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart.tsx
@@ -40,7 +40,7 @@ export const FrontpageCurrentTopicsPart = ({
                         return null;
                     }
 
-                    const displayDate = item.publish?.first ?? item.modifiedTime;
+                    const displayDate = item.publish?.from ?? item.modifiedTime;
 
                     return (
                         <li key={item._id}>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
For forsiden og aktuelt-sider (CurrentTopicPage) trenger vi at datoen som vises som "Publisert:" er datoen hvor siden sist ble tilgjengeliggjort, dvs publish.from.

Dersom en side avpubliseres og deretter republiseres (eller forhåndspubliseres) er det den siste faktiske publiseringsdatoen som skal vises.