### PR TITLE
Fikser feil referanse i utlisting av dato

### DIFF
--- a/src/components/parts/_legacy/page-list/PageListLegacyPart.tsx
+++ b/src/components/parts/_legacy/page-list/PageListLegacyPart.tsx
@@ -56,7 +56,7 @@ export const PageListLegacyPart = (props: ContentProps) => {
                             )}
                             {!hideDatesInList && (
                                 <div className={style.date}>
-                                    <ArtikkelDato contentProps={props} />
+                                    <ArtikkelDato contentProps={section} />
                                 </div>
                             )}
                         </article>

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -123,6 +123,8 @@ export const getPublishedAndModifiedString = (
     const publishedTime = getPublishedDateTime(content);
     const getDatesLabel = translator('dates', language);
 
+    console.log(content);
+
     const wasModifiedAfterPublish = new Date(modifiedTime) > new Date(publishedTime);
 
     const publishedString = buildDateString({


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Feil props-referanse ble sendt inn til ArtikkelDato som gir feil dato i utlistingen.

## Testing
Testes i dev2
