### PR TITLE
Endrer XP_ORIGIN for dev-miljøer

### DIFF
--- a/.github/workflows/deploy.dev1.yml
+++ b/.github/workflows/deploy.dev1.yml
@@ -25,7 +25,7 @@ jobs:
       APP_ORIGIN: https://www.ansatt.dev.nav.no
       REVALIDATOR_PROXY_ORIGIN: http://nav-enonicxp-frontend-revalidator-proxy-dev1
       DECORATOR_URL: https://dekoratoren.ekstern.dev.nav.no
-      XP_ORIGIN: https://portal-admin-dev.oera.no
+      XP_ORIGIN: https://www.dev.nav.no
       TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect
       INNLOGGINGSSTATUS_URL: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api/auth
       RELEASE_TAG: dev1-${{ github.sha }}

--- a/.github/workflows/deploy.dev2.yml
+++ b/.github/workflows/deploy.dev2.yml
@@ -25,7 +25,7 @@ jobs:
       APP_ORIGIN: https://www-2.ansatt.dev.nav.no
       REVALIDATOR_PROXY_ORIGIN: http://nav-enonicxp-frontend-revalidator-proxy-dev2
       DECORATOR_URL: https://dekoratoren.ekstern.dev.nav.no
-      XP_ORIGIN: https://portal-admin-q6.oera.no
+      XP_ORIGIN: https://www-q6.nav.no
       TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect
       INNLOGGINGSSTATUS_URL: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api/auth
       RELEASE_TAG: dev2-${{ github.sha }}

--- a/.nais/vars/vars-dev1-failover.yml
+++ b/.nais/vars/vars-dev1-failover.yml
@@ -3,7 +3,7 @@ frontendApp: nav-enonicxp-frontend-dev1
 revalidatorApp: nav-enonicxp-frontend-revalidator-proxy-dev1
 dekoratorenApp: nav-dekoratoren
 externalHosts:
-  - portal-admin-dev.oera.no
+  - www.dev.nav.no
 secret: nav-enonicxp-dev1
 ingresses:
   - https://www-failover.intern.dev.nav.no

--- a/.nais/vars/vars-dev1.yml
+++ b/.nais/vars/vars-dev1.yml
@@ -2,7 +2,7 @@ appName: nav-enonicxp-frontend-dev1
 revalidatorApp: nav-enonicxp-frontend-revalidator-proxy-dev1
 dekoratorenApp: nav-dekoratoren
 externalHosts:
-  - portal-admin-dev.oera.no
+  - www.dev.nav.no
   - www-failover.intern.dev.nav.no
 secret: nav-enonicxp-dev1
 ingresses:

--- a/.nais/vars/vars-dev2-failover.yml
+++ b/.nais/vars/vars-dev2-failover.yml
@@ -3,7 +3,7 @@ frontendApp: nav-enonicxp-frontend-dev2
 revalidatorApp: nav-enonicxp-frontend-revalidator-proxy-dev2
 dekoratorenApp: nav-dekoratoren-beta
 externalHosts:
-  - portal-admin-q6.oera.no
+  - www-q6.nav.no
 secret: nav-enonicxp-dev2
 ingresses:
   - https://www-2-failover.intern.dev.nav.no

--- a/.nais/vars/vars-dev2.yml
+++ b/.nais/vars/vars-dev2.yml
@@ -2,7 +2,7 @@ appName: nav-enonicxp-frontend-dev2
 revalidatorApp: nav-enonicxp-frontend-revalidator-proxy-dev2
 dekoratorenApp: nav-dekoratoren-beta
 externalHosts:
-  - www-q6.oera.no
+  - www-q6.nav.no
   - www-2-failover.intern.dev.nav.no
 secret: nav-enonicxp-dev2
 ingresses:

--- a/.nais/vars/vars-dev2.yml
+++ b/.nais/vars/vars-dev2.yml
@@ -2,7 +2,7 @@ appName: nav-enonicxp-frontend-dev2
 revalidatorApp: nav-enonicxp-frontend-revalidator-proxy-dev2
 dekoratorenApp: nav-dekoratoren-beta
 externalHosts:
-  - portal-admin-q6.oera.no
+  - www-q6.oera.no
   - www-2-failover.intern.dev.nav.no
 secret: nav-enonicxp-dev2
 ingresses:


### PR DESCRIPTION
Denne må matche vhost-mappingene i XP, ellers får vi i noen tilfeller out of scope errors ved generering av URL'er fra portal-lib.

(Endret til å bruke portal-admin* for stund siden pga DNS feil på de "gamle" www.dev/www-q6 domenene, men dette er fikset nå 😄  )