### PR TITLE
Fikser editor-props bugs (+ refactor)

### DIFF
--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -11,7 +11,9 @@ import { EditorHelp } from './_editor-only/editor-help/EditorHelp';
 type Props = {
     componentProps?: ComponentProps;
     pageProps: ContentProps;
-    isNestedComponent?: boolean;
+    // Must be set true if the component is not a part of the regular XP component tree structure
+    // This prevents errors in the editor due to invalid editor props
+    isCustomNestedComponent?: boolean;
 };
 
 export type ComponentEditorProps = {
@@ -24,7 +26,7 @@ const buildEditorProps = (componentProps: ComponentProps): ComponentEditorProps 
     'data-portal-component': componentProps.path,
 });
 
-export const ComponentToRender = ({ componentProps, pageProps, isNestedComponent }: Props) => {
+const ComponentToRender = ({ componentProps, pageProps, isCustomNestedComponent }: Props) => {
     if (!componentProps?.type) {
         return (
             <EditorHelp
@@ -37,7 +39,9 @@ export const ComponentToRender = ({ componentProps, pageProps, isNestedComponent
     }
 
     const editorProps =
-        !!pageProps.editorView && !isNestedComponent ? buildEditorProps(componentProps) : undefined;
+        !!pageProps.editorView && !isCustomNestedComponent
+            ? buildEditorProps(componentProps)
+            : undefined;
 
     switch (componentProps.type) {
         case ComponentType.Text:

--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -11,9 +11,20 @@ import { EditorHelp } from './_editor-only/editor-help/EditorHelp';
 type Props = {
     componentProps?: ComponentProps;
     pageProps: ContentProps;
+    isNestedComponent?: boolean;
 };
 
-export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
+export type ComponentEditorProps = {
+    'data-portal-component-type': ComponentType;
+    'data-portal-component': string;
+};
+
+const buildEditorProps = (componentProps: ComponentProps): ComponentEditorProps => ({
+    'data-portal-component-type': componentProps.type,
+    'data-portal-component': componentProps.path,
+});
+
+export const ComponentToRender = ({ componentProps, pageProps, isNestedComponent }: Props) => {
     if (!componentProps?.type) {
         return (
             <EditorHelp
@@ -25,14 +36,29 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
         );
     }
 
+    const editorProps =
+        !!pageProps.editorView && !isNestedComponent ? buildEditorProps(componentProps) : undefined;
+
     switch (componentProps.type) {
         case ComponentType.Text:
-            return <TextComponentXp textProps={componentProps} editMode={!!pageProps.editorView} />;
+            return <TextComponentXp textProps={componentProps} editorProps={editorProps} />;
         case ComponentType.Layout:
         case ComponentType.Page:
-            return <LayoutMapper layoutProps={componentProps} pageProps={pageProps} />;
+            return (
+                <LayoutMapper
+                    layoutProps={componentProps}
+                    pageProps={pageProps}
+                    editorProps={editorProps}
+                />
+            );
         case ComponentType.Part:
-            return <PartsMapper partProps={componentProps} pageProps={pageProps} />;
+            return (
+                <PartsMapper
+                    partProps={componentProps}
+                    pageProps={pageProps}
+                    editorProps={editorProps}
+                />
+            );
         case ComponentType.Fragment:
             return <FragmentComponent componentProps={componentProps} pageProps={pageProps} />;
         default:
@@ -40,10 +66,11 @@ export const ComponentToRender = ({ componentProps, pageProps }: Props) => {
     }
 };
 
-export const ComponentMapper = ({ componentProps, pageProps }: Props) => {
+export const ComponentMapper = (props: Props) => {
+    const { componentProps } = props;
     return (
         <AuthDependantRender renderOn={componentProps?.config?.renderOnAuthState}>
-            <ComponentToRender componentProps={componentProps} pageProps={pageProps} />
+            <ComponentToRender {...props} />
         </AuthDependantRender>
     );
 };

--- a/src/components/ComponentMapper.tsx
+++ b/src/components/ComponentMapper.tsx
@@ -64,7 +64,13 @@ const ComponentToRender = ({ componentProps, pageProps, isCustomNestedComponent 
                 />
             );
         case ComponentType.Fragment:
-            return <FragmentComponent componentProps={componentProps} pageProps={pageProps} />;
+            return (
+                <FragmentComponent
+                    componentProps={componentProps}
+                    pageProps={pageProps}
+                    editorProps={editorProps}
+                />
+            );
         default:
             return <div>{`Unimplemented component type: ${(componentProps as any).type}`}</div>;
     }

--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { ComponentType, FragmentComponentProps } from 'types/component-props/_component-common';
+import { FragmentComponentProps } from 'types/component-props/_component-common';
 import { ContentProps } from 'types/content-props/_content-common';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
-import { ComponentMapper } from './ComponentMapper';
+import { ComponentEditorProps, ComponentMapper } from './ComponentMapper';
 
 type Props = {
     componentProps: FragmentComponentProps;
     pageProps: ContentProps;
+    editorProps?: ComponentEditorProps;
 };
 
 const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
@@ -23,13 +24,8 @@ const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
     return <ComponentMapper pageProps={pageProps} componentProps={componentProps.fragment} />;
 };
 
-export const FragmentComponent = ({ componentProps, pageProps }: Props) => {
+export const FragmentComponent = ({ componentProps, pageProps, editorProps }: Props) => {
     if (pageProps.editorView === 'edit') {
-        const editorProps = {
-            'data-portal-component-type': ComponentType.Fragment,
-            'data-portal-component': componentProps.path,
-        };
-
         return (
             <div {...editorProps}>
                 <_FragmentComponent pageProps={pageProps} componentProps={componentProps} />

--- a/src/components/FragmentComponent.tsx
+++ b/src/components/FragmentComponent.tsx
@@ -21,11 +21,17 @@ const _FragmentComponent = ({ componentProps, pageProps }: Props) => {
         );
     }
 
-    return <ComponentMapper pageProps={pageProps} componentProps={componentProps.fragment} />;
+    return (
+        <ComponentMapper
+            pageProps={pageProps}
+            componentProps={componentProps.fragment}
+            isCustomNestedComponent={true}
+        />
+    );
 };
 
 export const FragmentComponent = ({ componentProps, pageProps, editorProps }: Props) => {
-    if (pageProps.editorView === 'edit') {
+    if (editorProps) {
         return (
             <div {...editorProps}>
                 <_FragmentComponent pageProps={pageProps} componentProps={componentProps} />

--- a/src/components/layouts/LayoutContainer.tsx
+++ b/src/components/layouts/LayoutContainer.tsx
@@ -5,6 +5,7 @@ import { BEM, classNames } from 'utils/classnames';
 import { usePageContentProps } from 'store/pageContext';
 import { editorAuthstateClassname } from 'components/_common/authDependantRender/editorAuthstateClassname/EditorAuthstateClassname';
 import { getCommonLayoutStyle } from './LayoutStyle';
+import { useLayoutConfig } from './useLayoutConfig';
 
 import style from './LayoutContainer.module.scss';
 
@@ -23,22 +24,19 @@ export const LayoutContainer = ({
     ...divElementProps
 }: Props) => {
     const { editorView } = usePageContentProps();
-    const { descriptor, path, type, config = {} } = layoutProps;
+    const { layoutConfig } = useLayoutConfig();
+
+    const { descriptor, type, config = {} } = layoutProps;
     const layoutName = descriptor.split(':')[1];
     const commonLayoutStyle = getCommonLayoutStyle(config);
     const paddingConfig = config.paddingSides?._selected;
-    const editorProps = !!pageProps.editorView
-        ? {
-              'data-portal-component-type': type,
-              'data-portal-component': path,
-          }
-        : undefined;
+
     const bem = BEM(type);
 
     return (
         <div
             {...divElementProps}
-            {...editorProps}
+            {...layoutConfig.editorProps}
             className={classNames(
                 style.layout,
                 bem(layoutName),

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutComponentProps, LayoutType } from 'types/component-props/layouts';
-import { ComponentType } from 'types/component-props/_component-common';
 import { TwoColsPage } from 'components/layouts/two-cols-page/TwoColsPage';
+import { ComponentEditorProps } from 'components/ComponentMapper';
 import { FixedColsLayout } from './fixed-cols/FixedColsLayout';
 import { FlexColsLayout } from './flex-cols/FlexColsLayout';
 import { LegacyLayout } from './legacy/LegacyLayout';
@@ -22,6 +22,7 @@ import { FrontpageLoggedinSectionLayout } from './frontpage-loggedin-section/Fro
 type Props = {
     pageProps: ContentProps;
     layoutProps?: LayoutComponentProps;
+    editorProps?: ComponentEditorProps;
 };
 
 const layoutComponents: {
@@ -46,16 +47,11 @@ const layoutComponents: {
     [LayoutType.TwoColsPage]: TwoColsPage,
 };
 
-export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
-    const { config, descriptor, path, regions } = layoutProps;
+export const LayoutMapper = ({ pageProps, layoutProps, editorProps }: Props) => {
+    const { config, descriptor, regions } = layoutProps;
     const isEditView = pageProps.editorView === 'edit';
 
     const { LayoutConfigProvider } = useLayoutConfig();
-
-    const editorProps = {
-        'data-portal-component-type': ComponentType.Layout,
-        'data-portal-component': path,
-    };
 
     if (!descriptor || !regions) {
         return isEditView ? <div {...editorProps} /> : null;
@@ -72,6 +68,7 @@ export const LayoutMapper = ({ pageProps, layoutProps }: Props) => {
             value={{
                 type: descriptor,
                 title: config?.title,
+                editorProps,
             }}
         >
             <LayoutComponent pageProps={pageProps} layoutProps={layoutProps} />

--- a/src/components/layouts/LayoutMapper.tsx
+++ b/src/components/layouts/LayoutMapper.tsx
@@ -49,12 +49,11 @@ const layoutComponents: {
 
 export const LayoutMapper = ({ pageProps, layoutProps, editorProps }: Props) => {
     const { config, descriptor, regions } = layoutProps;
-    const isEditView = pageProps.editorView === 'edit';
 
     const { LayoutConfigProvider } = useLayoutConfig();
 
     if (!descriptor || !regions) {
-        return isEditView ? <div {...editorProps} /> : null;
+        return editorProps ? <div {...editorProps} /> : null;
     }
 
     const LayoutComponent = layoutComponents[descriptor];

--- a/src/components/layouts/useLayoutConfig.tsx
+++ b/src/components/layouts/useLayoutConfig.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
 import { LayoutType } from 'types/component-props/layouts';
 import { EmptyObject } from 'types/util-types';
+import { ComponentEditorProps } from 'components/ComponentMapper';
 
 type LayoutConfig = {
     type: LayoutType;
     title?: string;
+    editorProps?: ComponentEditorProps;
 };
 
 const LayoutContext = React.createContext<LayoutConfig | EmptyObject>({});

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -31,6 +31,7 @@ import { LinkListsLegacyPart } from 'components/parts/_legacy/link-lists/LinkLis
 import { MainArticleLegacyPart } from 'components/parts/_legacy/main-article/MainArticleLegacyPart';
 import { PublishingCalendarLegacyPart } from 'components/parts/_legacy/publishing-calendar/PublishingCalendarLegacyPart';
 import { PublishingCalendarEntryLegacyPart } from 'components/parts/_legacy/publishing-calendar/PublishingCalendarEntryLegacyPart';
+import { ComponentEditorProps } from 'components/ComponentMapper';
 import { AlertBoxPart } from './alert-box/AlertBoxPart';
 import { LinkPanelPart } from './link-panel/LinkPanelPart';
 import { LinkPanelsLegacyPart } from './_legacy/link-panels/LinkPanelsLegacyPart';
@@ -61,11 +62,6 @@ const partsDeprecated: ReadonlySet<PartTypeAll> = new Set([
 ]) satisfies ReadonlySet<PartDeprecatedType>;
 
 const bem = BEM(ComponentType.Part);
-
-const buildEditorProps = (componentPath: string) => ({
-    'data-portal-component-type': ComponentType.Part,
-    'data-portal-component': componentPath,
-});
 
 const PartComponentMapper = ({
     partProps,
@@ -171,19 +167,20 @@ const PartComponentMapper = ({
     }
 };
 
-export const PartsMapper = ({
-    pageProps,
-    partProps,
-}: {
+type Props = {
     partProps: PartComponentProps;
     pageProps: ContentProps;
-}) => {
-    const { path, descriptor, config } = partProps;
+    editorProps?: ComponentEditorProps;
+};
+
+export const PartsMapper = ({ pageProps, partProps, editorProps }: Props) => {
+    const { descriptor, config } = partProps;
 
     const isEditView = pageProps.editorView === 'edit';
-    const editorProps = isEditView ? buildEditorProps(path) : undefined;
 
     if (!descriptor || partsDeprecated.has(descriptor)) {
+        // We still need to render invalid components in the editor to prevent errors
+        // and allow users to remove the invalid component
         return isEditView ? <div {...editorProps} /> : null;
     }
 

--- a/src/components/parts/PartsMapper.tsx
+++ b/src/components/parts/PartsMapper.tsx
@@ -181,7 +181,7 @@ export const PartsMapper = ({ pageProps, partProps, editorProps }: Props) => {
     if (!descriptor || partsDeprecated.has(descriptor)) {
         // We still need to render invalid components in the editor to prevent errors
         // and allow users to remove the invalid component
-        return isEditView ? <div {...editorProps} /> : null;
+        return editorProps ? <div {...editorProps} /> : null;
     }
 
     const partName = descriptor.split(':')[1];

--- a/src/components/parts/_text/TextComponentXp.tsx
+++ b/src/components/parts/_text/TextComponentXp.tsx
@@ -1,20 +1,14 @@
 import React from 'react';
-import { ComponentType, TextComponentProps } from 'types/component-props/_component-common';
+import { TextComponentProps } from 'types/component-props/_component-common';
+import { ComponentEditorProps } from 'components/ComponentMapper';
 
 type Props = {
     textProps: TextComponentProps;
-    editMode?: boolean;
+    editorProps?: ComponentEditorProps;
 };
 
-export const TextComponentXp = ({ textProps, editMode }: Props) => {
-    const { text, path } = textProps;
-
-    const editorProps = editMode
-        ? {
-              'data-portal-component-type': ComponentType.Text,
-              'data-portal-component': path,
-          }
-        : undefined;
+export const TextComponentXp = ({ textProps, editorProps }: Props) => {
+    const { text } = textProps;
 
     if (!text) {
         if (editMode) {

--- a/src/components/parts/_text/TextComponentXp.tsx
+++ b/src/components/parts/_text/TextComponentXp.tsx
@@ -11,7 +11,7 @@ export const TextComponentXp = ({ textProps, editorProps }: Props) => {
     const { text } = textProps;
 
     if (!text) {
-        if (editMode) {
+        if (editorProps) {
             return <div {...editorProps}>{'Tom tekst-komponent, klikk for å redigere'}</div>;
         }
         return null;

--- a/src/components/parts/product-details/ProductDetailsPart.tsx
+++ b/src/components/parts/product-details/ProductDetailsPart.tsx
@@ -84,6 +84,7 @@ export const ProductDetailsPart = ({ config }: PartComponentProps<PartType.Produ
                                 key={index}
                                 componentProps={component}
                                 pageProps={pageProps}
+                                isCustomNestedComponent={true}
                             />
                         ))}
                     </ExpandableComponentWrapper>


### PR DESCRIPTION
- Skriver om håndtering av editor-props, slik at disse nå defineres i ComponentMapper, og prop-drilles ned til neste nivå av komponent-mappere.
- Fikser bugs i editoren som oppstår når en komponent har nøstede komponenter som ikke ligger i XP component-strukturen (gjelder fragmenter og product-details part)