### PR TITLE
Fjern margin-bottom i Accordion og Expandable

### DIFF
--- a/src/components/_common/accordion/Accordion.module.scss
+++ b/src/components/_common/accordion/Accordion.module.scss
@@ -5,6 +5,9 @@
         margin-bottom: 0;
         > *:last-child {
             margin-bottom: 0;
+            > *:last-child {
+                margin-bottom: 0;
+            }
         }
     }
 }

--- a/src/components/_common/accordion/Accordion.module.scss
+++ b/src/components/_common/accordion/Accordion.module.scss
@@ -3,6 +3,9 @@
 
     :global(.parsedHtml:last-child) {
         margin-bottom: 0;
+        > *:last-child {
+            margin-bottom: 0;
+        }
     }
 }
 

--- a/src/components/_common/expandable/Expandable.module.scss
+++ b/src/components/_common/expandable/Expandable.module.scss
@@ -89,6 +89,12 @@
     }
     :global(.parsedHtml:last-child) {
         margin-bottom: 0;
+        > *:last-child {
+            margin-bottom: 0;
+            > *:last-child {
+                margin-bottom: 0;
+            }
+        }
     }
 
     :global(.part__html-area):has(.expandable) + :global(.part__html-area):has(.expandable) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Fjerner margin-bottom "rekursivt" fra nøstede barn i Accordion og Expandable

Litt stygt, men andre løsninger med JavaScript eller mer komplisert CSS jeg så på funka ikke så bra heller.