### PR TITLE
Clear render cache on decorator update

### DIFF
--- a/.github/workflows/deploy.dev2.yml
+++ b/.github/workflows/deploy.dev2.yml
@@ -24,7 +24,7 @@ jobs:
       ADMIN_ORIGIN: https://portal-admin-q6.oera.no
       APP_ORIGIN: https://www-2.ansatt.dev.nav.no
       REVALIDATOR_PROXY_ORIGIN: http://nav-enonicxp-frontend-revalidator-proxy-dev2
-      DECORATOR_URL: https://dekoratoren.ekstern.dev.nav.no
+      DECORATOR_URL: https://dekoratoren-beta.intern.dev.nav.no
       XP_ORIGIN: https://www-q6.nav.no
       TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect
       INNLOGGINGSSTATUS_URL: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api/auth

--- a/.nais/vars/vars-dev2.yml
+++ b/.nais/vars/vars-dev2.yml
@@ -4,6 +4,7 @@ dekoratorenApp: nav-dekoratoren-beta
 externalHosts:
   - www-q6.nav.no
   - www-2-failover.intern.dev.nav.no
+  - dekoratoren-beta.intern.dev.nav.no
 secret: nav-enonicxp-dev2
 ingresses:
   - https://www-2.ansatt.dev.nav.no

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -4,11 +4,18 @@ import { CacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
 import { RedisCache } from 'srcCommon/redis';
 import { pathToCacheKey } from 'srcCommon/cache-key';
 import { logger } from 'srcCommon/logger';
+import { addDecoratorUpdateListener } from 'srcCommon/decorator-version-updater';
 
 export const redisCache = new RedisCache();
 
 const localCache = new LRUCache<string, CacheHandlerValue>({
     max: 2000,
+});
+
+addDecoratorUpdateListener((versionId) => {
+    logger.info('Decorator updated, clearing render cache!');
+    redisCache.updateRenderCacheKeyPrefix(versionId);
+    localCache.clear();
 });
 
 export default class PageCacheHandler {

--- a/server/src/cache/page-cache-handler.ts
+++ b/server/src/cache/page-cache-handler.ts
@@ -13,7 +13,7 @@ const localCache = new LRUCache<string, CacheHandlerValue>({
 });
 
 addDecoratorUpdateListener((versionId) => {
-    logger.info('Decorator updated, clearing render cache!');
+    logger.info(`Decorator updated, clearing render cache - ${versionId}`);
     redisCache.updateRenderCacheKeyPrefix(versionId);
     localCache.clear();
 });

--- a/server/src/cache/revalidator-proxy-heartbeat.ts
+++ b/server/src/cache/revalidator-proxy-heartbeat.ts
@@ -3,8 +3,8 @@
 // See: https://github.com/navikt/nav-enonicxp-frontend-revalidator-proxy
 import { networkInterfaces } from 'os';
 import { logger } from 'srcCommon/logger';
-import { getRenderCacheKeyPrefix, getResponseCacheKeyPrefix } from 'srcCommon/redis';
 import { objectToQueryString } from 'srcCommon/fetch-utils';
+import { redisCache } from './page-cache-handler';
 
 const { ENV, NODE_ENV, DOCKER_HOST_ADDRESS, REVALIDATOR_PROXY_ORIGIN, SERVICE_SECRET } =
     process.env;
@@ -22,10 +22,7 @@ const getPodAddress = () => {
     const podAddress = nets?.eth0?.[0]?.address;
 
     if (!podAddress) {
-        logger.error(
-            'Error: pod IP address could not be determined' +
-                ' - Event driven cache regeneration will not be active for this instance'
-        );
+        logger.error('Error: pod IP address could not be determined!');
         return null;
     }
 
@@ -37,9 +34,10 @@ const getProxyLivenessUrl = (buildId: string) => {
     return podAddress
         ? `${REVALIDATOR_PROXY_ORIGIN}/liveness${objectToQueryString({
               address: podAddress,
-              redisPrefixes: [getRenderCacheKeyPrefix(buildId), getResponseCacheKeyPrefix()].join(
-                  ','
-              ),
+              redisPrefixes: [
+                  redisCache.responseCacheKeyPrefix,
+                  redisCache.renderCacheKeyPrefix,
+              ].join(','),
           })}`
         : null;
 };
@@ -66,6 +64,12 @@ export const initRevalidatorProxyHeartbeat = (buildId: string) => {
     logger.info('Starting heartbeat loop');
 
     const heartbeatFunc = () => {
+        const url = getProxyLivenessUrl(buildId);
+        if (!url) {
+            logger.error('Failed to determine revalidator heartbeat url!');
+            return;
+        }
+
         fetch(url, {
             headers: { secret: SERVICE_SECRET },
         }).catch((e) => logger.error(`Failed to send heartbeat signal - ${e}`));

--- a/server/src/server-setup/server-setup.ts
+++ b/server/src/server-setup/server-setup.ts
@@ -10,10 +10,7 @@ import { handleGetPendingResponses } from 'req-handlers/pending-responses';
 import { serverSetupDev } from 'server-setup/server-setup-dev';
 import { logger } from 'srcCommon/logger';
 import { redisCache } from 'cache/page-cache-handler';
-import {
-    fetchDecoratorVersion,
-    startDecoratorVersionUpdater,
-} from 'srcCommon/decorator-version-updater';
+import { fetchDecoratorVersion } from 'srcCommon/decorator-version-updater';
 
 // Set the no-cache header on json files from the incremental cache to ensure
 // data requested during client side navigation is always validated if cached
@@ -40,8 +37,6 @@ export const serverSetup = async (expressApp: Express, nextApp: NextServer) => {
     }
 
     await redisCache.init(currentBuildId, decoratorVersionId ?? '');
-
-    startDecoratorVersionUpdater();
 
     logger.info(
         `Current build id: ${currentBuildId} - Current decorator version id: ${decoratorVersionId}`

--- a/server/src/server-setup/server-setup.ts
+++ b/server/src/server-setup/server-setup.ts
@@ -9,11 +9,8 @@ import { handleInvalidateAllReq } from 'req-handlers/invalidate-all';
 import { handleGetPendingResponses } from 'req-handlers/pending-responses';
 import { serverSetupDev } from 'server-setup/server-setup-dev';
 import { logger } from 'srcCommon/logger';
-import PageCacheHandler, { redisCache } from 'cache/page-cache-handler';
-import {
-    addDecoratorUpdateListener,
-    fetchDecoratorVersion,
-} from 'srcCommon/decorator-version-updater';
+import { redisCache } from 'cache/page-cache-handler';
+import { fetchDecoratorVersion } from 'srcCommon/decorator-version-updater';
 
 // Set the no-cache header on json files from the incremental cache to ensure
 // data requested during client side navigation is always validated if cached
@@ -39,7 +36,7 @@ export const serverSetup = async (expressApp: Express, nextApp: NextServer) => {
         logger.error('Failed to fetch decorator version!');
     }
 
-    await redisCache.init(currentBuildId, decoratorVersionId || '');
+    await redisCache.init(currentBuildId, decoratorVersionId ?? '');
 
     logger.info(
         `Current build id: ${currentBuildId} - Current decorator version id: ${decoratorVersionId}`

--- a/server/src/server-setup/server-setup.ts
+++ b/server/src/server-setup/server-setup.ts
@@ -10,7 +10,10 @@ import { handleGetPendingResponses } from 'req-handlers/pending-responses';
 import { serverSetupDev } from 'server-setup/server-setup-dev';
 import { logger } from 'srcCommon/logger';
 import { redisCache } from 'cache/page-cache-handler';
-import { fetchDecoratorVersion } from 'srcCommon/decorator-version-updater';
+import {
+    fetchDecoratorVersion,
+    startDecoratorVersionUpdater,
+} from 'srcCommon/decorator-version-updater';
 
 // Set the no-cache header on json files from the incremental cache to ensure
 // data requested during client side navigation is always validated if cached
@@ -37,6 +40,8 @@ export const serverSetup = async (expressApp: Express, nextApp: NextServer) => {
     }
 
     await redisCache.init(currentBuildId, decoratorVersionId ?? '');
+
+    startDecoratorVersionUpdater();
 
     logger.info(
         `Current build id: ${currentBuildId} - Current decorator version id: ${decoratorVersionId}`

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import { getNextBuildId, getNextServer } from 'next-utils';
 import { logger } from 'srcCommon/logger';
 import path from 'path';
 import { injectNextImageCacheDir } from 'cache/image-cache-handler';
+import { initDecoratorVersionUpdater } from 'srcCommon/decorator-version-updater';
 import { websockets } from './websockets';
 
 const promMiddleware = promBundle({
@@ -80,6 +81,7 @@ nextApp.prepare().then(async () => {
         if (!isFailover) {
             const buildId = getNextBuildId(nextServer);
             initRevalidatorProxyHeartbeat(buildId);
+            initDecoratorVersionUpdater();
         }
 
         logger.info(`Server started on port ${port}`);

--- a/src/utils/fetch/fetch-content.ts
+++ b/src/utils/fetch/fetch-content.ts
@@ -26,7 +26,7 @@ const getXpCacheKey =
           })
         : () => ({});
 
-const redisCache = await new RedisCache().init(process.env.BUILD_ID);
+const redisCache = await new RedisCache().init(process.env.BUILD_ID, '');
 
 const fetchConfig = {
     headers: {

--- a/srcCommon/decorator-version-updater.ts
+++ b/srcCommon/decorator-version-updater.ts
@@ -55,5 +55,5 @@ export const initDecoratorVersionUpdater = () => {
         clearInterval(intervalId);
     }
 
-    setInterval(fetchAndUpdateVersion, UPDATE_RATE_MS);
+    intervalId = setInterval(fetchAndUpdateVersion, UPDATE_RATE_MS);
 };

--- a/srcCommon/decorator-version-updater.ts
+++ b/srcCommon/decorator-version-updater.ts
@@ -1,0 +1,59 @@
+import { setInterval } from 'next/dist/compiled/@edge-runtime/primitives';
+import { fetchJson } from 'srcCommon/fetch-utils';
+import { logger } from 'srcCommon/logger';
+
+type DecoratorVersionApiResponse = {
+    versionId: string;
+    started: number;
+};
+
+type DecoratorUpdateListener = (versionId: string) => unknown;
+
+const DECORATOR_VERSION_API_URL = `${process.env.DECORATOR_URL}/api/version`;
+
+const UPDATE_RATE_MS = 5000;
+
+const listeners: Set<DecoratorUpdateListener> = new Set();
+
+const currentVersion = {
+    versionId: '',
+    started: 0,
+};
+
+export const fetchDecoratorVersion = () =>
+    fetchJson<DecoratorVersionApiResponse>(DECORATOR_VERSION_API_URL);
+
+const fetchAndUpdateVersion = () =>
+    fetchDecoratorVersion().then((response) => {
+        if (!response) {
+            logger.error('Failed to fetch decorator version!');
+            return;
+        }
+
+        const { versionId, started } = response;
+
+        if (started > currentVersion.started) {
+            logger.info(`New decorator version: ${versionId} [${started}]`);
+            currentVersion.versionId = versionId;
+            currentVersion.started = started;
+            listeners.forEach((listener) => listener(versionId));
+        }
+    });
+
+export const addDecoratorUpdateListener = (listener: DecoratorUpdateListener) => {
+    listeners.add(listener);
+};
+
+export const removeDecoratorUpdateListener = (listener: DecoratorUpdateListener) => {
+    listeners.delete(listener);
+};
+
+let intervalId: number | null = null;
+
+export const startDecoratorVersionUpdater = () => {
+    if (intervalId !== null) {
+        clearInterval(intervalId);
+    }
+
+    setInterval(fetchAndUpdateVersion, UPDATE_RATE_MS);
+};

--- a/srcCommon/decorator-version-updater.ts
+++ b/srcCommon/decorator-version-updater.ts
@@ -32,7 +32,7 @@ const fetchAndUpdateVersion = () =>
 
         const { versionId, started } = response;
 
-        if (started > currentVersion.started) {
+        if (versionId !== currentVersion.versionId && started > currentVersion.started) {
             logger.info(`New decorator version: ${versionId} [${started}]`);
             currentVersion.versionId = versionId;
             currentVersion.started = started;

--- a/srcCommon/decorator-version-updater.ts
+++ b/srcCommon/decorator-version-updater.ts
@@ -50,7 +50,7 @@ export const removeDecoratorUpdateListener = (listener: DecoratorUpdateListener)
 
 let intervalId: number | null = null;
 
-export const startDecoratorVersionUpdater = () => {
+export const initDecoratorVersionUpdater = () => {
     if (intervalId !== null) {
         clearInterval(intervalId);
     }

--- a/srcCommon/redis.ts
+++ b/srcCommon/redis.ts
@@ -72,8 +72,11 @@ class RedisCacheImpl {
     }
 
     public async getRender(key: string) {
+        const fullKey = this.getFullKey(key, this.renderCacheKeyPrefix);
+        logger.info(`Fetching from response cache: ${fullKey}`);
+
         return this.client
-            .getEx(this.getFullKey(key, this.renderCacheKeyPrefix), {
+            .getEx(fullKey, {
                 PX: this.renderCacheTTL,
             })
             .then((result) => (result ? JSON.parse(result) : result))
@@ -109,7 +112,10 @@ class RedisCacheImpl {
     }
 
     public async setRender(key: string, data: CacheHandlerValue) {
-        return this.set(this.getFullKey(key, this.renderCacheKeyPrefix), this.renderCacheTTL, data);
+        const fullKey = this.getFullKey(key, this.renderCacheKeyPrefix);
+        logger.info(`Saving to render cache: ${fullKey}`);
+
+        return this.set(fullKey, this.renderCacheTTL, data);
     }
 
     public async setResponse(key: string, data: XpResponseProps) {

--- a/srcCommon/redis.ts
+++ b/srcCommon/redis.ts
@@ -130,7 +130,9 @@ class RedisCacheDummy extends RedisCacheImpl {
         return this;
     }
 
-    public updateRenderCacheKeyPrefix(key: string) {}
+    public updateRenderCacheKeyPrefix(key: string) {
+        return;
+    }
 
     public async getRender(key: string) {
         return null;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter ny cache-prefix for render-cache + sletter lokal cache når en ny versjon av dekoratøren er deployet.

Dette skal inn i ny versjon av nav-dekoratoren-moduler, men tester konseptet her først. Er ikke helt ferdig, må håndtere casen der ny deploy ikke er fullført, der podder med to ulike versjoner av dekoratøren kjører.