### PR TITLE
Dev xp rewrite fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -213,6 +213,16 @@ const config = {
             destination: `${process.env.APP_ORIGIN}/no/nav-og-samfunn/samarbeid/for-kommunen/digisos/til-kommuner-som-onsker-a-ta-i-bruk-digital-soknad-om-okonomisk-sosialhjelp/Håndbok for innføring av digital søknad %2800B%29 12.12.19.pdf`,
             permanent: false,
         },
+        // /_/* should point to XP services. Redirect only if XP is on a different origin
+        ...(process.env.XP_ORIGIN !== process.env.APP_ORIGIN
+            ? [
+                  {
+                      source: '/_/:path*',
+                      destination: `${process.env.XP_ORIGIN}/_/:path*`,
+                      permanent: false,
+                  },
+              ]
+            : []),
     ],
     rewrites: async () => [
         {
@@ -249,15 +259,6 @@ const config = {
             source: '/feilside',
             destination: '/404',
         },
-        // /_/* should point to XP services. Rewrite only if XP is on a different origin
-        ...(process.env.XP_ORIGIN !== process.env.APP_ORIGIN
-            ? [
-                  {
-                      source: '/_/:path*',
-                      destination: `${process.env.XP_ORIGIN}/_/:path*`,
-                  },
-              ]
-            : []),
         ...(isLocal
             ? [
                   {

--- a/server/src/server-setup/server-setup-dev.ts
+++ b/server/src/server-setup/server-setup-dev.ts
@@ -16,7 +16,7 @@ export const serverSetupDev = (expressApp: Express, nextApp: NextServer) => {
     // These paths should never redirect, to ensure the site will load correctly
     // when accessed from the Content Studio editor
     expressApp.all(
-        ['/draft/*', '/archive/*', '/editor/*', '/_next/*', '/gfx/*', '/api/*'],
+        ['/draft/*', '/archive/*', '/editor/*', '/_next/*', '/gfx/*', '/api/*', '/_/*'],
         (req, res) => {
             return nextRequestHandler(req, res);
         }


### PR DESCRIPTION
Endrer rewrites fra /_/* til heller å bruke redirects. Er noe™️ som som har gjort at rewrites til XP har sluttet å funke (muligens noe proxy-regler i big-ip). Men redirects gjør samme jobben.