### PR TITLE
Fjerner justify og redaktørstyrt styling. Fjerner ubrukt setId prop

### DIFF
--- a/src/components/_common/headers/Header.module.scss
+++ b/src/components/_common/headers/Header.module.scss
@@ -3,24 +3,11 @@
 .header {
     display: flex;
     flex-direction: column;
-    align-items: center;
     position: relative;
     width: 100%;
 
     &:focus {
         outline: none;
         box-shadow: none;
-    }
-
-    &__left {
-        align-items: flex-start;
-    }
-
-    &__center {
-        align-items: center;
-    }
-
-    &__right {
-        align-items: flex-end;
     }
 }

--- a/src/components/_common/headers/Header.tsx
+++ b/src/components/_common/headers/Header.tsx
@@ -3,7 +3,6 @@ import { Heading } from '@navikt/ds-react';
 import { onlyText } from 'utils/react-children';
 import { classNames } from 'utils/classnames';
 import { Level, levelToSize, Size } from 'types/typo-style';
-import { HeaderCommonConfig } from 'types/component-props/_mixins';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
 
 // eslint-disable-next-line css-modules/no-unused-class
@@ -13,33 +12,18 @@ type Props = {
     children: React.ReactNode;
     level: Level;
     size?: Size;
-    justify?: HeaderCommonConfig['justify'];
     hideCopyButton?: boolean;
     anchorId?: string;
-    setId?: boolean;
     className?: string;
 };
 
-export const Header = ({
-    children,
-    size,
-    level,
-    justify,
-    hideCopyButton,
-    anchorId,
-    setId = true,
-    className,
-}: Props) => {
+export const Header = ({ children, size, level, hideCopyButton, anchorId, className }: Props) => {
     const anchor = anchorId ? (anchorId.startsWith('#') ? anchorId : `#${anchorId}`) : undefined;
 
     const fallbackSizeByLevel = levelToSize[level] || 'large';
 
     return (
-        <div
-            className={classNames(style.header, justify && style[`header__${justify}`], className)}
-            id={setId ? anchorId : undefined}
-            tabIndex={-1}
-        >
+        <div className={classNames(style.header, className)} id={anchorId} tabIndex={-1}>
             <Heading size={size || fallbackSizeByLevel} level={level}>
                 {children}
             </Heading>

--- a/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
+++ b/src/components/_common/headers/themed-page-header/ThemedPageHeader.tsx
@@ -40,7 +40,7 @@ export const ThemedPageHeader = ({ contentProps, showTimeStamp = true }: Props) 
         <div className={classNames(style.themedPageHeader, typeSpecificClassName)}>
             <Illustration illustration={illustration} className={style.illustration} />
             <div className={style.text}>
-                <Header justify={'left'} level={'1'} size={'xlarge'} className={style.header}>
+                <Header level={'1'} size={'xlarge'} className={style.header}>
                     {title || displayName}
                 </Header>
                 {(subTitle || modified) && (

--- a/src/components/_editor-only/site-info/header/SiteInfoHeader.tsx
+++ b/src/components/_editor-only/site-info/header/SiteInfoHeader.tsx
@@ -23,9 +23,7 @@ export const SiteInfoHeader = ({ serverName, clusterState }: Props) => {
     return (
         <div className={style.container}>
             <div>
-                <Header level={'1'} justify={'left'}>
-                    {'nav.no cms status'}
-                </Header>
+                <Header level={'1'}>{'nav.no cms status'}</Header>
             </div>
             {clusterState ? (
                 <AlertBox

--- a/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
+++ b/src/components/layouts/areapage-situations/AreapageSituationsLayout.tsx
@@ -33,7 +33,7 @@ export const AreapageSituationsLayout = ({ pageProps, layoutProps }: Props) => {
             layoutProps={layoutProps}
             className={style.container}
         >
-            <Header level={'2'} justify={'left'} size={'large'} className={style.header}>
+            <Header level={'2'} size={'large'} className={style.header}>
                 {title}
             </Header>
             <EditorHelp

--- a/src/components/layouts/flex-cols/FlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/FlexColsLayout.tsx
@@ -39,7 +39,6 @@ export const FlexColsLayout = ({ pageProps, layoutProps }: Props) => {
                 <Header
                     level={'2'}
                     size={'large'}
-                    justify={'left'}
                     hideCopyButton={!toggleCopyButton}
                     anchorId={anchorId}
                     className={style.header}

--- a/src/components/layouts/flex-cols/ProductPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/ProductPageFlexColsLayout.tsx
@@ -37,7 +37,6 @@ export const ProductPageFlexColsLayout = ({ pageProps, layoutProps }: Props) => 
                 <Header
                     level="2"
                     size="large"
-                    justify={'left'}
                     hideCopyButton={!toggleCopyButton}
                     anchorId={anchorId}
                     className={style.header}

--- a/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
+++ b/src/components/layouts/flex-cols/SituationPageFlexColsLayout.tsx
@@ -54,7 +54,6 @@ export const SituationPageFlexColsLayout = ({ pageProps, layoutProps }: Props) =
                     <Header
                         level="2"
                         size="large"
-                        justify={isShelf ? 'center' : 'left'}
                         hideCopyButton={!toggleCopyButton}
                         anchorId={anchorId}
                         className={classNames(style.header, isShelf && style.shelfHeader)}

--- a/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
+++ b/src/components/layouts/frontpage-loggedin-section/FrontpageLoggedinSectionLayout.tsx
@@ -22,7 +22,7 @@ const HeaderWithName = ({ headerText }: { headerText: string }) => {
     const greetings = translator('greetings', language);
 
     return (
-        <Header level={'2'} size={'large'} justify={'left'} className={style.header}>
+        <Header level={'2'} size={'large'} className={style.header}>
             {name ? headerText.replace('$navn', capitalize(name)) : greetings('hi')}
         </Header>
     );
@@ -53,7 +53,7 @@ export const FrontpageLoggedinSectionLayout = ({ layoutProps, pageProps }: Props
                 data-hj-suppress
             >
                 <HeaderWithName headerText={header} />
-                <Header level={'2'} size={'small'} justify={'left'} className={style.services}>
+                <Header level={'2'} size={'small'} className={style.services}>
                     {yourServicesText('yourServices')}
                 </Header>
                 <Region pageProps={pageProps} regionProps={regions.cards} className={style.cards} />

--- a/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
+++ b/src/components/layouts/index-page/front-page/FrontPageAreaNavigation.tsx
@@ -41,7 +41,7 @@ export const FrontPageAreaNavigation = ({ content }: Props) => {
 
     return (
         <div className={classNames(style.wrapper, audience && style[audience])}>
-            <Header level={'2'} justify={'left'} size={'large'} className={style.header}>
+            <Header level={'2'} size={'large'} className={style.header}>
                 {areasHeader}
             </Header>
             <nav aria-label="Velg område">

--- a/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -103,7 +103,6 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
                 <Header
                     size="large"
                     level="2"
-                    justify={'left'}
                     hideCopyButton={true}
                     className={classNames(style.header, !!iconImgProps && style.headerWithIcon)}
                 >

--- a/src/components/macros/header-with-anchor/MacroHeaderWithAnchor.tsx
+++ b/src/components/macros/header-with-anchor/MacroHeaderWithAnchor.tsx
@@ -28,7 +28,6 @@ export const MacroHeaderWithAnchor = ({ config }: MacroHeaderWithAnchorProps) =>
             size={size}
             anchorId={id}
             hideCopyButton={true}
-            justify={'left'}
             className={style.headerWithAnchor}
         >
             {headerText}

--- a/src/components/pages/forms-overview-page/header/FormsOverviewHeader.tsx
+++ b/src/components/pages/forms-overview-page/header/FormsOverviewHeader.tsx
@@ -12,7 +12,7 @@ export const FormsOverviewHeader = (props: FormsOverviewProps) => {
 
     return (
         <div className={style.container}>
-            <Header level={'1'} size={'xlarge'} justify={'left'} className={style.header}>
+            <Header level={'1'} size={'xlarge'} className={style.header}>
                 {title}
             </Header>
             <BodyShort className={style.subHeader}>{underTitle}</BodyShort>

--- a/src/components/parts/filters-menu/FiltersMenuPart.tsx
+++ b/src/components/parts/filters-menu/FiltersMenuPart.tsx
@@ -102,7 +102,7 @@ export const FiltersMenuPart = ({ config, path }: PartComponentProps<PartType.Fi
     return (
         <section className={style.filtersMenu} aria-describedby="description">
             {title && (
-                <Header level="2" size="large" justify="left">
+                <Header level="2" size="large">
                     {title}
                 </Header>
             )}

--- a/src/components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart.tsx
+++ b/src/components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart.tsx
@@ -30,7 +30,7 @@ export const FrontpageCurrentTopicsPart = ({
 
     return (
         <div className={style.currentTopics}>
-            <Header size={'large'} level={'2'} justify={'left'} className={style.header}>
+            <Header size={'large'} level={'2'} className={style.header}>
                 {title}
             </Header>
             <ul className={style.list}>

--- a/src/components/parts/frontpage-shortcuts/FrontpageShortcutsPart.tsx
+++ b/src/components/parts/frontpage-shortcuts/FrontpageShortcutsPart.tsx
@@ -60,7 +60,7 @@ export const FrontpageShortcutsPart = ({
             }
         >
             {sectionTitle && (
-                <Header size="large" level="2" justify="left" className={style.header}>
+                <Header size="large" level="2" className={style.header}>
                     {sectionTitle}
                 </Header>
             )}

--- a/src/components/parts/header/HeaderPart.tsx
+++ b/src/components/parts/header/HeaderPart.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Header } from 'components/_common/headers/Header';
 import { HeadingTag, headingToLevel, headingToSize } from 'types/typo-style';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
-import { HeaderCommonConfig } from 'types/component-props/_mixins';
 
 import style from './HeaderPart.module.scss';
 
@@ -10,7 +9,7 @@ export type PartConfigHeader = {
     title: string;
     anchorId: string;
     titleTag: HeadingTag;
-} & HeaderCommonConfig;
+};
 
 export const HeaderPart = ({ config }: PartComponentProps<PartType.Header>) => {
     if (!config) {
@@ -32,7 +31,6 @@ export const HeaderPart = ({ config }: PartComponentProps<PartType.Header>) => {
             level={level}
             size={size}
             anchorId={anchorId}
-            justify={'left'}
             hideCopyButton={true}
             className={style.headerPart}
         >

--- a/src/types/component-props/_mixins.ts
+++ b/src/types/component-props/_mixins.ts
@@ -1,6 +1,5 @@
 import { ContentListProps } from 'types/content-props/content-list-props';
 import { ContentProps } from 'types/content-props/_content-common';
-import { HeaderTypoStyle } from 'types/typo-style';
 import { PictogramsProps } from 'types/content-props/pictograms';
 import { Taxonomy } from 'types/taxonomies';
 import { AuthStateType } from 'store/slices/authState';
@@ -165,13 +164,3 @@ export type LayoutCommonConfigMixin = Partial<
         }>;
     } & RenderOnAuthStateMixin
 >;
-
-export type HeaderCommonConfig = {
-    justify: 'left' | 'center' | 'right';
-    typo: OptionSetSingle<{
-        default: EmptyObject;
-        custom: {
-            typo: HeaderTypoStyle;
-        };
-    }>;
-};

--- a/src/types/typo-style.ts
+++ b/src/types/typo-style.ts
@@ -2,14 +2,6 @@ export type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 export type Level = '1' | '2' | '3' | '4' | '5' | '6';
 export type Size = 'xlarge' | 'large' | 'medium' | 'small' | 'xsmall';
 
-export enum HeaderTypoStyle {
-    Sidetittel = 'sidetittel',
-    Innholdstittel = 'innholdstittel',
-    Systemtittel = 'systemtittel',
-    Undertittel = 'undertittel',
-    Element = 'element',
-}
-
 export const headingToLevel: Record<HeadingTag, Level> = {
     h1: '1',
     h2: '2',
@@ -37,14 +29,6 @@ export const levelToSize: Record<Level, Size> = {
     4: 'small',
     5: 'xsmall',
     6: 'xsmall',
-};
-
-export const typoToSize: Record<HeaderTypoStyle, Size> = {
-    [HeaderTypoStyle.Sidetittel]: 'xlarge',
-    [HeaderTypoStyle.Innholdstittel]: 'large',
-    [HeaderTypoStyle.Systemtittel]: 'medium',
-    [HeaderTypoStyle.Undertittel]: 'small',
-    [HeaderTypoStyle.Element]: 'xsmall',
 };
 
 export const isHeadingTag = (tag?: string): tag is HeadingTag =>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fjerner bruk av justify. Denne var satt til `"left"` i alle props inn til Header bortsett fra varehylle. Her er det også meningen at header skal være justify "left" i henhold til designet.
- Fjerner HeaderCommonConfig type og tilhørende typer. Disse er ikke lenger i bruk fordi header-common i Enonic ikke lenger finnes. Det skal heller ikke være mulig å styre presentasjon i like stor grad av redaktørene.
- Fjerner setId. Denne var ikke i bruk andre steder enn i selve Header-komponenten og ble alltid satt til `true`.

## Testing
Testes i dev

