### PR TITLE
Reduser avstand til toppen hvis språkvelger

### DIFF
--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -26,6 +26,10 @@ $verticalMargin: 1.75rem;
     }
 }
 
+.pullUp {
+    padding-top: 0;
+}
+
 .mainContent {
     grid-column: 2;
     grid-row: 1;

--- a/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -9,6 +9,7 @@ import { GeneralPageHeader } from 'components/_common/headers/general-page-heade
 import { PageUpdatedInfo } from 'components/_common/pageUpdatedInfo/PageUpdatedInfo';
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
+import { classNames } from 'utils/classnames';
 
 import styles from './PageWithSideMenus.module.scss';
 
@@ -19,7 +20,7 @@ type Props = {
 
 export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
-    const { language } = usePageContentProps();
+    const { language, languages } = usePageContentProps();
     const getLabel = translator('internalNavigation', language);
 
     if (!regions || !config) {
@@ -27,8 +28,8 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     }
 
     const { showInternalNav, anchorLinks } = config;
-
     const { pageContent, topPageContent, bottomRow } = regions;
+    const hasMultipleLanguages = languages && languages?.length > 0;
 
     const isNewLayoutPage =
         pageProps.type === ContentType.ProductPage ||
@@ -38,7 +39,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
 
     return (
         <LayoutContainer
-            className={styles.pageWithSideMenus}
+            className={classNames(styles.pageWithSideMenus, hasMultipleLanguages && styles.pullUp)}
             pageProps={pageProps}
             layoutProps={layoutProps}
         >

--- a/src/components/pages/situation-page/SituationPage.module.scss
+++ b/src/components/pages/situation-page/SituationPage.module.scss
@@ -27,4 +27,8 @@
             width: 100%;
         }
     }
+
+    .pullUp {
+        margin-top: 0;
+    }
 }

--- a/src/components/pages/situation-page/SituationPage.tsx
+++ b/src/components/pages/situation-page/SituationPage.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { SituationPageProps } from 'types/content-props/dynamic-page-props';
 import { ComponentMapper } from 'components/ComponentMapper';
+import { usePageContentProps } from 'store/pageContext';
+import { classNames } from 'utils/classnames';
 
 import styles from './SituationPage.module.scss';
 
 export const SituationPage = (props: SituationPageProps) => {
+    const { languages } = usePageContentProps();
+    const hasMultipleLanguages = languages && languages?.length > 0;
+
     return (
         <article className={styles.situationPage}>
-            <div className={styles.content}>
+            <div className={classNames(styles.content, hasMultipleLanguages && styles.pullUp)}>
                 <ComponentMapper componentProps={props.page} pageProps={props} />
             </div>
         </article>


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter (omtrent) samme toppavstand på sider som har språkvelger som sider som ikke har den.
- Påvirker bl.a. nav.no/aap, nav.no/ukraina, nav.no/kontaktoss

![image](https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/5e6be0c6-7503-4f47-9d86-5bf91ec586d4)


