### PR TITLE
Fikser feil i LayoutContainer

### DIFF
--- a/packages/nextjs/src/components/layouts/LayoutContainer.tsx
+++ b/packages/nextjs/src/components/layouts/LayoutContainer.tsx
@@ -26,6 +26,7 @@ export const LayoutContainer = ({
     const { layoutConfig } = useLayoutConfig();
 
     const { descriptor, type, config = {} } = layoutProps;
+    const { pageProps, ...filteredDivElementProps } = divElementProps;
     const layoutName = descriptor.split(':')[1];
     const commonLayoutStyle = getCommonLayoutStyle(config);
     const paddingConfig = config.paddingSides?._selected;
@@ -34,7 +35,7 @@ export const LayoutContainer = ({
 
     return (
         <div
-            {...divElementProps}
+            {...filteredDivElementProps}
             {...layoutConfig.editorProps}
             className={classNames(
                 style.layout,

--- a/packages/nextjs/src/components/layouts/LayoutContainer.tsx
+++ b/packages/nextjs/src/components/layouts/LayoutContainer.tsx
@@ -20,13 +20,14 @@ export const LayoutContainer = ({
     layoutProps,
     layoutStyle,
     children,
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+    pageProps,
     ...divElementProps
 }: Props) => {
     const { editorView } = usePageContentProps();
     const { layoutConfig } = useLayoutConfig();
 
     const { descriptor, type, config = {} } = layoutProps;
-    const { pageProps: _pageProps, ...filteredDivElementProps } = divElementProps;
     const layoutName = descriptor.split(':')[1];
     const commonLayoutStyle = getCommonLayoutStyle(config);
     const paddingConfig = config.paddingSides?._selected;
@@ -35,7 +36,7 @@ export const LayoutContainer = ({
 
     return (
         <div
-            {...filteredDivElementProps}
+            {...divElementProps}
             {...layoutConfig.editorProps}
             className={classNames(
                 style.layout,

--- a/packages/nextjs/src/components/layouts/LayoutContainer.tsx
+++ b/packages/nextjs/src/components/layouts/LayoutContainer.tsx
@@ -26,7 +26,7 @@ export const LayoutContainer = ({
     const { layoutConfig } = useLayoutConfig();
 
     const { descriptor, type, config = {} } = layoutProps;
-    const { pageProps, ...filteredDivElementProps } = divElementProps;
+    const { pageProps: _pageProps, ...filteredDivElementProps } = divElementProps;
     const layoutName = descriptor.split(':')[1];
     const commonLayoutStyle = getCommonLayoutStyle(config);
     const paddingConfig = config.paddingSides?._selected;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Fjerner pageprops="[object Object]" i LayoutContainer

## Testing

Har testet i q6

![ContainerLayout](https://github.com/user-attachments/assets/e76818f1-cea3-45e9-ad65-b75f3204e9f8)
