### PR TITLE
Fjernet tekst om åpningstider i legacyChat

### DIFF
--- a/src/translations/default.ts
+++ b/src/translations/default.ts
@@ -228,7 +228,7 @@ export const translationsBundleNb = {
         legacyChat: {
             title: 'Du kan chatte med oss',
             ingress:
-                'Du møter først chatbot Frida som svarer deg. Du kan også be Frida om å få snakke med en veileder (hverdager 9-1430).',
+                'Du møter først chatbot Frida som svarer deg. Du kan også be Frida om å få snakke med en veileder.',
         },
         write: {
             title: 'Skriv til oss',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -219,7 +219,7 @@ export const translationsBundleEn: PartialTranslations = {
         legacyChat: {
             title: 'You can chat with us',
             ingress:
-                'You will first be met by chatbot Frida who will answer you. You can also ask Frida to talk to an advisor (weekdays 9-1430).',
+                'You will first be met by chatbot Frida who will answer you. You can also ask Frida to talk to an advisor.',
         },
         write: {
             title: 'Write to us',

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -203,7 +203,7 @@ export const translationsBundleNn: PartialTranslations = {
         legacyChat: {
             title: 'Du kan chatte med oss',
             ingress:
-                'Du møter først chatbot Frida som svarar deg. Du kan òg be om å få snakke med ein rettleiar (kvardagar 9-1430).',
+                'Du møter først chatbot Frida som svarar deg. Du kan òg be om å få snakke med ein rettleiar.',
         },
         write: {
             title: 'Skriv til oss',


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Fjernet tekst om åpningstider i Frida legacyChat på engelske sider.
Eksempel:
https://www.nav.no/en/home/rules-and-regulations/staying-abroad

-   Også fjernet på bokmåls- og nynorsksidene, selv om disse ikke ser ut til å være i bruk.

## Testing

Har testet selv i dev / lokalt

