### PR TITLE
Reduser avstand på sider uten intern-meny

### DIFF
--- a/src/components/_common/alternativeAudience/AlternativeAudience.module.scss
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.module.scss
@@ -1,4 +1,5 @@
 .alternativeAudience {
+    margin-top: var(--a-spacing-7);
     margin-bottom: var(--a-spacing-7);
 
     .text {

--- a/src/components/_common/headers/general-page-header/GeneralPageHeader.module.scss
+++ b/src/components/_common/headers/general-page-header/GeneralPageHeader.module.scss
@@ -40,4 +40,8 @@
         font-variant: all-small-caps;
         color: var(--a-text-subtle);
     }
+
+    .ingress {
+        margin-bottom: 0 !important;
+    }
 }

--- a/src/components/_common/headers/general-page-header/GeneralPageHeader.module.scss
+++ b/src/components/_common/headers/general-page-header/GeneralPageHeader.module.scss
@@ -41,7 +41,7 @@
         color: var(--a-text-subtle);
     }
 
-    .ingress {
-        margin-bottom: 0 !important;
+    .ingress:global(.navds-body-long) {
+        margin-bottom: 0;
     }
 }

--- a/src/components/_common/headers/general-page-header/GeneralPageHeader.tsx
+++ b/src/components/_common/headers/general-page-header/GeneralPageHeader.tsx
@@ -36,7 +36,9 @@ export const GeneralPageHeader = (props: Props) => {
                 {title}
             </Heading>
             {ingress && !hideIngress && !props.hideIngressOverride && (
-                <BodyLong size="large">{ingress}</BodyLong>
+                <BodyLong className={style.ingress} size="large">
+                    {ingress}
+                </BodyLong>
             )}
         </div>
     );


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter margin-top på alternative-audience istedenfor margin-bottom på ingressen.
- Syns det ser greit ut på sider uten internmeny, sider med hverken internmeny eller alternativeaudience, og sider uten begge deler

![image](https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/59e67463-42de-4002-9288-43dd9460fcc0)
