### PR TITLE
Legger til MELDEKORT_API_URL i failover-workflow

### DIFF
--- a/.github/workflows/deploy-failover.prod.yml
+++ b/.github/workflows/deploy-failover.prod.yml
@@ -20,6 +20,7 @@ jobs:
       DECORATOR_URL: https://www.nav.no/dekoratoren
       XP_ORIGIN: https://www.nav.no
       TELEMETRY_URL: https://telemetry.nav.no/collect
+      MELDEKORT_API_URL: https://meldekort-api.nav.no/meldekort/meldekort-api/api/person
       INNLOGGINGSSTATUS_URL: https://www.nav.no/person/nav-dekoratoren-api/auth
       NAVNO_SEARCH_API_URL: https://navno-search-api.nav.no/content/search-url
       FAILOVER_ORIGIN: https://www-failover.nav.no


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Legger til MELDEKORT_API_URL i failover-workflow.

## Testing
Har ingen mekanisme for å trigge denne workflowen, og bør uansett kjøres på kvelden i prod, så sjekker at den er på plass i morgen.