### PR TITLE
Fiks dobbel tagline

### DIFF
--- a/src/components/_common/headers/sharedHeaderUtils.ts
+++ b/src/components/_common/headers/sharedHeaderUtils.ts
@@ -26,7 +26,8 @@ export const getContentTagline = (content: GetContentTaglineProps, currentLangua
 
     if (taxonomy.length > 0 || customCategory) {
         const taxonomyStrings = getTranslatedTaxonomies(taxonomy, language);
-        if (customCategory) {
+
+        if (customCategory && taxonomyStrings.length === 0) {
             taxonomyStrings.push(customCategory);
         }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Ikke bruk customcategory dersom taksonomi er satt

Slik det ser ut nå på https://www.nav.no/samarbeidspartner/om-sykmeldingen:
![image](https://github.com/user-attachments/assets/e48ac39c-f137-4b7f-95c4-06025c42767f)

Med denne fiksen:
![image](https://github.com/user-attachments/assets/48beab20-7b90-4b86-9784-8d8c566e2887)
