### PR TITLE
Fikse kategori tags

### DIFF
--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -3,6 +3,8 @@ import { BodyLong } from '@navikt/ds-react';
 import {
     AlternativeAudience as AlternativeAudienceType,
     Audience,
+    AudienceOptions,
+    getAudience,
 } from 'types/component-props/_mixins';
 import { usePageContentProps } from 'store/pageContext';
 import { Language, translator } from 'translations';
@@ -69,9 +71,41 @@ export const AlternativeAudience = () => {
     const { showProductName } = config;
     const { alternativeAudience } = data;
 
+    const getAudienceLabel = translator('audience', language);
+    const getProviderAudienceLabel = translator('providerAudience', language);
+
     if (!alternativeAudience) {
         return null;
     }
+
+    const getProviderTypes = (audience: AudienceOptions) => {
+        if (audience._selected !== Audience.PROVIDER) {
+            return [];
+        }
+        return audience[audience._selected].provider_audience;
+    };
+
+    const buildAudienceAffirmation = () => {
+        const { audience: currentAudience } = data;
+        const currentAudienceKey = getAudience(currentAudience);
+
+        if (!currentAudience || !currentAudienceKey || currentAudienceKey === 'person') {
+            return '';
+        }
+
+        const currentAudienceLabel = getAudienceLabel(currentAudienceKey);
+        const providerTypes = getProviderTypes(currentAudience) || [];
+        const providerTypesString = joinWithConjunction(
+            providerTypes.map((type) => getProviderAudienceLabel(type)),
+            language
+        );
+
+        const forString = `${getStringPart('for').charAt(0).toUpperCase()}${getStringPart(
+            'for'
+        ).slice(1)}`;
+
+        return `${forString} ${providerTypesString || currentAudienceLabel}. `;
+    };
 
     const getStringPart = translator('stringParts', language);
     const getRelatedString = translator('related', language);
@@ -83,6 +117,7 @@ export const AlternativeAudience = () => {
     return (
         <div className={style.alternativeAudience}>
             <BodyLong size="small" className={style.text}>
+                {buildAudienceAffirmation()}
                 {getRelatedString('relatedAudience').replace('{name}', productName)}{' '}
                 {audienceLinks.map((link, index) => (
                     <Fragment key={index}>

--- a/src/components/_common/card/card-utils.ts
+++ b/src/components/_common/card/card-utils.ts
@@ -2,7 +2,8 @@ import { CardType } from 'types/card';
 import { LinkProps } from 'types/link-props';
 import { AnimatedIconsProps } from 'types/content-props/animated-icons';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
-import { Audience, getAudience } from 'types/component-props/_mixins';
+import { Audience } from 'types/component-props/_mixins';
+import { getContentTagline } from 'components/_common/headers/sharedHeaderUtils';
 import {
     GuidePageProps,
     ProductPageProps,
@@ -10,8 +11,6 @@ import {
     ThemedArticlePageProps,
     ToolsPageProps,
 } from 'types/content-props/dynamic-page-props';
-import { Language, translator } from 'translations';
-import { getTranslatedTaxonomies, joinWithConjunction } from 'utils/string';
 
 export type CardTargetProps =
     | ProductPageProps
@@ -39,50 +38,21 @@ export const cardTypeMap = {
     [ContentType.GenericPage]: CardType.Generic,
 };
 
-const getCardTagline = (content: CardTargetProps, language: Language): string => {
-    const { data } = content;
-    const { taxonomy = [], customCategory, audience } = data;
-    const selectedAudience = audience && getAudience(audience);
-    const guideTaglines = translator('guides', language);
-    const situationTaglines = translator('situations', language);
-
-    if (content.type === ContentType.GuidePage) {
-        return (selectedAudience && guideTaglines(selectedAudience)) || '';
-    }
-
-    if (content.type === ContentType.SituationPage) {
-        return (selectedAudience && situationTaglines(selectedAudience)) || '';
-    }
-
-    if (taxonomy.length > 0 || customCategory) {
-        const taxonomyStrings = getTranslatedTaxonomies(taxonomy, language);
-        if (customCategory) {
-            taxonomyStrings.push(customCategory);
-        }
-
-        return joinWithConjunction(taxonomyStrings, language);
-    }
-
-    // Catch all if no other taglines could be determined
-    const productAudienceTranslations = translator('products', language);
-    return selectedAudience ? productAudienceTranslations(selectedAudience) : '';
-};
-
 export const getCardProps = (
     targetContent: CardTargetProps | undefined,
-    content: ContentProps,
+    currentContent: ContentProps,
     ingressOverride?: string
 ): CardProps | null => {
     if (!targetContent?.data) {
         return null;
     }
 
-    const { language } = content;
+    const { language } = currentContent;
 
     const { data, type, _path, displayName } = targetContent;
     const { title, ingress, illustration, externalProductUrl } = data;
 
-    const audience = content.data?.audience;
+    const audience = currentContent.data?.audience;
 
     const cardType = cardTypeMap[type];
     const cardUrl = externalProductUrl || _path;
@@ -93,7 +63,7 @@ export const getCardProps = (
         text: cardTitle,
     };
 
-    const tagline = getCardTagline(targetContent, language);
+    const tagline = getContentTagline(targetContent, language);
     const description = ingressOverride || ingress;
     const preferStaticIllustration = audience?._selected === Audience.EMPLOYER;
 

--- a/src/components/_common/headers/general-page-header/GeneralPageHeader.tsx
+++ b/src/components/_common/headers/general-page-header/GeneralPageHeader.tsx
@@ -1,7 +1,7 @@
 import { BodyLong, BodyShort, Heading } from '@navikt/ds-react';
 import {
     PagePropsForPageHeader,
-    getHeaderTagline,
+    getContentTagline,
 } from 'components/_common/headers/sharedHeaderUtils';
 import { Illustration } from 'components/_common/illustration/Illustration';
 import { ContentProps } from 'types/content-props/_content-common';
@@ -16,7 +16,7 @@ type Props = {
 export const GeneralPageHeader = (props: Props) => {
     const { pageProps } = props as { pageProps: PagePropsForPageHeader };
     const illustration = pageProps.data.illustration;
-    const tagLine = getHeaderTagline(pageProps);
+    const tagLine = getContentTagline(pageProps);
     const title = pageProps.data.title || pageProps.displayName;
     const { ingress, hideIngress } = pageProps.data;
 

--- a/src/components/_common/headers/sharedHeaderUtils.ts
+++ b/src/components/_common/headers/sharedHeaderUtils.ts
@@ -1,11 +1,6 @@
-import {
-    Audience,
-    ProductDataMixin,
-    getAudience,
-    getSubAudience,
-} from 'types/component-props/_mixins';
+import { ProductDataMixin, getAudience } from 'types/component-props/_mixins';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
-import { translator } from 'translations';
+import { Language, translator } from 'translations';
 import { getTranslatedTaxonomies, joinWithConjunction } from 'utils/string';
 
 export type PagePropsForPageHeader = ContentProps & {
@@ -15,54 +10,33 @@ export type PagePropsForPageHeader = ContentProps & {
     >;
 };
 
-export const getHeaderTagline = ({ type, language, data }: PagePropsForPageHeader) => {
-    const { taxonomy, audience, customCategory } = data;
+export const getContentTagline = (content: PagePropsForPageHeader, currentLanguage?: Language) => {
+    const { data } = content;
+    const { taxonomy = [], customCategory, audience } = data;
 
-    const currentAudience = getAudience(audience);
-    const subAudience = getSubAudience(audience);
+    const language = currentLanguage || content.language;
+    const selectedAudience = audience && getAudience(audience);
+    const guideTaglines = translator('guides', language);
+    const situationTaglines = translator('situations', language);
 
-    if (currentAudience === Audience.PROVIDER && subAudience && subAudience.length > 0) {
-        const getStringParts = translator('stringParts', language);
-        const getSubAudienceLabel = translator('providerAudience', language);
-        const subAudienceLabels = subAudience.map((audience) =>
-            getSubAudienceLabel(audience).toLowerCase()
-        );
-        return `${getStringParts('for')} ${joinWithConjunction(subAudienceLabels, language)}`;
+    if (content.type === ContentType.GuidePage) {
+        return (selectedAudience && guideTaglines(selectedAudience)) || '';
     }
 
-    if (type === ContentType.SituationPage) {
-        const getTaxonomyLabel = translator('situations', language);
-        return getTaxonomyLabel(currentAudience || 'person');
+    if (content.type === ContentType.SituationPage) {
+        return (selectedAudience && situationTaglines(selectedAudience)) || '';
     }
 
-    if (type === ContentType.GuidePage) {
-        const getTaxonomyLabel = translator('guides', language);
-        return getTaxonomyLabel(currentAudience || 'person');
+    if (taxonomy.length > 0 || customCategory) {
+        const taxonomyStrings = getTranslatedTaxonomies(taxonomy, language);
+        if (customCategory) {
+            taxonomyStrings.push(customCategory);
+        }
+
+        return joinWithConjunction(taxonomyStrings, language);
     }
 
-    if (type === ContentType.Overview) {
-        const getTaxonomyLabel = translator('overview', language);
-        return getTaxonomyLabel('any');
-    }
-
-    if (
-        taxonomy &&
-        (type === ContentType.ThemedArticlePage || type === ContentType.FormIntermediateStepPage)
-    ) {
-        const taxonomyArray = getTranslatedTaxonomies(taxonomy, language);
-        const allCategories = customCategory ? [...taxonomyArray, customCategory] : taxonomyArray;
-
-        return joinWithConjunction(allCategories, language);
-    }
-
-    if (
-        type === ContentType.ProductPage &&
-        (currentAudience === Audience.EMPLOYER || currentAudience === Audience.PROVIDER) // Will catch unlikely events where no sub audience for provider was set
-    ) {
-        const getTaxonomyLabel = translator('products', language);
-        return getTaxonomyLabel(currentAudience);
-    }
-
-    const taxonomyArray = taxonomy ? getTranslatedTaxonomies(taxonomy, language) : [];
-    return joinWithConjunction(taxonomyArray, language);
+    // Catch all if no other taglines could be determined
+    const productAudienceTranslations = translator('products', language);
+    return selectedAudience ? productAudienceTranslations(selectedAudience) : '';
 };

--- a/src/components/_common/headers/sharedHeaderUtils.ts
+++ b/src/components/_common/headers/sharedHeaderUtils.ts
@@ -14,7 +14,7 @@ export const getContentTagline = (content: PagePropsForPageHeader, currentLangua
     const { data } = content;
     const { taxonomy = [], customCategory, audience } = data;
 
-    const language = currentLanguage || content.language;
+    const language = currentLanguage ?? content.language;
     const selectedAudience = audience && getAudience(audience);
     const guideTaglines = translator('guides', language);
     const situationTaglines = translator('situations', language);

--- a/src/components/_common/headers/sharedHeaderUtils.ts
+++ b/src/components/_common/headers/sharedHeaderUtils.ts
@@ -20,11 +20,11 @@ export const getContentTagline = (content: PagePropsForPageHeader, currentLangua
     const situationTaglines = translator('situations', language);
 
     if (content.type === ContentType.GuidePage) {
-        return (selectedAudience && guideTaglines(selectedAudience)) || '';
+        return (selectedAudience && guideTaglines(selectedAudience)) ?? '';
     }
 
     if (content.type === ContentType.SituationPage) {
-        return (selectedAudience && situationTaglines(selectedAudience)) || '';
+        return (selectedAudience && situationTaglines(selectedAudience)) ?? '';
     }
 
     if (taxonomy.length > 0 || customCategory) {

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -7,7 +7,7 @@ import { translator } from 'translations';
 import { Illustration } from 'components/_common/illustration/Illustration';
 import {
     PagePropsForPageHeader,
-    getHeaderTagline,
+    getContentTagline,
 } from 'components/_common/headers/sharedHeaderUtils';
 import { themedPageHeaderGetTypeClassName } from './themedPageHeaderUtils';
 
@@ -25,7 +25,7 @@ export const ThemedPageHeader = ({ contentProps, showTimeStamp = true }: Props) 
     const getDatesLabel = translator('dates', language);
 
     const typeSpecificClassName = themedPageHeaderGetTypeClassName(type);
-    const subTitle = getHeaderTagline(contentProps);
+    const subTitle = getContentTagline(contentProps);
 
     const modified =
         showTimeStamp &&

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -179,7 +179,7 @@ export const translationsBundleNb = {
     },
     situations: {
         person: 'Dette kan du ha rett til',
-        employer: 'For arbeidsgivere',
+        employer: 'Hva arbeidsgivere må vite',
         provider: 'For samarbeidspartnere',
     },
     guides: {

--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -184,8 +184,8 @@ export const translationsBundleNb = {
     },
     guides: {
         person: 'Slik gjør du det',
-        employer: 'For arbeidsgivere',
-        provider: 'For samarbeidspartnere',
+        employer: 'Slik gjør du det',
+        provider: 'Slik gjør du det',
     },
     publishingCalendar: {
         event: 'Hendelse',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -200,8 +200,8 @@ export const translationsBundleEn: PartialTranslations = {
         provider: 'For providers',
     },
     situations: {
-        person: 'You may have right to this',
-        employer: 'For employers',
+        person: 'Your rights',
+        employer: 'What employers should know',
         provider: 'For providers',
     },
     guides: {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fikser taglines og slår sammen logikk for uthenting av tagline i overskrift og minikort.
- Gjeninnfører "For arbeidsgiver. Det finnes..."-tekst i aktuelle målgrupper.

## Testing
Testes i dev


