### PR TITLE
Analytics: Redaksjonelle navn på områder og typer

### DIFF
--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -17,6 +17,20 @@ const orderedAreas: Area[] = [
     Area.OTHER,
 ];
 
+const analyticsAreas = {
+    [Area.ALL]: 'N/A',
+    [Area.WORK]: 'arbeid',
+    [Area.HEALTH]: 'helse og sykdom',
+    [Area.FAMILY]: 'familie og barn',
+    [Area.PENSION]: 'pensjon',
+    [Area.SOCIAL_COUNSELLING]: 'sosiale tjenester',
+    [Area.ACCESSIBILITY]: 'hjelpemidler og tilrettelegging',
+    [Area.INCLUSION]: 'inkludering og tilrettelegging',
+    [Area.RECRUITMENT]: 'rekruttering',
+    [Area.DOWNSIZING]: 'permittering og nedbemanning',
+    [Area.OTHER]: 'på tvers',
+};
+
 type Props = {
     items: OverviewFilterableItem[];
 };
@@ -27,7 +41,7 @@ export const OverviewAreaFilter = ({ items }: Props) => {
     const handleFilterUpdate = (area: Area) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             kategori: 'område',
-            filternavn: area,
+            filternavn: analyticsAreas[area],
             opprinnelse: 'oversiktsside områder',
             komponent: 'OverviewAreaFilter',
         });

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -16,6 +16,19 @@ const orderedTaxonomies: ProductTaxonomy[] = [
     ProductTaxonomy.OTHER,
 ];
 
+const analyticsTaxonomi = {
+    [ProductTaxonomy.ALL]: 'N/A',
+    [ProductTaxonomy.BENEFITS]: 'pengestøtte',
+    [ProductTaxonomy.INSURANCE]: 'forsikring',
+    [ProductTaxonomy.MEASURES]: 'tiltak',
+    [ProductTaxonomy.SERVICE]: 'tjeneste',
+    [ProductTaxonomy.COUNSELLING]: 'veiledning',
+    [ProductTaxonomy.ASSISTIVE_TOOLS]: 'hjelpemiddel',
+    [ProductTaxonomy.EMPLOYEE_BENEFITS]: 'pengestøtte til ansatt',
+    [ProductTaxonomy.REFUND]: 'refusjon',
+    [ProductTaxonomy.OTHER]: 'annet',
+};
+
 type Props = {
     items: OverviewFilterableItem[];
 };
@@ -26,7 +39,7 @@ export const OverviewTaxonomyFilter = ({ items }: Props) => {
     const handleFilterUpdate = (taxonomy: ProductTaxonomy) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             kategori: 'type',
-            filternavn: taxonomy,
+            filternavn: analyticsTaxonomi[taxonomy],
             opprinnelse: 'oversiktsside typer',
             komponent: 'OverviewTaxonomyFilter',
         });

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -17,7 +17,8 @@ type Props = {
 };
 
 const analyticsRedaction = (value: string) =>
-    Number.isNaN(value) ? `tekst (${value.length})` : `nummer (${Math.log10(Number(value)) + 1})`;
+    isNaN(Number(value)) ? `tekst (${value.length})` : `nummer (${Math.log10(Number(value)) + 1})`;
+
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const { setTextFilter } = useOverviewFilters();
     const { language } = usePageContentProps();

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -16,6 +16,8 @@ type Props = {
     hideLabel?: boolean;
 };
 
+const analyticsRedaction = (value: string) =>
+    Number.isNaN(value) ? `tekst (${value.length})` : `nummer (${Math.log10(Number(value)) + 1})`;
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const { setTextFilter } = useOverviewFilters();
     const { language } = usePageContentProps();
@@ -37,7 +39,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
             );
             logAmplitudeEvent(AnalyticsEvents.FILTER, {
                 kategori: 'fritekst',
-                filternavn: value,
+                filternavn: analyticsRedaction(value),
                 komponent: 'OverviewTextFilter',
             });
         }, 500),

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -17,7 +17,9 @@ type Props = {
 };
 
 const analyticsRedaction = (value: string) =>
-    isNaN(Number(value)) ? `tekst (${value.length})` : `nummer (${Math.log10(Number(value)) + 1})`;
+    isNaN(Number(value))
+        ? `tekst (${value.length})`
+        : `nummer (${Math.round(Math.log10(Number(value))) + 1})`;
 
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const { setTextFilter } = useOverviewFilters();


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Mapper labels for produktområde og produkttype til navn som brukes redaksjonelt
Erstatter fritekst med info om nummer- eller tekstlengde (kan ikke logge brukerinput direkte)

## Testing

Har testet selv i dev

