### PR TITLE
Kollapse brukertest-komponent når den ikke er i bruk

### DIFF
--- a/src/components/_common/user-tests/UserTests.module.scss
+++ b/src/components/_common/user-tests/UserTests.module.scss
@@ -1,7 +1,5 @@
 .wrapper {
     width: 100%;
-    margin-top: var(--a-spacing-10);
-
     & > * {
         max-width: 600px;
         width: 100%;

--- a/src/components/_common/user-tests/editor-view/UserTestsEditorView.module.scss
+++ b/src/components/_common/user-tests/editor-view/UserTestsEditorView.module.scss
@@ -7,6 +7,7 @@
 }
 
 .header {
+    margin-top: var(--a-spacing-10);
     border: 2px black solid;
     border-left-width: 0;
     border-right-width: 0;

--- a/src/components/_common/user-tests/variants/UserTestVariant.module.scss
+++ b/src/components/_common/user-tests/variants/UserTestVariant.module.scss
@@ -1,6 +1,7 @@
 @use 'common' as common;
 
 .testVariant {
+    margin-top: var(--a-spacing-10);
     padding: var(--a-spacing-6);
     background-color: var(--a-orange-100);
     border-radius: common.$border-radius-xlarge;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Flyttet margins-top for å unngå margins når brukertesten ikke er aktiv