### PR TITLE
Defaulter til tom array hvis taxonomy eller area er undefined

### DIFF
--- a/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
+++ b/src/components/pages/forms-overview-page/forms-list/panel/FormsOverviewListPanel.tsx
@@ -31,8 +31,8 @@ const getFormDetailsDisplayOptions = (
 };
 
 const buildSubHeader = (
-    taxonomy: FormDetailsListItemProps['taxonomy'],
-    area: FormDetailsListItemProps['area'],
+    taxonomy: FormDetailsListItemProps['taxonomy'] = [],
+    area: FormDetailsListItemProps['area'] = [],
     language: Language
 ) => {
     const taxonomyTranslations = translator('taxonomies', language);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sider for "slik gjør du det" inneholder ikke kategorier, men skal allikevel kunne vises under skjemaoversikter.
Legger inn defaulting av array hvis en av de (eller begge) er undefined.

## Testing
Testes i dev