### PR TITLE
Legger til målgruppe og innholdstype for alle events mot Amplitude

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -5,6 +5,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartConfigAccordion } from 'components/parts/accordion/AccordionPart';
 import { classNames } from 'utils/classnames';
@@ -20,7 +21,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
     const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
     const contentProps = usePageContentProps();
     const { context } = getDecoratorParams(contentProps);
-    const { editorView } = contentProps;
+    const { editorView, type } = contentProps;
     const [openAccordions, setOpenAccordions] = useState<number[]>([]);
     const expandAll = () => {
         setOpenAccordions(accordion.map((_, index) => index));
@@ -42,6 +43,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
             opprinnelse: 'trekkspill',
             komponent: 'Accordion',
             målgruppe: context,
+            innholdstype: innholdsType(type),
         });
     };
 

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -4,6 +4,7 @@ import { ParsedHtml } from 'components/_common/parsedHtml/ParsedHtml';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartConfigAccordion } from 'components/parts/accordion/AccordionPart';
 import { classNames } from 'utils/classnames';
@@ -17,14 +18,13 @@ type PanelItem = AccordionProps['accordion'][number];
 
 export const Accordion = ({ accordion }: AccordionProps) => {
     const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
-
-    const { editorView } = usePageContentProps();
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const { editorView } = contentProps;
     const [openAccordions, setOpenAccordions] = useState<number[]>([]);
-
     const expandAll = () => {
         setOpenAccordions(accordion.map((_, index) => index));
     };
-
     const validatePanel = (item: PanelItem) => !!(item.title && item.html);
 
     useShortcuts({ shortcut: Shortcuts.SEARCH, callback: expandAll });
@@ -41,6 +41,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
             tittel,
             opprinnelse: 'trekkspill',
             komponent: 'Accordion',
+            målgruppe: context,
         });
     };
 

--- a/src/components/_common/accordion/Accordion.tsx
+++ b/src/components/_common/accordion/Accordion.tsx
@@ -5,7 +5,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartConfigAccordion } from 'components/parts/accordion/AccordionPart';
 import { classNames } from 'utils/classnames';
@@ -43,7 +43,7 @@ export const Accordion = ({ accordion }: AccordionProps) => {
             opprinnelse: 'trekkspill',
             komponent: 'Accordion',
             målgruppe: context,
-            innholdstype: innholdsType(type),
+            innholdstype: innholdsTypeMap[type],
         });
     };
 

--- a/src/components/_common/card/useCard.tsx
+++ b/src/components/_common/card/useCard.tsx
@@ -8,7 +8,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 
 type AnalyticsProps = {
     analyticsLinkGroup?: string;
@@ -67,7 +67,7 @@ export const useCard = ({ link, size, type }: UseCardSettings): UseCardState => 
         destinasjon: link.url,
         lenketekst: link.text,
         målgruppe: context,
-        innholdstype: innholdsType(contentProps.type),
+        innholdstype: innholdsTypeMap[contentProps.type],
     };
 
     const handleUserEvent = (e: React.MouseEvent | React.TouchEvent): void => {

--- a/src/components/_common/card/useCard.tsx
+++ b/src/components/_common/card/useCard.tsx
@@ -7,6 +7,7 @@ import { LinkProps } from 'types/link-props';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 
 type AnalyticsProps = {
     analyticsLinkGroup?: string;
@@ -36,10 +37,10 @@ type UseCardSettings = {
 
 export const useCard = ({ link, size, type }: UseCardSettings): UseCardState => {
     const router = useRouter();
-    const { editorView } = usePageContentProps();
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const { editorView } = contentProps;
     const { layoutConfig } = useLayoutConfig();
-
     const { url, canRouteClientSide } = usePublicUrl(link.url);
 
     const getComponentAnalyticsName = (type: CardType, size: CardSize) => {
@@ -64,6 +65,7 @@ export const useCard = ({ link, size, type }: UseCardSettings): UseCardState => 
         seksjon: layoutConfig.title,
         destinasjon: link.url,
         lenketekst: link.text,
+        målgruppe: context,
     };
 
     const handleUserEvent = (e: React.MouseEvent | React.TouchEvent): void => {

--- a/src/components/_common/card/useCard.tsx
+++ b/src/components/_common/card/useCard.tsx
@@ -8,6 +8,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 
 type AnalyticsProps = {
     analyticsLinkGroup?: string;
@@ -66,6 +67,7 @@ export const useCard = ({ link, size, type }: UseCardSettings): UseCardState => 
         destinasjon: link.url,
         lenketekst: link.text,
         målgruppe: context,
+        innholdstype: innholdsType(contentProps.type),
     };
 
     const handleUserEvent = (e: React.MouseEvent | React.TouchEvent): void => {

--- a/src/components/_common/copyLink/copyLink.tsx
+++ b/src/components/_common/copyLink/copyLink.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { LinkIcon } from '@navikt/aksel-icons';
 import { translator } from 'translations';
 import { classNames } from 'utils/classnames';
-import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 
 import style from './copyLink.module.scss';
@@ -19,9 +20,10 @@ const linkCopiedDisplayTimeMs = 2500;
 
 export const CopyLink = ({ anchor, heading, className, showLabel = true }: CopyLinkProps) => {
     const [showCopyTooltip, setShowCopyTooltip] = useState(false);
-    const { language } = usePageContentProps();
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
     const { layoutConfig } = useLayoutConfig();
-    const getLabel = translator('header', language);
+    const getLabel = translator('header', contentProps.language);
 
     if (!anchor) {
         return null;
@@ -38,6 +40,7 @@ export const CopyLink = ({ anchor, heading, className, showLabel = true }: CopyL
                 setTimeout(() => setShowCopyTooltip(false), linkCopiedDisplayTimeMs);
             }
             logAmplitudeEvent(AnalyticsEvents.COPY_LINK, {
+                målgruppe: context,
                 seksjon: layoutConfig.title,
             });
         }

--- a/src/components/_common/copyLink/copyLink.tsx
+++ b/src/components/_common/copyLink/copyLink.tsx
@@ -5,6 +5,7 @@ import { classNames } from 'utils/classnames';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 
 import style from './copyLink.module.scss';
@@ -22,8 +23,9 @@ export const CopyLink = ({ anchor, heading, className, showLabel = true }: CopyL
     const [showCopyTooltip, setShowCopyTooltip] = useState(false);
     const contentProps = usePageContentProps();
     const { context } = getDecoratorParams(contentProps);
+    const { language, type } = contentProps;
     const { layoutConfig } = useLayoutConfig();
-    const getLabel = translator('header', contentProps.language);
+    const getLabel = translator('header', language);
 
     if (!anchor) {
         return null;
@@ -42,6 +44,7 @@ export const CopyLink = ({ anchor, heading, className, showLabel = true }: CopyL
             logAmplitudeEvent(AnalyticsEvents.COPY_LINK, {
                 målgruppe: context,
                 seksjon: layoutConfig.title,
+                innholdstype: innholdsType(type),
             });
         }
     };

--- a/src/components/_common/copyLink/copyLink.tsx
+++ b/src/components/_common/copyLink/copyLink.tsx
@@ -5,7 +5,7 @@ import { classNames } from 'utils/classnames';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 
 import style from './copyLink.module.scss';
@@ -44,7 +44,7 @@ export const CopyLink = ({ anchor, heading, className, showLabel = true }: CopyL
             logAmplitudeEvent(AnalyticsEvents.COPY_LINK, {
                 målgruppe: context,
                 seksjon: layoutConfig.title,
-                innholdstype: innholdsType(type),
+                innholdstype: innholdsTypeMap[type],
             });
         }
     };

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -4,7 +4,7 @@ import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@n
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget, handleStickyScrollOffset } from 'utils/scroll-to';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
@@ -54,7 +54,7 @@ export const Expandable = ({
             opprinnelse: analyticsOriginTag || 'utvidbar tekst',
             komponent: 'Expandable',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
     };
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget, handleStickyScrollOffset } from 'utils/scroll-to';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
@@ -32,6 +34,8 @@ export const Expandable = ({
 }: Props) => {
     const [isOpen, setIsOpen] = useState(isOpenDefault ?? false);
     const accordionRef = useRef<HTMLDivElement | null>(null);
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
 
     useShortcuts({
         shortcut: Shortcuts.SEARCH,
@@ -48,6 +52,7 @@ export const Expandable = ({
             tittel,
             opprinnelse: analyticsOriginTag || 'utvidbar tekst',
             komponent: 'Expandable',
+            målgruppe: context,
         });
     };
 

--- a/src/components/_common/expandable/Expandable.tsx
+++ b/src/components/_common/expandable/Expandable.tsx
@@ -4,6 +4,7 @@ import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@n
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { classNames } from 'utils/classnames';
 import { smoothScrollToTarget, handleStickyScrollOffset } from 'utils/scroll-to';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
@@ -53,6 +54,7 @@ export const Expandable = ({
             opprinnelse: analyticsOriginTag || 'utvidbar tekst',
             komponent: 'Expandable',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
     };
 

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -5,7 +5,7 @@ import { translator } from 'translations';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { FilterCheckbox } from 'components/parts/filters-menu/FilterCheckbox';
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
 import { useScrollPosition } from 'utils/useStickyScroll';
@@ -91,7 +91,7 @@ export const FilterBar = ({ layoutProps }: Props) => {
                                     opprinnelse: 'innholdtekst',
                                     komponent: 'FilterBar',
                                     målgruppe: context,
-                                    innholdstype: innholdsType(contentProps.type),
+                                    innholdstype: innholdsTypeMap[contentProps.type],
                                 });
                                 saveScrollPosition();
                                 toggleFilter(filter.id);

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -5,6 +5,7 @@ import { translator } from 'translations';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { FilterCheckbox } from 'components/parts/filters-menu/FilterCheckbox';
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
 import { useScrollPosition } from 'utils/useStickyScroll';
@@ -90,6 +91,7 @@ export const FilterBar = ({ layoutProps }: Props) => {
                                     opprinnelse: 'innholdtekst',
                                     komponent: 'FilterBar',
                                     målgruppe: context,
+                                    innholdstype: innholdsType(contentProps.type),
                                 });
                                 saveScrollPosition();
                                 toggleFilter(filter.id);

--- a/src/components/_common/filter-bar/FilterBar.tsx
+++ b/src/components/_common/filter-bar/FilterBar.tsx
@@ -4,6 +4,7 @@ import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { translator } from 'translations';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { FilterCheckbox } from 'components/parts/filters-menu/FilterCheckbox';
 import { SectionWithHeaderProps } from 'types/component-props/layouts/section-with-header';
 import { useScrollPosition } from 'utils/useStickyScroll';
@@ -24,19 +25,15 @@ type Props = {
 /** @deprecated */
 export const FilterBar = ({ layoutProps }: Props) => {
     const filterBarRef = useRef(null);
-
-    const { language } = usePageContentProps();
-    const getLabel = translator('filteredContent', language);
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const getLabel = translator('filteredContent', contentProps.language);
     const { selectedFilters, availableFilters, toggleFilter } = useFilterState();
-
     const { saveScrollPosition, scrollBackToElement } = useScrollPosition(filterBarRef.current);
-
     const [filtersToDisplay, setFiltersToDisplay] = useState<FilterWithCategory[]>([]);
 
     useEffect(() => {
         const { content, intro } = layoutProps.regions;
-
         const components = [
             ...(content ? content.components : []),
             ...(intro ? intro.components : []),
@@ -92,6 +89,7 @@ export const FilterBar = ({ layoutProps }: Props) => {
                                     filternavn: filter.filterName,
                                     opprinnelse: 'innholdtekst',
                                     komponent: 'FilterBar',
+                                    målgruppe: context,
                                 });
                                 saveScrollPosition();
                                 toggleFilter(filter.id);

--- a/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
+++ b/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
@@ -7,6 +7,7 @@ import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 
 import style from 'components/_common/lenke/lenkeBase/LenkeBase.module.scss';
 
@@ -51,7 +52,6 @@ export const LenkeBase = ({
     const { editorView } = contentProps;
     const { context } = getDecoratorParams(contentProps);
     const { layoutConfig } = useLayoutConfig();
-
     const { url, canRouteClientSide } = usePublicUrl(href);
     const analyticsData = {
         komponent: analyticsComponent,
@@ -60,6 +60,7 @@ export const LenkeBase = ({
         destinasjon: url,
         lenketekst: analyticsLabel || onlyText(children),
         målgruppe: context,
+        innholdstype: innholdsType(contentProps.type),
     };
 
     const WrapperComponent =

--- a/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
+++ b/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
@@ -7,7 +7,7 @@ import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 
 import style from 'components/_common/lenke/lenkeBase/LenkeBase.module.scss';
 
@@ -60,7 +60,7 @@ export const LenkeBase = ({
         destinasjon: url,
         lenketekst: analyticsLabel || onlyText(children),
         målgruppe: context,
-        innholdstype: innholdsType(contentProps.type),
+        innholdstype: innholdsTypeMap[contentProps.type],
     };
 
     const WrapperComponent =

--- a/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
+++ b/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
@@ -6,6 +6,7 @@ import { onlyText } from 'utils/react-children';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import { usePublicUrl } from 'utils/usePublicUrl';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 
 import style from 'components/_common/lenke/lenkeBase/LenkeBase.module.scss';
 
@@ -46,7 +47,9 @@ export const LenkeBase = ({
     children,
     ...rest
 }: Props) => {
-    const { editorView } = usePageContentProps();
+    const contentProps = usePageContentProps();
+    const { editorView } = contentProps;
+    const { context } = getDecoratorParams(contentProps);
     const { layoutConfig } = useLayoutConfig();
 
     const { url, canRouteClientSide } = usePublicUrl(href);
@@ -56,6 +59,7 @@ export const LenkeBase = ({
         seksjon: analyticsLinkGroup || layoutConfig.title,
         destinasjon: url,
         lenketekst: analyticsLabel || onlyText(children),
+        målgruppe: context,
     };
 
     const WrapperComponent =

--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -10,6 +10,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 
 import style from './OverviewFilters.module.scss';
 
@@ -53,6 +54,7 @@ const MobileView = ({
                                         opprinnelse: 'oversiktsside filter mobil',
                                         komponent: 'MobileView',
                                         målgruppe: context,
+                                        innholdstype: innholdsType(contentProps.type),
                                     });
                                 }}
                                 className={style.mobileFilterButton}

--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -10,7 +10,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 
 import style from './OverviewFilters.module.scss';
 
@@ -54,7 +54,7 @@ const MobileView = ({
                                         opprinnelse: 'oversiktsside filter mobil',
                                         komponent: 'MobileView',
                                         målgruppe: context,
-                                        innholdstype: innholdsType(contentProps.type),
+                                        innholdstype: innholdsTypeMap[contentProps.type],
                                     });
                                 }}
                                 className={style.mobileFilterButton}

--- a/src/components/_common/overview-filters/OverviewFilters.tsx
+++ b/src/components/_common/overview-filters/OverviewFilters.tsx
@@ -7,8 +7,9 @@ import { OverviewTextFilter } from 'components/_common/overview-filters/text-fil
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { classNames } from 'utils/classnames';
 import { translator } from 'translations';
-import { usePageContentProps } from 'store/pageContext';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 
 import style from './OverviewFilters.module.scss';
 
@@ -18,16 +19,14 @@ const MobileView = ({
     showAreaFilter,
     showTaxonomyFilter,
 }: Props) => {
-    const { language } = usePageContentProps();
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
     const [isOpen, setIsOpen] = useState(false);
     const filtersRef = useRef<HTMLDivElement>(null);
-
     const hasToggleFilters = showAreaFilter || showTaxonomyFilter;
-
     const searchLabel = translator(
         'overview',
-        language
+        contentProps.language
     )(hasToggleFilters ? 'filterOrSearch' : 'search');
 
     return (
@@ -53,6 +52,7 @@ const MobileView = ({
                                         kategori: 'mobile-toggle',
                                         opprinnelse: 'oversiktsside filter mobil',
                                         komponent: 'MobileView',
+                                        målgruppe: context,
                                     });
                                 }}
                                 className={style.mobileFilterButton}

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -3,7 +3,7 @@ import { Area } from 'types/areas';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -49,7 +49,7 @@ export const OverviewAreaFilter = ({ items }: Props) => {
             opprinnelse: 'oversiktsside områder',
             komponent: 'OverviewAreaFilter',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
         setAreaFilter(area);
     };

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Area } from 'types/areas';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -37,13 +39,15 @@ type Props = {
 
 export const OverviewAreaFilter = ({ items }: Props) => {
     const { areaFilter, setAreaFilter } = useOverviewFilters();
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
     const handleFilterUpdate = (area: Area) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             kategori: 'område',
             filternavn: analyticsAreas[area],
             opprinnelse: 'oversiktsside områder',
             komponent: 'OverviewAreaFilter',
+            målgruppe: context,
         });
         setAreaFilter(area);
     };

--- a/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
+++ b/src/components/_common/overview-filters/area-filter/OverviewAreaFilter.tsx
@@ -3,6 +3,7 @@ import { Area } from 'types/areas';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -48,6 +49,7 @@ export const OverviewAreaFilter = ({ items }: Props) => {
             opprinnelse: 'oversiktsside områder',
             komponent: 'OverviewAreaFilter',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
         setAreaFilter(area);
     };

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -3,6 +3,7 @@ import { ProductTaxonomy } from 'types/taxonomies';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -47,6 +48,7 @@ export const OverviewTaxonomyFilter = ({ items }: Props) => {
             opprinnelse: 'oversiktsside typer',
             komponent: 'OverviewTaxonomyFilter',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
         setTaxonomyFilter(taxonomy);
     };

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ProductTaxonomy } from 'types/taxonomies';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -35,6 +37,8 @@ type Props = {
 
 export const OverviewTaxonomyFilter = ({ items }: Props) => {
     const { taxonomyFilter, setTaxonomyFilter } = useOverviewFilters();
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
 
     const handleFilterUpdate = (taxonomy: ProductTaxonomy) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
@@ -42,6 +46,7 @@ export const OverviewTaxonomyFilter = ({ items }: Props) => {
             filternavn: analyticsTaxonomi[taxonomy],
             opprinnelse: 'oversiktsside typer',
             komponent: 'OverviewTaxonomyFilter',
+            målgruppe: context,
         });
         setTaxonomyFilter(taxonomy);
     };

--- a/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
+++ b/src/components/_common/overview-filters/taxonomy-filter/OverviewTaxonomyFilter.tsx
@@ -3,7 +3,7 @@ import { ProductTaxonomy } from 'types/taxonomies';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { OverviewFilterBase } from 'components/_common/overview-filters/OverViewFilterBase/OverviewFilterBase';
 import { OverviewFilterableItem, useOverviewFilters } from 'store/hooks/useOverviewFilters';
 
@@ -48,7 +48,7 @@ export const OverviewTaxonomyFilter = ({ items }: Props) => {
             opprinnelse: 'oversiktsside typer',
             komponent: 'OverviewTaxonomyFilter',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
         setTaxonomyFilter(taxonomy);
     };

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -2,14 +2,16 @@ import React, { useCallback, useEffect, useId, useState } from 'react';
 import { Search } from '@navikt/ds-react';
 import debounce from 'lodash.debounce';
 import { translator } from 'translations';
+import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { windowScrollTo } from 'utils/scroll-to';
-import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import {
     OVERVIEW_FILTERS_TEXT_INPUT_EVENT,
     OverviewFiltersTextInputEventDetail,
 } from 'store/slices/overviewFilters';
+
 import style from './OverviewTextFilter.module.scss';
 
 type Props = {
@@ -23,9 +25,10 @@ const analyticsRedaction = (value: string) =>
 
 export const OverviewTextFilter = ({ hideLabel }: Props) => {
     const { setTextFilter } = useOverviewFilters();
-    const { language } = usePageContentProps();
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const label = translator('overview', contentProps.language)('search');
     const inputId = useId();
-
     const [textInput, setTextInput] = useState('');
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -44,6 +47,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                 kategori: 'fritekst',
                 filternavn: analyticsRedaction(value),
                 komponent: 'OverviewTextFilter',
+                målgruppe: context,
             });
         }, 500),
         [setTextFilter]
@@ -61,7 +65,6 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                 setTextInput(value);
             }
         };
-
         window.addEventListener(OVERVIEW_FILTERS_TEXT_INPUT_EVENT, handleInputFromEvent);
         return () => {
             window.removeEventListener(OVERVIEW_FILTERS_TEXT_INPUT_EVENT, handleInputFromEvent);
@@ -95,7 +98,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
             <Search
                 onChange={handleUserInput}
                 value={textInput}
-                label={translator('overview', language)('search')}
+                label={label}
                 hideLabel={hideLabel}
                 variant={'secondary'}
                 autoComplete={'off'}

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -5,6 +5,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { windowScrollTo } from 'utils/scroll-to';
 import {
@@ -48,6 +49,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                 filternavn: analyticsRedaction(value),
                 komponent: 'OverviewTextFilter',
                 målgruppe: context,
+                innholdstype: innholdsType(contentProps.type),
             });
         }, 500),
         [setTextFilter]

--- a/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
+++ b/src/components/_common/overview-filters/text-filter/OverviewTextFilter.tsx
@@ -5,7 +5,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { useOverviewFilters } from 'store/hooks/useOverviewFilters';
 import { windowScrollTo } from 'utils/scroll-to';
 import {
@@ -49,7 +49,7 @@ export const OverviewTextFilter = ({ hideLabel }: Props) => {
                 filternavn: analyticsRedaction(value),
                 komponent: 'OverviewTextFilter',
                 målgruppe: context,
-                innholdstype: innholdsType(contentProps.type),
+                innholdstype: innholdsTypeMap[contentProps.type],
             });
         }, 500),
         [setTextFilter]

--- a/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
+++ b/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
@@ -4,7 +4,7 @@ import { PictogramsProps } from 'types/content-props/pictograms';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { IllustrationStatic } from 'components/_common/illustration/static/IllustrationStatic';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
 import { AlertBox } from 'components/_common/alertBox/AlertBox';
@@ -71,7 +71,7 @@ export const ProductPanelExpandable = ({
             opprinnelse: 'produktdetalj',
             komponent: 'ProductPanelExpandable',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
             ...analyticsData,
         });
     };

--- a/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
+++ b/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { BodyShort, ExpansionCard, Loader } from '@navikt/ds-react';
+import { PictogramsProps } from 'types/content-props/pictograms';
+import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { IllustrationStatic } from 'components/_common/illustration/static/IllustrationStatic';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
-import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
-import { PictogramsProps } from 'types/content-props/pictograms';
 import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { translator } from 'translations';
-import { usePageContentProps } from 'store/pageContext';
 
 import style from './ProductPanelExpandable.module.scss';
 
@@ -36,12 +37,10 @@ export const ProductPanelExpandable = ({
     children,
 }: Props) => {
     const [isOpen, setIsOpen] = useState(false);
-
-    const { language } = usePageContentProps();
-    const loadingText = translator('overview', language)('loading');
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const loadingText = translator('overview', contentProps.language)('loading');
     const anchorIdWithHash = `#${anchorId}`;
-
     const checkHashAndExpandPanel = () => {
         if (window.location.hash === anchorIdWithHash) {
             contentLoaderCallback?.();
@@ -70,6 +69,7 @@ export const ProductPanelExpandable = ({
             tittel,
             opprinnelse: 'produktdetalj',
             komponent: 'ProductPanelExpandable',
+            målgruppe: context,
             ...analyticsData,
         });
     };

--- a/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
+++ b/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
@@ -4,6 +4,7 @@ import { PictogramsProps } from 'types/content-props/pictograms';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { IllustrationStatic } from 'components/_common/illustration/static/IllustrationStatic';
 import { CopyLink } from 'components/_common/copyLink/copyLink';
 import { AlertBox } from 'components/_common/alertBox/AlertBox';
@@ -70,6 +71,7 @@ export const ProductPanelExpandable = ({
             opprinnelse: 'produktdetalj',
             komponent: 'ProductPanelExpandable',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
             ...analyticsData,
         });
     };

--- a/src/components/_common/qbrick-video/QbrickVideo.tsx
+++ b/src/components/_common/qbrick-video/QbrickVideo.tsx
@@ -9,7 +9,7 @@ import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { NextImage } from 'components/_common/image/NextImage';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { QbrickVideoProps } from './utils/videoProps';
 import { getTimestampFromDuration } from './utils/videoHelpers';
 import { useQbrickPlayerState } from './useQbrickPlayerState';
@@ -27,7 +27,7 @@ export const QbrickVideo = (props: QbrickVideoProps) => {
             videoProps: props,
             videoContainerId,
             context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         }
     );
 

--- a/src/components/_common/qbrick-video/QbrickVideo.tsx
+++ b/src/components/_common/qbrick-video/QbrickVideo.tsx
@@ -9,6 +9,7 @@ import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { NextImage } from 'components/_common/image/NextImage';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { QbrickVideoProps } from './utils/videoProps';
 import { getTimestampFromDuration } from './utils/videoHelpers';
 import { useQbrickPlayerState } from './useQbrickPlayerState';
@@ -26,6 +27,7 @@ export const QbrickVideo = (props: QbrickVideoProps) => {
             videoProps: props,
             videoContainerId,
             context,
+            innholdstype: innholdsType(contentProps.type),
         }
     );
 

--- a/src/components/_common/qbrick-video/QbrickVideo.tsx
+++ b/src/components/_common/qbrick-video/QbrickVideo.tsx
@@ -4,10 +4,11 @@ import Script from 'next/script';
 import { translator } from 'translations';
 import { getMediaUrl } from 'utils/urls';
 import { classNames } from 'utils/classnames';
-import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { logger } from 'srcCommon/logger';
+import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { NextImage } from 'components/_common/image/NextImage';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { QbrickVideoProps } from './utils/videoProps';
 import { getTimestampFromDuration } from './utils/videoHelpers';
 import { useQbrickPlayerState } from './useQbrickPlayerState';
@@ -15,16 +16,16 @@ import { useQbrickPlayerState } from './useQbrickPlayerState';
 import style from './QbrickVideo.module.scss';
 
 export const QbrickVideo = (props: QbrickVideoProps) => {
-    const { language: contentLanguage, editorView } = usePageContentProps();
-
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const { language: contentLanguage, editorView } = contentProps;
     const { title, duration, poster } = props;
-
     const videoContainerId = useId();
-
     const { createAndStartPlayer, resetPlayer, playerState, setPlayerState } = useQbrickPlayerState(
         {
             videoProps: props,
             videoContainerId,
+            context,
         }
     );
 
@@ -33,9 +34,7 @@ export const QbrickVideo = (props: QbrickVideoProps) => {
     }, [resetPlayer]);
 
     const translations = translator('macroVideo', contentLanguage);
-
     const durationAsString = getTimestampFromDuration(duration);
-
     const imageUrl = poster?.startsWith('http')
         ? poster
         : getMediaUrl(poster, !!editorView, contentLanguage);

--- a/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
+++ b/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
@@ -36,7 +36,15 @@ export const useQbrickPlayerState = ({
         }
 
         createAndStart(videoProps, videoContainer, widgetId, setPlayerState, context, innholdstype);
-    }, [videoProps, videoContainerId, widgetId, playerState, setPlayerState, context]);
+    }, [
+        videoProps,
+        videoContainerId,
+        widgetId,
+        playerState,
+        setPlayerState,
+        context,
+        innholdstype,
+    ]);
 
     const resetPlayer = useCallback(() => {
         setPlayerState('stopped');

--- a/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
+++ b/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
@@ -11,9 +11,10 @@ const PLAYER_POLLING_RATE_MS = 50;
 type Props = {
     videoProps: QbrickVideoProps;
     videoContainerId: string;
+    context?: string;
 };
 
-export const useQbrickPlayerState = ({ videoProps, videoContainerId }: Props) => {
+export const useQbrickPlayerState = ({ videoProps, videoContainerId, context }: Props) => {
     const [playerState, setPlayerState] = useState<PlayerState>('stopped');
     const widgetId = useId();
 
@@ -28,8 +29,8 @@ export const useQbrickPlayerState = ({ videoProps, videoContainerId }: Props) =>
             return;
         }
 
-        createAndStart(videoProps, videoContainer, widgetId, setPlayerState);
-    }, [videoProps, videoContainerId, widgetId, playerState, setPlayerState]);
+        createAndStart(videoProps, videoContainer, widgetId, setPlayerState, context);
+    }, [videoProps, videoContainerId, widgetId, playerState, setPlayerState, context]);
 
     const resetPlayer = useCallback(() => {
         setPlayerState('stopped');
@@ -51,7 +52,8 @@ const createAndStart = (
     { accountId, mediaId, language, title, duration }: QbrickVideoProps,
     videoContainer: HTMLElement,
     widgetId: string,
-    setPlayerState: (state: PlayerState) => void
+    setPlayerState: (state: PlayerState) => void,
+    context?: string
 ) => {
     const createPlayer = (timeLeft: number = PLAYER_TIMEOUT_MS) => {
         if (timeLeft <= 0) {
@@ -88,6 +90,7 @@ const createAndStart = (
                     tittel: title,
                     varighet: duration,
                     språk: language,
+                    målgruppe: context,
                 });
             })
             .on('playable', () => {

--- a/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
+++ b/src/components/_common/qbrick-video/useQbrickPlayerState.tsx
@@ -12,9 +12,15 @@ type Props = {
     videoProps: QbrickVideoProps;
     videoContainerId: string;
     context?: string;
+    innholdstype?: string;
 };
 
-export const useQbrickPlayerState = ({ videoProps, videoContainerId, context }: Props) => {
+export const useQbrickPlayerState = ({
+    videoProps,
+    videoContainerId,
+    context,
+    innholdstype,
+}: Props) => {
     const [playerState, setPlayerState] = useState<PlayerState>('stopped');
     const widgetId = useId();
 
@@ -29,7 +35,7 @@ export const useQbrickPlayerState = ({ videoProps, videoContainerId, context }: 
             return;
         }
 
-        createAndStart(videoProps, videoContainer, widgetId, setPlayerState, context);
+        createAndStart(videoProps, videoContainer, widgetId, setPlayerState, context, innholdstype);
     }, [videoProps, videoContainerId, widgetId, playerState, setPlayerState, context]);
 
     const resetPlayer = useCallback(() => {
@@ -53,7 +59,8 @@ const createAndStart = (
     videoContainer: HTMLElement,
     widgetId: string,
     setPlayerState: (state: PlayerState) => void,
-    context?: string
+    context?: string,
+    innholdstype?: string
 ) => {
     const createPlayer = (timeLeft: number = PLAYER_TIMEOUT_MS) => {
         if (timeLeft <= 0) {
@@ -91,6 +98,7 @@ const createAndStart = (
                     varighet: duration,
                     språk: language,
                     målgruppe: context,
+                    innholdstype,
                 });
             })
             .on('playable', () => {

--- a/src/components/_common/user-tests/UserTests.tsx
+++ b/src/components/_common/user-tests/UserTests.tsx
@@ -11,7 +11,6 @@ export type UserTestsComponentProps = {
         data: UserTestsConfigData;
     };
     selectedTestIds: string[];
-    _path?: string;
 };
 
 export const UserTests = (props: UserTestsComponentProps) => {

--- a/src/components/_common/user-tests/UserTests.tsx
+++ b/src/components/_common/user-tests/UserTests.tsx
@@ -11,6 +11,7 @@ export type UserTestsComponentProps = {
         data: UserTestsConfigData;
     };
     selectedTestIds: string[];
+    _path: string;
 };
 
 export const UserTests = (props: UserTestsComponentProps) => {

--- a/src/components/_common/user-tests/UserTests.tsx
+++ b/src/components/_common/user-tests/UserTests.tsx
@@ -11,7 +11,7 @@ export type UserTestsComponentProps = {
         data: UserTestsConfigData;
     };
     selectedTestIds: string[];
-    _path: string;
+    _path?: string;
 };
 
 export const UserTests = (props: UserTestsComponentProps) => {

--- a/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
+++ b/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
@@ -21,6 +21,7 @@ const baseProps: UserTestsComponentProps = {
             variants: [],
         },
     },
+    _path: 'test',
 };
 
 const buildProps = (variants: UserTestVariantProps[], selectedTestIds: string[] = []) => {

--- a/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
+++ b/src/components/_common/user-tests/public-view/UserTestsPublicView.test.tsx
@@ -11,7 +11,7 @@ import { PageContextProvider } from 'store/pageContext';
 
 const cookieId = 'cookie-1234';
 
-const baseProps: UserTestsComponentProps = {
+const baseProps: UserTestsComponentProps & { _path: string } = {
     selectedTestIds: [],
     tests: {
         data: {

--- a/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
+++ b/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { ExpansionCard, BodyShort, Heading } from '@navikt/ds-react';
-import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { officeDetailsFormatAddress } from 'components/pages/office-page/office-details/utils';
 
@@ -14,8 +15,9 @@ export interface OfficeInformationProps {
 
 export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
     const [isOpen, setIsOpen] = useState(false);
-    const { language } = usePageContentProps();
-    const getOfficeTranslations = translator('office', language);
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const getOfficeTranslations = translator('office', contentProps.language);
     const title = getOfficeTranslations('officeInformation');
     const { postadresse, beliggenhet, organisasjonsnummer, enhetNr } = officeData;
     const visitingAddress = officeDetailsFormatAddress(beliggenhet, true);
@@ -27,6 +29,7 @@ export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
             tittel,
             opprinnelse: 'kontorinformasjon',
             komponent: 'OfficeInformation',
+            målgruppe: context,
         });
     };
 

--- a/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
+++ b/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
@@ -4,6 +4,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { officeDetailsFormatAddress } from 'components/pages/office-page/office-details/utils';
 
@@ -30,6 +31,7 @@ export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
             opprinnelse: 'kontorinformasjon',
             komponent: 'OfficeInformation',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
     };
 

--- a/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
+++ b/src/components/pages/office-page/office-details/officeInformation/OfficeInformation.tsx
@@ -4,7 +4,7 @@ import { translator } from 'translations';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { OfficeDetailsData } from 'types/content-props/office-details-props';
 import { officeDetailsFormatAddress } from 'components/pages/office-page/office-details/utils';
 
@@ -31,7 +31,7 @@ export const OfficeInformation = ({ officeData }: OfficeInformationProps) => {
             opprinnelse: 'kontorinformasjon',
             komponent: 'OfficeInformation',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
     };
 

--- a/src/components/parts/filters-menu/FiltersMenuPart.tsx
+++ b/src/components/parts/filters-menu/FiltersMenuPart.tsx
@@ -11,6 +11,7 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { ExpandableMixin } from 'types/component-props/_mixins';
 import { checkIfFilterFirstInPage } from './helpers';
 import { FilterCheckbox } from './FilterCheckbox';
@@ -69,6 +70,7 @@ export const FiltersMenuPart = ({ config, path }: PartComponentProps<PartType.Fi
             opprinnelse: 'filtermeny',
             komponent: 'FiltersMenuPart',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
         toggleFilter(filter.id);
     };

--- a/src/components/parts/filters-menu/FiltersMenuPart.tsx
+++ b/src/components/parts/filters-menu/FiltersMenuPart.tsx
@@ -11,7 +11,7 @@ import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { ExpandableMixin } from 'types/component-props/_mixins';
 import { checkIfFilterFirstInPage } from './helpers';
 import { FilterCheckbox } from './FilterCheckbox';
@@ -70,7 +70,7 @@ export const FiltersMenuPart = ({ config, path }: PartComponentProps<PartType.Fi
             opprinnelse: 'filtermeny',
             komponent: 'FiltersMenuPart',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
         toggleFilter(filter.id);
     };

--- a/src/components/parts/filters-menu/FiltersMenuPart.tsx
+++ b/src/components/parts/filters-menu/FiltersMenuPart.tsx
@@ -10,6 +10,7 @@ import { Header } from 'components/_common/headers/Header';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { ExpandableMixin } from 'types/component-props/_mixins';
 import { checkIfFilterFirstInPage } from './helpers';
 import { FilterCheckbox } from './FilterCheckbox';
@@ -33,16 +34,13 @@ export type PartConfigFilterMenu = {
 } & ExpandableMixin;
 
 export const FiltersMenuPart = ({ config, path }: PartComponentProps<PartType.FiltersMenu>) => {
-    const { language, editorView, page } = usePageContentProps();
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
+    const { language, editorView, page } = contentProps;
     const { categories, description, expandableTitle, title } = config;
-
     const { clearFiltersForPage, selectedFilters, setAvailableFilters, toggleFilter } =
         useFilterState();
-
-    const isFirstFilterInPage = checkIfFilterFirstInPage({
-        path,
-        page,
-    });
+    const isFirstFilterInPage = checkIfFilterFirstInPage({ path, page });
 
     useEffect(() => {
         // Multiple FilterMenus in same page will break.
@@ -64,13 +62,13 @@ export const FiltersMenuPart = ({ config, path }: PartComponentProps<PartType.Fi
     }, []);
 
     const getLabel = translator('filteredContent', language);
-
     const onToggleFilterHandler = (filter: Filter, category: FilterMenuCategory) => {
         logAmplitudeEvent(AnalyticsEvents.FILTER, {
             kategori: category.categoryName,
             filternavn: filter.filterName,
             opprinnelse: 'filtermeny',
             komponent: 'FiltersMenuPart',
+            målgruppe: context,
         });
         toggleFilter(filter.id);
     };

--- a/src/components/parts/readMorePart/ReadMorePart.tsx
+++ b/src/components/parts/readMorePart/ReadMorePart.tsx
@@ -7,6 +7,7 @@ import { handleStickyScrollOffset } from 'utils/scroll-to';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
+import { innholdsType } from 'types/content-props/_content-common';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
@@ -43,6 +44,7 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
             opprinnelse: 'lesmer',
             komponent: 'ReadMore',
             målgruppe: context,
+            innholdstype: innholdsType(contentProps.type),
         });
     };
 

--- a/src/components/parts/readMorePart/ReadMorePart.tsx
+++ b/src/components/parts/readMorePart/ReadMorePart.tsx
@@ -7,7 +7,7 @@ import { handleStickyScrollOffset } from 'utils/scroll-to';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
 import { usePageContentProps } from 'store/pageContext';
 import { getDecoratorParams } from 'utils/decorator-utils';
-import { innholdsType } from 'types/content-props/_content-common';
+import { innholdsTypeMap } from 'types/content-props/_content-common';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
@@ -44,7 +44,7 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
             opprinnelse: 'lesmer',
             komponent: 'ReadMore',
             målgruppe: context,
-            innholdstype: innholdsType(contentProps.type),
+            innholdstype: innholdsTypeMap[contentProps.type],
         });
     };
 

--- a/src/components/parts/readMorePart/ReadMorePart.tsx
+++ b/src/components/parts/readMorePart/ReadMorePart.tsx
@@ -2,12 +2,14 @@ import React, { useRef, useState } from 'react';
 import { ReadMore } from '@navikt/ds-react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
 import { ParsedHtml } from 'components/_common/parsedHtml/ParsedHtml';
+import { classNames } from 'utils/classnames';
+import { handleStickyScrollOffset } from 'utils/scroll-to';
 import { AnalyticsEvents, logAmplitudeEvent } from 'utils/amplitude';
+import { usePageContentProps } from 'store/pageContext';
+import { getDecoratorParams } from 'utils/decorator-utils';
 import { Shortcuts, useShortcuts } from 'utils/useShortcuts';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ProcessedHtmlProps } from 'types/processed-html-props';
-import { classNames } from 'utils/classnames';
-import { handleStickyScrollOffset } from 'utils/scroll-to';
 
 import defaultHtml from 'components/_common/parsedHtml/DefaultHtmlStyling.module.scss';
 import styles from './ReadMorePart.module.scss';
@@ -21,6 +23,8 @@ export type PartConfigReadMore = {
 export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) => {
     const [isOpen, setIsOpen] = useState(config?.isOpen ?? false);
     const divRef = useRef<HTMLDivElement | null>(null);
+    const contentProps = usePageContentProps();
+    const { context } = getDecoratorParams(contentProps);
 
     useShortcuts({
         shortcut: Shortcuts.SEARCH,
@@ -33,12 +37,12 @@ export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) 
 
     const openChangeHandler = (isOpening: boolean, tittel: string) => {
         handleStickyScrollOffset(isOpening, divRef.current);
-
         setIsOpen(isOpening);
         logAmplitudeEvent(isOpening ? AnalyticsEvents.ACC_EXPAND : AnalyticsEvents.ACC_COLLAPSE, {
             tittel,
             opprinnelse: 'lesmer',
             komponent: 'ReadMore',
+            målgruppe: context,
         });
     };
 

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -95,92 +95,55 @@ export enum ContentType {
     FallbackPage = 'no.nav.navno:fallback-page',
 }
 
-export const innholdsType = (type: ContentType) => {
-    switch (type) {
-        case ContentType.InternalLink:
-            return 'Intern Lenke';
-        case ContentType.ExternalLink:
-            return 'Ekstern Lenke';
-        case ContentType.SectionPage:
-            return 'Oppslagstavle';
-        case ContentType.TransportPage:
-            return 'Transportside';
-        case ContentType.DynamicPage:
-            return 'Dynamisk side';
-        case ContentType.ContentList:
-            return 'Innholdsliste';
-        case ContentType.ContactInformationPage:
-            return 'Kontaktinformasjon';
-        case ContentType.GenericPage:
-            return 'Generisk side';
-        case ContentType.PageList:
-            return 'Artikkelliste';
-        case ContentType.MainArticle:
-            return 'Artikkel';
-        case ContentType.MainArticleChapter:
-            return 'Kapittel';
-        case ContentType.Melding:
-            return 'Driftsmelding';
-        case ContentType.LargeTable:
-            return 'Ekstra stor tabell';
-        case ContentType.OfficeInformation:
-            return 'Enhetsinformasjon';
-        case ContentType.PublishingCalendar:
-            return 'Publiseringskalender';
-        case ContentType.PublishingCalendarEntry:
-            return 'Kalenderhendelse';
-        case ContentType.GlobalNumberValuesSet:
-            return 'Globale tall-verdier';
-        case ContentType.ProductPage:
-            return 'Produktside';
-        case ContentType.ProductDetails:
-            return 'Produktdetaljer';
-        case ContentType.OfficeEditorialPage:
-            return 'Kontorside for redaktørinnhold';
-        case ContentType.GuidePage:
-            return 'Slik gjør du det';
-        case ContentType.ThemedArticlePage:
-            return 'Temaartikkel';
-        case ContentType.CurrentTopicPage:
-            return 'Aktuelt';
-        case ContentType.SituationPage:
-            return 'Situasjonsside';
-        case ContentType.Pictograms:
-            return 'Piktogram';
-        case ContentType.ToolsPage:
-            return 'Verktøy-side';
-        case ContentType.Calculator:
-            return 'Kalkulator';
-        case ContentType.Overview:
-            return 'Oversiktsside';
-        case ContentType.GlobalCaseTimeSet:
-            return 'Saksbehandlingstider';
-        case ContentType.PayoutDates:
-            return 'Utbetalingsdatoer';
-        case ContentType.FrontPage:
-            return 'Forside';
-        case ContentType.FrontPageNested:
-            return 'Underforside';
-        case ContentType.AreaPage:
-            return 'Områdeside';
-        case ContentType.PressLandingPage:
-            return 'Landingsside for presse';
-        case ContentType.FormDetails:
-            return 'Skjemadetaljer';
-        case ContentType.FormIntermediateStepPage:
-            return 'Mellomsteg for søknad, skjema, klage og ettersendelse';
-        case ContentType.FormsOverview:
-            return 'Skjemaoversikt';
-        case ContentType.UserTestsConfig:
-            return 'Brukertester';
-        case ContentType.Video:
-            return 'Qbrick Video';
-        case ContentType.AlertInContext:
-            return 'Varsel i kontekst';
-        case ContentType.OfficePage:
-            return 'Kontorside (gammel)';
-    }
-    return `Ugyldig [${type}]`;
+export const innholdsTypeMap: Record<ContentType, string> = {
+    [ContentType.InternalLink]: 'Intern Lenke',
+    [ContentType.ExternalLink]: 'Ekstern Lenke',
+    [ContentType.SectionPage]: 'Oppslagstavle',
+    [ContentType.TransportPage]: 'Transportside',
+    [ContentType.DynamicPage]: 'Dynamisk side',
+    [ContentType.ContentList]: 'Innholdsliste',
+    [ContentType.ContactInformationPage]: 'Kontaktinformasjon',
+    [ContentType.GenericPage]: 'Generisk side',
+    [ContentType.PageList]: 'Artikkelliste',
+    [ContentType.MainArticle]: 'Artikkel',
+    [ContentType.MainArticleChapter]: 'Kapittel',
+    [ContentType.Melding]: 'Driftsmelding',
+    [ContentType.LargeTable]: 'Ekstra stor tabell',
+    [ContentType.OfficeInformation]: 'Enhetsinformasjon',
+    [ContentType.PublishingCalendar]: 'Publiseringskalender',
+    [ContentType.PublishingCalendarEntry]: 'Kalenderhendelse',
+    [ContentType.GlobalNumberValuesSet]: 'Globale tall-verdier',
+    [ContentType.ProductPage]: 'Produktside',
+    [ContentType.ProductDetails]: 'Produktdetaljer',
+    [ContentType.OfficeEditorialPage]: 'Kontorside for redaktørinnhold',
+    [ContentType.GuidePage]: 'Slik gjør du det',
+    [ContentType.ThemedArticlePage]: 'Temaartikkel',
+    [ContentType.CurrentTopicPage]: 'Aktuelt',
+    [ContentType.SituationPage]: 'Situasjonsside',
+    [ContentType.Pictograms]: 'Piktogram',
+    [ContentType.ToolsPage]: 'Verktøy-side',
+    [ContentType.Calculator]: 'Kalkulator',
+    [ContentType.Overview]: 'Oversiktsside',
+    [ContentType.GlobalCaseTimeSet]: 'Saksbehandlingstider',
+    [ContentType.PayoutDates]: 'Utbetalingsdatoer',
+    [ContentType.FrontPage]: 'Forside',
+    [ContentType.FrontPageNested]: 'Underforside',
+    [ContentType.AreaPage]: 'Områdeside',
+    [ContentType.PressLandingPage]: 'Landingsside for presse',
+    [ContentType.FormDetails]: 'Skjemadetaljer',
+    [ContentType.FormIntermediateStepPage]: 'Mellomsteg for søknad, skjema, klage og ettersendelse',
+    [ContentType.FormsOverview]: 'Skjemaoversikt',
+    [ContentType.UserTestsConfig]: 'Brukertester',
+    [ContentType.Video]: 'Qbrick Video',
+    [ContentType.AlertInContext]: 'Varsel i kontekst',
+    [ContentType.OfficePage]: 'Kontorside (gammel)',
+
+    [ContentType.Error]: `Ugyldig type: [${ContentType.Error}]`,
+    [ContentType.Site]: `Ugyldig type: [${ContentType.Site}]`,
+    [ContentType.Fragment]: `Ugyldig type: [${ContentType.Fragment}]`,
+    [ContentType.TemplatePage]: `Ugyldig type: [${ContentType.TemplatePage}]`,
+    [ContentType.Url]: `Ugyldig type: [${ContentType.Url}]`,
+    [ContentType.FallbackPage]: `Ugyldig type: [${ContentType.FallbackPage}]`,
 };
 
 export type ContentAndMediaCommonProps = {

--- a/src/types/content-props/_content-common.ts
+++ b/src/types/content-props/_content-common.ts
@@ -95,6 +95,94 @@ export enum ContentType {
     FallbackPage = 'no.nav.navno:fallback-page',
 }
 
+export const innholdsType = (type: ContentType) => {
+    switch (type) {
+        case ContentType.InternalLink:
+            return 'Intern Lenke';
+        case ContentType.ExternalLink:
+            return 'Ekstern Lenke';
+        case ContentType.SectionPage:
+            return 'Oppslagstavle';
+        case ContentType.TransportPage:
+            return 'Transportside';
+        case ContentType.DynamicPage:
+            return 'Dynamisk side';
+        case ContentType.ContentList:
+            return 'Innholdsliste';
+        case ContentType.ContactInformationPage:
+            return 'Kontaktinformasjon';
+        case ContentType.GenericPage:
+            return 'Generisk side';
+        case ContentType.PageList:
+            return 'Artikkelliste';
+        case ContentType.MainArticle:
+            return 'Artikkel';
+        case ContentType.MainArticleChapter:
+            return 'Kapittel';
+        case ContentType.Melding:
+            return 'Driftsmelding';
+        case ContentType.LargeTable:
+            return 'Ekstra stor tabell';
+        case ContentType.OfficeInformation:
+            return 'Enhetsinformasjon';
+        case ContentType.PublishingCalendar:
+            return 'Publiseringskalender';
+        case ContentType.PublishingCalendarEntry:
+            return 'Kalenderhendelse';
+        case ContentType.GlobalNumberValuesSet:
+            return 'Globale tall-verdier';
+        case ContentType.ProductPage:
+            return 'Produktside';
+        case ContentType.ProductDetails:
+            return 'Produktdetaljer';
+        case ContentType.OfficeEditorialPage:
+            return 'Kontorside for redaktørinnhold';
+        case ContentType.GuidePage:
+            return 'Slik gjør du det';
+        case ContentType.ThemedArticlePage:
+            return 'Temaartikkel';
+        case ContentType.CurrentTopicPage:
+            return 'Aktuelt';
+        case ContentType.SituationPage:
+            return 'Situasjonsside';
+        case ContentType.Pictograms:
+            return 'Piktogram';
+        case ContentType.ToolsPage:
+            return 'Verktøy-side';
+        case ContentType.Calculator:
+            return 'Kalkulator';
+        case ContentType.Overview:
+            return 'Oversiktsside';
+        case ContentType.GlobalCaseTimeSet:
+            return 'Saksbehandlingstider';
+        case ContentType.PayoutDates:
+            return 'Utbetalingsdatoer';
+        case ContentType.FrontPage:
+            return 'Forside';
+        case ContentType.FrontPageNested:
+            return 'Underforside';
+        case ContentType.AreaPage:
+            return 'Områdeside';
+        case ContentType.PressLandingPage:
+            return 'Landingsside for presse';
+        case ContentType.FormDetails:
+            return 'Skjemadetaljer';
+        case ContentType.FormIntermediateStepPage:
+            return 'Mellomsteg for søknad, skjema, klage og ettersendelse';
+        case ContentType.FormsOverview:
+            return 'Skjemaoversikt';
+        case ContentType.UserTestsConfig:
+            return 'Brukertester';
+        case ContentType.Video:
+            return 'Qbrick Video';
+        case ContentType.AlertInContext:
+            return 'Varsel i kontekst';
+        case ContentType.OfficePage:
+            return 'Kontorside (gammel)';
+    }
+    return `Ugyldig [${type}]`;
+};
+
 export type ContentAndMediaCommonProps = {
     type: ContentType | MediaType;
     _id: string;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Legger til `målgruppe` = context fra dekoratøren for alle events
- Legger til `innholdstype` = visningsnavn i CS for innholdstypen for alle events

## Testing
Har testet selv i dev
