### PR TITLE
Fjerner varsel om manglende schedule

### DIFF
--- a/src/components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem.tsx
+++ b/src/components/_editor-only/site-info/publish-info/content-item/SiteInfoPublishInfoItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import { BodyShort, Heading } from '@navikt/ds-react';
-import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { SiteInfoContentProps } from 'components/_editor-only/site-info/types';
 import { stripXpPathPrefix } from 'utils/urls';
 import { formatDateTime } from 'utils/datetime';
@@ -46,12 +45,6 @@ export const SiteInfoPublishInfoItem = ({
                 }`}
                 {publish.to ? ` - Avpubliseres: ${formatDateTime(publish.to)}` : ''}
             </BodyShort>
-            {((isPrepublish && !publish.scheduledFrom) || (publish.to && !publish.scheduledTo)) && (
-                <BodyShort className={style.warning} size={'small'}>
-                    <ExclamationmarkTriangleFillIcon />
-                    {'Schedule for publisering mangler!'}
-                </BodyShort>
-            )}
         </div>
     );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det finnes ingen `publish.scheduledFrom `eller `publish.scheduledTo`. Mulig dette har eksistert tidligere i objektet, men jeg finner ingen referanse i dokumentasjonen nå, og det settes heller ikke i objektet når jeg sjekker. I Enonic 13 er det notert "Robustness of scheduled jobs have changed" uten noen konkrete enderinger.

Foreslår at vi fjerner den - jeg ser ingen andre måter å sjekke scheduling som ikke allerede er ivaretatt av å sjekke for `publish.from` og `publish.to`.

![schedule](https://github.com/user-attachments/assets/82685bcb-34f6-4470-b849-d194db35d5bd)

## Testing
Testes i dev