### PR TITLE
Endret linjeavstand i punktlister og justert gråfarge

### DIFF
--- a/src/global-override-styles.scss
+++ b/src/global-override-styles.scss
@@ -68,10 +68,8 @@
     .navds-body-long--small,
     .navds-body-long--medium,
     .navds-body-long--large {
-        &:not(li) {
-            line-height: 1.75;
-            margin-bottom: var(--a-spacing-9);
-        }
+        line-height: 1.75;
+        margin-bottom: var(--a-spacing-9);
     }
 
     .navds-heading--xsmall,
@@ -102,12 +100,6 @@
     .navds-heading--xlarge {
         font-size: var(--text-fluid-36-48);
         font-weight: 650;
-    }
-
-    h3,
-    h4,
-    h5 {
-        color: var(--a-gray-800);
     }
 
     strong {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Økt linjeavstand for tekst i punktlister.

Fjernet overstyring av lysere gråfarge for h3, h4 og h5. Fra var(--a-gray-800) til var(--a-gray-900).

## Testing

Har testet lokalt og i dev2

