### PR TITLE
la inn ny alert for redaktører med varsel om feil url i kort-url for arbeidsgivet

### DIFF
--- a/src/components/_editor-only/EditorWidgets.tsx
+++ b/src/components/_editor-only/EditorWidgets.tsx
@@ -29,7 +29,7 @@ export const EditorWidgets = ({ content }: Props) => {
                 {!liveId && (editorView === 'inline' || editorView === 'edit') && (
                     <ReferencesInfo content={content} />
                 )}
-                <EditorGlobalWarnings key={content._id} />
+                <EditorGlobalWarnings content={content} />
                 {editorView !== 'edit' && <VersionHistory content={content} />}
             </div>
         </div>

--- a/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { ContentProps } from 'types/content-props/_content-common';
 import { DuplicateIdsWarning } from 'components/_editor-only/duplicate-ids-warning/DuplicateIdsWarning';
-
+import { SamledeVarsler } from 'components/_editor-only/samlede-varsler/SamledeVarsler';
 import style from './EditorGlobalWarnings.module.scss';
 
 const EDITOR_GLOBAL_WARNINGS_CONTAINER_ID = 'global-warnings';
@@ -25,10 +26,13 @@ export const RenderToEditorGlobalWarnings = ({ children }: { children: React.Rea
     return createPortal(children, element);
 };
 
-export const EditorGlobalWarnings = () => {
+export const EditorGlobalWarnings = ({ content }: { content: ContentProps }) => {
     return (
-        <div className={style.container} id={EDITOR_GLOBAL_WARNINGS_CONTAINER_ID}>
-            <DuplicateIdsWarning />
-        </div>
+        <>
+            <div className={style.container} id={EDITOR_GLOBAL_WARNINGS_CONTAINER_ID}>
+                <DuplicateIdsWarning />
+            </div>
+            <SamledeVarsler content={content} />
+        </>
     );
 };

--- a/src/components/_editor-only/samlede-varsler/SamledeVarsler.tsx
+++ b/src/components/_editor-only/samlede-varsler/SamledeVarsler.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Alert } from '@navikt/ds-react';
+import { ContentProps } from 'types/content-props/_content-common';
+
+export const SamledeVarsler = ({ content }: { content: ContentProps }) => {
+    const malgruppeErArbeidsgiver = content.data?.audience?._selected === 'employer';
+    const path = content.data?.customPath;
+    const pathIncludesArbeidsgiver = path.includes('/arbeidsgiver');
+    const feilKortUrl = malgruppeErArbeidsgiver && !pathIncludesArbeidsgiver;
+
+    console.log(content.data);
+
+    return (
+        <>
+            {feilKortUrl && (
+                <Alert variant="warning">
+                    Det er problemer med denne siden som må rettes:
+                    <ul>
+                        {feilKortUrl ? (
+                            <li>
+                                Målgruppe er satt til Arbeidsgiver, så kort-url må også starte med
+                                {' "/arbeidsgiver"'}
+                            </li>
+                        ) : null}
+                    </ul>
+                    Dette varselet er kun synlig for redaktører.
+                </Alert>
+            )}
+        </>
+    );
+};


### PR DESCRIPTION
PR for gjennomgang fredag:

- Får feilmelding om at customPath ikke finnes i SamledeVarsler.tsx, men jeg får allikevel url i responsen. Var noe med ContentProps, burde fikse.
- Hvis jeg skriver f.eks "/svangerskapspenger" (istedenfor "/arbeidsgiver/svangerskapspenger", får jeg følgende respons:
![image](https://github.com/user-attachments/assets/186ed8b8-c7eb-447b-854b-62a441a321fa)
- Plukket ut komponenten for seg selv. Tanker om norsk komponentnavn? Tanker om komponentnavn generelt?