### PR TITLE
endret url for uxsignals

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,7 +59,7 @@ const csp = async () => {
     const termerHost = 'termer.no';
     const tiTiHosts = [tingtunHost, termerHost];
 
-    const uxSignalsScriptHost = 'uxsignals-frontend.uxsignals.app.iterate.no';
+    const uxSignalsScriptHost = 'widget.uxsignals.com';
     const uxSignalsApiHost = 'api.uxsignals.com';
 
     // Filter duplicates, as some origins may be identical, depending on

--- a/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
+++ b/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const UxSignalsWidget = ({ embedCode }: Props) => {
     useEffect(() => {
         const script = document.createElement('script');
-        script.src = 'https://uxsignals-frontend.uxsignals.app.iterate.no/embed.js';
+        script.src = 'https://widget.uxsignals.com/embed.js';
         script.async = true;
         document.body.appendChild(script);
         return () => {


### PR DESCRIPTION
This pull request includes a change to the `UxSignalsWidget` component to update the source URL for the embedded script.

* [`src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx`](diffhunk://#diff-01cd8fa85af6a3d73e71f54f23fbd9da0765afb4ad1bbbbcafa0a80ed7f56281L13-R13): Updated the `script.src` URL from `https://uxsignals-frontend.uxsignals.app.iterate.no/embed.js` to `https://widget.uxsignals.com/embed.js`.