### PR TITLE
Endrer skalering av pods

### DIFF
--- a/.nais/hpa/hpa-prod.yml
+++ b/.nais/hpa/hpa-prod.yml
@@ -11,14 +11,14 @@ spec:
     kind: Deployment
     name: nav-enonicxp-frontend
   minReplicas: 2
-  maxReplicas: 40
+  maxReplicas: 128
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 0
       policies:
-        - type: Pods
-          value: 2
-          periodSeconds: 60
+      - type: Percent
+        value: 100
+        periodSeconds: 15
       selectPolicy: Max
   metrics:
     - type: Resource


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Øker max fra 40 til 128 (200 er makismalt innenfor personbruker namespace)
- Øker skalering fra 2 hvert minutt til 100% av eksisterende pods hvert 15 sekund

https://nav-it.slack.com/archives/C5KUST8N6/p1732195444164249
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#default-behavior
