### PR TITLE
Setter komponent 'alternativ-målgruppe' og 'skjemaoversikt-filter'

### DIFF
--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -102,7 +102,9 @@ export const AlternativeAudience = () => {
             'for'
         ).slice(1)}`;
 
-        return `${forString} ${providerTypesString || currentAudienceLabel}${addPeriod ? '.' : ''} `;
+        return `${forString} ${providerTypesString || currentAudienceLabel}${
+            addPeriod ? '.' : ''
+        } `;
     };
 
     if (!alternativeAudience) {
@@ -126,7 +128,7 @@ export const AlternativeAudience = () => {
                 {getRelatedString('relatedAudience').replace('{name}', productName)}{' '}
                 {audienceLinks.map((link, index) => (
                     <Fragment key={index}>
-                        <LenkeInline href={link.url} analyticsLabel={'Aktuell målgruppe'}>
+                        <LenkeInline href={link.url} analyticsComponent="alternativ-målgruppe">
                             {link.title}
                         </LenkeInline>
                         {getConjunction({

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -5,11 +5,11 @@ import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { windowScrollTo } from 'utils/scroll-to';
+import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import {
     OVERVIEW_FILTERS_TEXT_INPUT_EVENT,
     OverviewFiltersTextInputEventDetail,
 } from 'store/slices/overviewFilters';
-
 import style from './OverviewTextFilter.module.scss';
 
 type Props = {
@@ -42,6 +42,10 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const handleUserInput = (inputValue: string) => {
         setTextInput(inputValue);
         dispatchInput(inputValue);
+        logAmplitudeEvent(AnalyticsEvents.FILTER, {
+            komponent: 'skjemaoversikt-filter',
+            filtertekst: inputValue,
+        });
     };
 
     useEffect(() => {

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -35,6 +35,10 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                     }
                 )
             );
+            logAmplitudeEvent(AnalyticsEvents.FILTER, {
+                komponent: 'skjemaoversikt-filter',
+                filtertekst: value,
+            });
         }, 500),
         [setTextFilter]
     );
@@ -42,10 +46,6 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const handleUserInput = (inputValue: string) => {
         setTextInput(inputValue);
         dispatchInput(inputValue);
-        logAmplitudeEvent(AnalyticsEvents.FILTER, {
-            komponent: 'skjemaoversikt-filter',
-            filtertekst: inputValue,
-        });
     };
 
     useEffect(() => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Justerer og utvider logging Amplitude:
- Bytte av målgruppe logges som event 'navigasjon' og komponent 'alternativ-målgruppe' + 'lenketekst'
- Filter i skjemoversikt logges som event 'filtervalg' med komponent 'skjemaoversikt-filter' + 'filtertekst'

## Testing
Har testet selv i dev 
