### PR TITLE
Viser skjemadetaljer med h4 når de ligger i produktsider

### DIFF
--- a/src/components/_common/form-details/FormDetails.tsx
+++ b/src/components/_common/form-details/FormDetails.tsx
@@ -64,8 +64,11 @@ export const FormDetails = ({
         return acc;
     }, []);
 
-    const showTitleAsLevel4 =
-        pageProps.type === ContentType.ProductPage && pageProps.data?.showSubsectionNavigation;
+    const showTitleAsLevel4 = new Set([
+        ContentType.ProductPage,
+        ContentType.GuidePage,
+        ContentType.CurrentTopicPage,
+    ]).has(pageProps.type);
 
     const formNumberToHighlight =
         formNumberSelected &&


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Når skjemadetaljer legges i produktsider eller slik gjør du det-side, så ligger de alltid under en h3. Dermed skal de nå utelukkende legges inn med h4-titler.

## Testing
Testes i dev