### PR TITLE
Fokus på hele kortene i varehyller

### DIFF
--- a/src/components/_common/card/LargeCardV2.module.scss
+++ b/src/components/_common/card/LargeCardV2.module.scss
@@ -29,28 +29,6 @@
     }
 }
 
-.container::before,
-.container::after {
-    content: '';
-    position: absolute;
-    background-color: var(--line-color);
-    z-index: 1;
-}
-
-.container::after {
-    inline-size: 100vw;
-    block-size: var(--line-thickness);
-    inset-inline-start: 0;
-    inset-block-start: calc(var(--line-offset) * -1);
-}
-
-.container::before {
-    inline-size: var(--line-thickness);
-    block-size: 100vh;
-    inset-block-start: 0;
-    inset-inline-start: calc(var(--line-offset) * -1);
-}
-
 .illustration {
     width: 3.75rem;
     height: 3.75rem;

--- a/src/components/_common/card/LargeCardV2.module.scss
+++ b/src/components/_common/card/LargeCardV2.module.scss
@@ -27,6 +27,10 @@
             text-decoration-thickness: 2px;
         }
     }
+
+    &:focus-within {
+        box-shadow: var(--a-shadow-focus);
+    }
 }
 
 .illustration {
@@ -45,6 +49,10 @@
 .link {
     text-underline-offset: 0.15625rem;
     text-decoration-thickness: 1px;
+
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 .linkText {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter fokus rundt hele kortet
- Fjerner styling som ble glemt i hasteomskriving av varehyllene

<img width="728" alt="image" src="https://github.com/navikt/nav-enonicxp-frontend/assets/71373910/3387bfcf-eaf4-431f-9b8b-db3a17de18cf">

