### PR TITLE
Fikser feil i kopiering av env-fil ved kjøring av dev-custom

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "start": "npm run start --workspace packages/server",
         "start-in-docker": "node -r dotenv/config server/.dist/server.cjs dotenv_config_path=./.env",
         "storybook": "npm run storybook --workspace packages/nextjs",
-        "dev": "npm run copy-env-development && npm run build:server && npm run start",
-        "dev-custom": "npm run copy-env-development && npm start",
+        "dev": "npm run copy-env-development && npm run build && npm run start",
+        "dev-custom": "npm run copy-env-development-custom && npm run build && npm run start",
         "dev-server": "npm run copy-env-prod-local && npm run dev --workspace packages/server",
         "build-local": "npm run copy-env-prod-local && npm run build",
         "start-local": "npm run copy-env-prod-local && npm run start",
@@ -28,7 +28,8 @@
         "test:server": "npm run test --workspace packages/server",
         "prepare": "husky || true",
         "copy-env-prod-local": "cp packages/nextjs/.env.prod-local packages/nextjs/.env",
-        "copy-env-development": "cp packages/nextjs/.env.development packages/nextjs/.env"
+        "copy-env-development": "cp packages/nextjs/.env.development packages/nextjs/.env",
+        "copy-env-development-custom": "cp packages/nextjs/.env.development.local packages/nextjs/.env"
     },
     "workspaces": [
         "packages/*"


### PR DESCRIPTION
## Oppsummering av hva som er gjort
dev-custom brukes for å kunne ha sin egen env-fil. Denne sluttet å fungere etter endringene vi gjorde i ryddingen. I tillegg må applikasjonen bygges også når man kjører i dev nå. Det tar litt lenger tid å spinne opp lokalt nå, men det er snakk om 15-20 sek og det er jo ikke noe man vanligvis gjør flere ganger om dagen.

