### PR TITLE
Endret tekststørrelse i Aktuelle målgrupper

### DIFF
--- a/src/components/_common/alternativeAudience/AlternativeAudience.tsx
+++ b/src/components/_common/alternativeAudience/AlternativeAudience.tsx
@@ -77,7 +77,10 @@ export const AlternativeAudience = () => {
     }
 
     const productName =
-        showProductName === false ? getStringPart('this') : displayName.toLowerCase();
+        showProductName === false
+            ? getStringPart('this')
+            : displayName.charAt(0).toLowerCase() + displayName.slice(1);
+
     const audienceLinks = buildAudienceLinks(alternativeAudience, language);
 
     return (


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Under "Andre målgrupper" legges til overskriften på innholdet i setningen: Det finnes også informasjon om <overskrift>.

Problemet er at NAV eller Nav blir lowercase, slik at "Sjøfartsoppgaver i NAV" blir "sjøfartsoppgaver i nav".

Løsning: Gjør om første bokstav til lowercase. Resten er uforandret.

## Testing

Har testet selv i dev / lokalt

