### PR TITLE
Lukker sticky beholder posisjon på siden

### DIFF
--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -48,10 +48,12 @@ export const Accordion = ({ accordion }: AccordionProps) => {
             console.log(
                 `Accordion item "${tittel}" is being closed. Vertical position: ${verticalPosition}px`
             );
-            window.scrollBy({
-                top: verticalPosition,
-                behavior: 'instant',
-            });
+            if (verticalPosition < 0) {
+                window.scrollBy({
+                    top: verticalPosition,
+                    behavior: 'instant',
+                });
+            }
         }
         openChangeHandler(isOpening, tittel, index);
     };

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -72,6 +72,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                         ref={(el) => {
                             itemRefs.current[index] = el;
                         }}
+                        tabIndex={-1}
                     >
                         <DSAccordion.Header className={styles.header} id={item.anchorId}>
                             {!isValid && (

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -51,19 +51,6 @@ export const Accordion = ({ accordion }: AccordionProps) => {
         });
     };
 
-    const handleOpenChange = (isOpening: boolean, tittel: string, index: number) => {
-        if (!isOpening && itemRefs.current[index]) {
-            const verticalPosition = itemRefs.current[index].getBoundingClientRect().top;
-            if (verticalPosition < 0) {
-                window.scrollBy({
-                    top: verticalPosition,
-                    behavior: 'instant',
-                });
-            }
-        }
-        openChangeHandler(isOpening, tittel, index);
-    };
-
     useEffect(() => {
         const anchorHash = window.location.hash || '';
         const matchingAccordion = accordion.findIndex(

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -14,7 +14,7 @@ import styles from './Accordion.module.scss';
 type AccordionProps = PartConfigAccordion;
 type PanelItem = AccordionProps['accordion'][number];
 
-const handleScrollPosition = (isOpening: boolean, current: HTMLDivElement | null) => {
+export const handleScrollPosition = (isOpening: boolean, current: HTMLDivElement | null) => {
     if (!isOpening && current) {
         const verticalPosition = current.getBoundingClientRect().top;
         if (verticalPosition < 0) {

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -7,24 +7,13 @@ import { usePageContentProps } from 'store/pageContext';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartConfigAccordion } from 'components/parts/accordion/AccordionPart';
 import { classNames } from 'utils/classnames';
+import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import styles from './Accordion.module.scss';
 
 type AccordionProps = PartConfigAccordion;
 type PanelItem = AccordionProps['accordion'][number];
-
-export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivElement | null) => {
-    if (!isOpening && current) {
-        const verticalPosition = current.getBoundingClientRect().top;
-        if (verticalPosition < 0) {
-            window.scrollBy({
-                top: verticalPosition,
-                behavior: 'instant',
-            });
-        }
-    }
-};
 
 export const Accordion = ({ accordion }: AccordionProps) => {
     const itemRefs = useRef<(HTMLDivElement | null)[]>([]);

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -14,6 +14,18 @@ import styles from './Accordion.module.scss';
 type AccordionProps = PartConfigAccordion;
 type PanelItem = AccordionProps['accordion'][number];
 
+const handleScrollPosition = (isOpening: boolean, current: HTMLDivElement | null) => {
+    if (!isOpening && current) {
+        const verticalPosition = current.getBoundingClientRect().top;
+        if (verticalPosition < 0) {
+            window.scrollBy({
+                top: verticalPosition,
+                behavior: 'instant',
+            });
+        }
+    }
+};
+
 export const Accordion = ({ accordion }: AccordionProps) => {
     const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -29,15 +41,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
     useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
 
     const openChangeHandler = (isOpening: boolean, tittel: string, index: number) => {
-        if (!isOpening && itemRefs.current[index]) {
-            const verticalPosition = itemRefs.current[index].getBoundingClientRect().top;
-            if (verticalPosition < 0) {
-                window.scrollBy({
-                    top: verticalPosition,
-                    behavior: 'instant',
-                });
-            }
-        }
+        handleScrollPosition(isOpening, itemRefs.current[index]);
 
         if (isOpening) {
             setOpenAccordions([...openAccordions, index]);

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -14,7 +14,7 @@ import styles from './Accordion.module.scss';
 type AccordionProps = PartConfigAccordion;
 type PanelItem = AccordionProps['accordion'][number];
 
-export const handleScrollPosition = (isOpening: boolean, current: HTMLDivElement | null) => {
+export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivElement | null) => {
     if (!isOpening && current) {
         const verticalPosition = current.getBoundingClientRect().top;
         if (verticalPosition < 0) {
@@ -41,7 +41,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
     useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
 
     const openChangeHandler = (isOpening: boolean, tittel: string, index: number) => {
-        handleScrollPosition(isOpening, itemRefs.current[index]);
+        handleStickyScrollOffset(isOpening, itemRefs.current[index]);
 
         if (isOpening) {
             setOpenAccordions([...openAccordions, index]);

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -29,7 +29,16 @@ export const Accordion = ({ accordion }: AccordionProps) => {
     useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
 
     const openChangeHandler = (isOpening: boolean, tittel: string, index: number) => {
-        console.log('openChangeHandler', isOpening, tittel, index);
+        if (!isOpening && itemRefs.current[index]) {
+            const verticalPosition = itemRefs.current[index].getBoundingClientRect().top;
+            if (verticalPosition < 0) {
+                window.scrollBy({
+                    top: verticalPosition,
+                    behavior: 'instant',
+                });
+            }
+        }
+
         if (isOpening) {
             setOpenAccordions([...openAccordions, index]);
         } else {
@@ -45,9 +54,6 @@ export const Accordion = ({ accordion }: AccordionProps) => {
     const handleOpenChange = (isOpening: boolean, tittel: string, index: number) => {
         if (!isOpening && itemRefs.current[index]) {
             const verticalPosition = itemRefs.current[index].getBoundingClientRect().top;
-            console.log(
-                `Accordion item "${tittel}" is being closed. Vertical position: ${verticalPosition}px`
-            );
             if (verticalPosition < 0) {
                 window.scrollBy({
                     top: verticalPosition,
@@ -82,7 +88,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
                         key={index}
                         className={styles.item}
                         open={openAccordions.includes(index)}
-                        onOpenChange={(open) => handleOpenChange(open, item.title, index)}
+                        onOpenChange={(open) => openChangeHandler(open, item.title, index)}
                         ref={(el) => {
                             itemRefs.current[index] = el;
                         }}

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
-import { handleScrollPosition } from 'components/_common/accordion/Accordion';
+import { handleStickyScrollOffset } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
@@ -41,7 +41,7 @@ export const Expandable = ({
 
     const toggleExpandCollapse = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
-        handleScrollPosition(isOpening, accordionRef.current);
+        handleStickyScrollOffset(isOpening, accordionRef.current);
 
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -3,10 +3,9 @@ import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
-import { smoothScrollToTarget } from 'utils/scroll-to';
+import { smoothScrollToTarget, handleStickyScrollOffset } from 'utils/scroll-to';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { ProductDetailType } from 'types/content-props/product-details';
-import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import style from './Expandable.module.scss';
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -119,6 +119,7 @@ export const Expandable = ({
             onToggle={(isOpen) => toggleExpandCollapse(isOpen, title)}
             open={isOpen}
             aria-label={ariaLabel || title}
+            tabIndex={-1}
         >
             <ExpansionCard.Header className={style.header}>
                 {getHeaderIcon()}

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
-import { handleStickyScrollOffset } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { ProductDetailType } from 'types/content-props/product-details';
+import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import style from './Expandable.module.scss';
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -40,6 +40,17 @@ export const Expandable = ({
 
     const toggleExpandCollapse = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
+
+        if (!isOpening && accordionRef.current) {
+            const verticalPosition = accordionRef.current.getBoundingClientRect().top;
+            if (verticalPosition < 0) {
+                window.scrollBy({
+                    top: verticalPosition,
+                    behavior: 'instant',
+                });
+            }
+        }
+
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
             opprinnelse: analyticsOriginTag || 'utvidbar tekst',

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
+import { handleScrollPosition } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget } from 'utils/scroll-to';
@@ -40,16 +41,7 @@ export const Expandable = ({
 
     const toggleExpandCollapse = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
-
-        if (!isOpening && accordionRef.current) {
-            const verticalPosition = accordionRef.current.getBoundingClientRect().top;
-            if (verticalPosition < 0) {
-                window.scrollBy({
-                    top: verticalPosition,
-                    behavior: 'instant',
-                });
-            }
-        }
+        handleScrollPosition(isOpening, accordionRef.current);
 
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -32,13 +32,8 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
 
-        console.log('openChangeHandler', isOpening, tittel, divRef.current);
-
         if (!isOpening && divRef.current) {
             const verticalPosition = divRef.current.getBoundingClientRect().top;
-            console.log(
-                `Read more "${tittel}" is being closed. Vertical position: ${verticalPosition}px`
-            );
             if (verticalPosition < 0) {
                 window.scrollBy({
                     top: verticalPosition,
@@ -46,6 +41,7 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
                 });
             }
         }
+
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
             opprinnelse: 'lesmer',
@@ -63,7 +59,6 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
                 onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
                 className={styles.readMore}
             >
-                {/* ref={refmao} */}
                 <div className={classNames(defaultHtml.html, 'parsedHtml')}>
                     <ParsedHtml htmlProps={html} />
                 </div>

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -2,12 +2,12 @@ import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
-import { handleStickyScrollOffset } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { classNames } from 'utils/classnames';
+import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import styles from './ReadMorePart.module.scss';

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
@@ -18,6 +18,8 @@ export type PartConfigReadMore = {
 
 export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) => {
     const [isOpen, setIsOpen] = useState(false);
+    const divRef = useRef<HTMLDivElement | null>(null);
+
     useShortcuts({
         shortcut: Shortcuts.SEARCH,
         callback: () => setIsOpen(true),
@@ -29,6 +31,21 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
+
+        console.log('openChangeHandler', isOpening, tittel, divRef.current);
+
+        if (!isOpening && divRef.current) {
+            const verticalPosition = divRef.current.getBoundingClientRect().top;
+            console.log(
+                `Read more "${tittel}" is being closed. Vertical position: ${verticalPosition}px`
+            );
+            if (verticalPosition < 0) {
+                window.scrollBy({
+                    top: verticalPosition,
+                    behavior: 'instant',
+                });
+            }
+        }
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
             opprinnelse: 'lesmer',
@@ -39,15 +56,18 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
     const { title, html } = config;
 
     return (
-        <ReadMore
-            header={title}
-            open={isOpen}
-            onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
-            className={styles.readMore}
-        >
-            <div className={classNames(defaultHtml.html, 'parsedHtml')}>
-                <ParsedHtml htmlProps={html} />
-            </div>
-        </ReadMore>
+        <div ref={divRef}>
+            <ReadMore
+                header={title}
+                open={isOpen}
+                onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
+                className={styles.readMore}
+            >
+                {/* ref={refmao} */}
+                <div className={classNames(defaultHtml.html, 'parsedHtml')}>
+                    <ParsedHtml htmlProps={html} />
+                </div>
+            </ReadMore>
+        </div>
     );
 };

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
@@ -7,6 +7,7 @@ import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { classNames } from 'utils/classnames';
+import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import styles from './ReadMorePart.module.scss';
@@ -18,6 +19,8 @@ export type PartConfigReadMore = {
 
 export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) => {
     const [isOpen, setIsOpen] = useState(false);
+    const divRef = useRef<HTMLDivElement | null>(null);
+
     useShortcuts({
         shortcut: Shortcuts.SEARCH,
         callback: () => setIsOpen(true),
@@ -28,6 +31,8 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
     }
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
+        handleStickyScrollOffset(isOpening, divRef.current);
+
         setIsOpen(isOpening);
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
@@ -39,15 +44,17 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
     const { title, html } = config;
 
     return (
-        <ReadMore
-            header={title}
-            open={isOpen}
-            onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
-            className={styles.readMore}
-        >
-            <div className={classNames(defaultHtml.html, 'parsedHtml')}>
-                <ParsedHtml htmlProps={html} />
-            </div>
-        </ReadMore>
+        <div tabIndex={-1} ref={divRef}>
+            <ReadMore
+                header={title}
+                open={isOpen}
+                onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
+                className={styles.readMore}
+            >
+                <div className={classNames(defaultHtml.html, 'parsedHtml')}>
+                    <ParsedHtml htmlProps={html} />
+                </div>
+            </ReadMore>
+        </div>
     );
 };

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
+import { handleScrollPosition } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
@@ -31,16 +32,7 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
-
-        if (!isOpening && divRef.current) {
-            const verticalPosition = divRef.current.getBoundingClientRect().top;
-            if (verticalPosition < 0) {
-                window.scrollBy({
-                    top: verticalPosition,
-                    behavior: 'instant',
-                });
-            }
-        }
+        handleScrollPosition(isOpening, divRef.current);
 
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -7,7 +7,6 @@ import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
 import { classNames } from 'utils/classnames';
-import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import defaultHtml from 'components/_common/parsed-html/DefaultHtmlStyling.module.scss';
 import styles from './ReadMorePart.module.scss';
@@ -19,8 +18,6 @@ export type PartConfigReadMore = {
 
 export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) => {
     const [isOpen, setIsOpen] = useState(false);
-    const divRef = useRef<HTMLDivElement | null>(null);
-
     useShortcuts({
         shortcut: Shortcuts.SEARCH,
         callback: () => setIsOpen(true),
@@ -32,8 +29,6 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
-        handleStickyScrollOffset(isOpening, divRef.current);
-
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
             opprinnelse: 'lesmer',
@@ -44,17 +39,15 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
     const { title, html } = config;
 
     return (
-        <div ref={divRef}>
-            <ReadMore
-                header={title}
-                open={isOpen}
-                onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
-                className={styles.readMore}
-            >
-                <div className={classNames(defaultHtml.html, 'parsedHtml')}>
-                    <ParsedHtml htmlProps={html} />
-                </div>
-            </ReadMore>
-        </div>
+        <ReadMore
+            header={title}
+            open={isOpen}
+            onOpenChange={(isOpen) => openChangeHandler(isOpen, title)}
+            className={styles.readMore}
+        >
+            <div className={classNames(defaultHtml.html, 'parsedHtml')}>
+                <ParsedHtml htmlProps={html} />
+            </div>
+        </ReadMore>
     );
 };

--- a/src/components/parts/read-more/ReadMorePart.tsx
+++ b/src/components/parts/read-more/ReadMorePart.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsed-html/ParsedHtml';
-import { handleScrollPosition } from 'components/_common/accordion/Accordion';
+import { handleStickyScrollOffset } from 'components/_common/accordion/Accordion';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
@@ -32,7 +32,7 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         setIsOpen(isOpening);
-        handleScrollPosition(isOpening, divRef.current);
+        handleStickyScrollOffset(isOpening, divRef.current);
 
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -21,3 +21,15 @@ export const smoothScrollToTarget = (targetId: string, offset = 0) => {
         targetElement.focus({ preventScroll: true });
     }
 };
+
+export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivElement | null) => {
+    if (!isOpening && current) {
+        const verticalPosition = current.getBoundingClientRect().top;
+        if (verticalPosition < 0) {
+            window.scrollBy({
+                top: verticalPosition,
+                behavior: 'instant',
+            });
+        }
+    }
+};

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -27,7 +27,7 @@ export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivEle
         const verticalPosition = current.getBoundingClientRect().top;
         if (verticalPosition < 0) {
             window.scrollBy({
-                top: verticalPosition,
+                top: verticalPosition - 80,
                 behavior: 'instant',
             });
         }

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -22,28 +22,14 @@ export const smoothScrollToTarget = (targetId: string, offset = 0) => {
     }
 };
 
-const getHeaderOffset = (): number => {
-    const fallbackHeaderHeight = 72;
-    const headerElement = document.getElementById('decorator-header') as HTMLElement;
-
-    if (headerElement) {
-        const computedStyleHeader = getComputedStyle(headerElement);
-        const headerHeight = computedStyleHeader.getPropertyValue('--header-height');
-        return parseInt(headerHeight) || fallbackHeaderHeight;
-    } else {
-        return fallbackHeaderHeight;
-    }
-};
-
 export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivElement | null) => {
     if (!isOpening && current) {
         const verticalPosition = current.getBoundingClientRect().top;
 
         if (verticalPosition < 0) {
-            window.scrollBy({
-                top: verticalPosition - getHeaderOffset(),
-                behavior: 'instant',
-            });
+            document.documentElement.style.scrollBehavior = 'auto';
+            current.focus();
+            document.documentElement.style.scrollBehavior = 'smooth';
         }
     }
 };

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -23,7 +23,7 @@ export const smoothScrollToTarget = (targetId: string, offset = 0) => {
 };
 
 const getHeaderOffset = (): number => {
-    const fallbackHeaderHeight = 80;
+    const fallbackHeaderHeight = 72;
     const headerElement = document.getElementById('decorator-header') as HTMLElement;
 
     if (headerElement) {

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -22,12 +22,26 @@ export const smoothScrollToTarget = (targetId: string, offset = 0) => {
     }
 };
 
+const getHeaderOffset = (): number => {
+    const fallbackHeaderHeight = 80;
+    const headerElement = document.getElementById('decorator-header') as HTMLElement;
+
+    if (headerElement) {
+        const computedStyleHeader = getComputedStyle(headerElement);
+        const headerHeight = computedStyleHeader.getPropertyValue('--header-height');
+        return parseInt(headerHeight) || fallbackHeaderHeight;
+    } else {
+        return fallbackHeaderHeight;
+    }
+};
+
 export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivElement | null) => {
     if (!isOpening && current) {
         const verticalPosition = current.getBoundingClientRect().top;
+
         if (verticalPosition < 0) {
             window.scrollBy({
-                top: verticalPosition - 80,
+                top: verticalPosition - getHeaderOffset(),
                 behavior: 'instant',
             });
         }

--- a/src/utils/scroll-to.ts
+++ b/src/utils/scroll-to.ts
@@ -27,9 +27,10 @@ export const handleStickyScrollOffset = (isOpening: boolean, current: HTMLDivEle
         const verticalPosition = current.getBoundingClientRect().top;
 
         if (verticalPosition < 0) {
-            document.documentElement.style.scrollBehavior = 'auto';
-            current.focus();
-            document.documentElement.style.scrollBehavior = 'smooth';
+            window.scrollBy({
+                top: verticalPosition,
+                behavior: 'instant',
+            });
         }
     }
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Fikser problemet hvor man hopper langt ned på siden hvis man lukker en ekspandert komponent som er sticky i toppen.
- Avhenger av https://github.com/navikt/decorator-next/pull/448 for at det skal fungere som forventet med scrollBy


## Testing

Har testet selv i dev. Testet alle de tre komponentene på ulike skjermstørrelser og i ulike scrollposisjoner. Testet i Chrome og Safari.

## Skjermbilde hvis relevant





