### PR TITLE
Utvider sjekk av innholdstyper som skal ha noindex

### DIFF
--- a/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -23,8 +23,10 @@ const getDescription = (content: ContentProps) => {
     return description.slice(0, DESCRIPTION_MAX_LENGTH);
 };
 
+const contentTypesWithNoIndex = new Set([ContentType.Error, ContentType.FormIntermediateStepPage]);
+
 const isNoIndex = (content: ContentProps) =>
-    content.isPagePreview || content.type === ContentType.Error || content.data?.noindex;
+    content.isPagePreview || contentTypesWithNoIndex.has(content.type) || content.data?.noindex;
 
 const getCanonicalUrl = (content: ContentProps) => {
     return content.data?.canonicalUrl || `${appOrigin}${getPublicPathname(content)}`;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Mellomsteg må ha noindex for å unngå at de vises i Google-søk. Se [beslutning](https://nav-it.slack.com/lists/T5LNAMWNA/F07KMGEV90R?record_id=Rec07TUFHASAC).

## Testing

Testes i dev