### PR TITLE
Korrigerer knappefarger for UI i global verdi-editor

### DIFF
--- a/src/components/pages/global-values-page/components/button/GVButton.module.scss
+++ b/src/components/pages/global-values-page/components/button/GVButton.module.scss
@@ -1,0 +1,20 @@
+.button {
+    &:global(.navds-button--primary),
+    &:global(.navds-button--danger) {
+        color: white;
+    }
+
+    &:global(.navds-button--danger) {
+        box-shadow: 0 0 0;
+
+        &:focus-visible {
+            box-shadow:
+                inset 0 0 0 1px
+                    var(
+                        --ac-button-primary-focus-border,
+                        var(--__ac-button-primary-focus-border, var(--a-surface-default))
+                    ),
+                var(--a-shadow-focus);
+        }
+    }
+}

--- a/src/components/pages/global-values-page/components/button/GVButton.tsx
+++ b/src/components/pages/global-values-page/components/button/GVButton.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Button } from 'components/_common/button/Button';
 import { EditorLinkWrapper } from 'components/_editor-only/editor-link-wrapper/EditorLinkWrapper';
+import style from './GVButton.module.scss';
 
 export const GVButton = (props: React.ComponentProps<typeof Button>) => (
     <EditorLinkWrapper>
-        <Button {...props} size={'small'}>
+        <Button {...props} size={'small'} className={style.button}>
             {props.children}
         </Button>
     </EditorLinkWrapper>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Etter endringer i malene har knappefargene i globale verdier-editoren blitt lite synlige. Denne PR'en korrigerer fargene på tekst og outline.


## Testing
Testet i dev
