### PR TITLE
Disable ux signals når samtykke ikke er gitt

### DIFF
--- a/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
+++ b/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
@@ -1,22 +1,69 @@
 import React, { useEffect } from 'react';
 import { EditorHelp } from 'components/_editor-only/editor-help/EditorHelp';
+import { getCurrentConsent } from '@navikt/nav-dekoratoren-moduler';
 
 import style from './UxSignalsWidget.module.scss';
 
-type Props = {
+type UxSignalsWidgetProps = {
     embedCode: string;
 };
 
-export const UxSignalsWidget = ({ embedCode }: Props) => {
-    useEffect(() => {
+type Consent = {
+    consent: {
+        analytics: boolean;
+        surveys: boolean;
+    };
+    userActionTaken: boolean;
+};
+
+const uxSignalsScriptUrl = 'https://widget.uxsignals.com/embed.js';
+
+export const UxSignalsWidget = ({ embedCode }: UxSignalsWidgetProps) => {
+    // If the cookie banner is visible, the user has not taken any action yet.
+    // Wait and see if the user takes action before adding the script if consent is given..
+    const checkConsentOrWait = ({ consent, userActionTaken }: Consent) => {
+        if (consent.surveys && consent.analytics) {
+            addUXSignalsScript();
+            return;
+        }
+        if (!userActionTaken) {
+            setTimeout(() => {
+                console.log('waiting...');
+                checkConsentOrWait(getCurrentConsent());
+            }, 1000);
+        }
+
+        console.log('no consent or user action taken');
+    };
+
+    const addUXSignalsScript = () => {
+        if (document.querySelector(`script[src="${uxSignalsScriptUrl}"]`)) {
+            return;
+        }
+
+        console.log('adding script');
+
         const script = document.createElement('script');
-        script.src = 'https://widget.uxsignals.com/embed.js';
+        script.src = uxSignalsScriptUrl;
         script.async = true;
         document.body.appendChild(script);
-        return () => {
+    };
+
+    const removeUXSignalsScript = () => {
+        console.log('removing script');
+        const script = document.querySelector(`script[src="${uxSignalsScriptUrl}"]`);
+        if (script) {
             document.body.removeChild(script);
+        }
+    };
+
+    useEffect(() => {
+        const consent = getCurrentConsent();
+        checkConsentOrWait(consent);
+        return () => {
+            removeUXSignalsScript();
         };
-    });
+    }, []);
 
     return (
         <>

--- a/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
+++ b/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
@@ -28,12 +28,12 @@ export const UxSignalsWidget = ({ embedCode }: UxSignalsWidgetProps) => {
             addUXSignalsScript();
             return;
         }
-        // Wait max 20 seconds for user respond to the cookie banner
+        // Wait max 60 seconds for user respond to the cookie banner
         // (userActionTaken) or give up.
-        if (!userActionTaken && tries < 20) {
+        if (!userActionTaken && tries < 60) {
             scriptAddTimeout = setTimeout(() => {
                 checkConsentOrWait(tries + 1);
-            }, 3000);
+            }, 1000);
         }
     };
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Widget for UX Signals laster inn et script (som også slettes når komponenten fjernes fra treet). Denne bør sjekke om samtykke er gitt. Det ble litt mer logikk for å få til dette, men oppsummert:

1. Koden sjekker om samtykke er gitt.
2. Hvis bruker ikke har tatt noe valg (dvs cookiebanner fortsatt vises), sjekk samtykke hvert sekund i 60 sekunder. Det gjør at UX Signals-widget kan sette  i gang når bruker har gitt samtykke.

## Testing
Testet i dev

## Dette trenger jeg å få et ekstra blikk på
Jeg lurer på om koden ble litt kronglete med hensyn til lesbarhet, så ta en titt på om den er lesbar nok eller om jeg burde kikke på en bedre løsning.