### PR TITLE
Legger til manglende mellomrom i CSS-verdi

### DIFF
--- a/packages/nextjs/src/components/layouts/LayoutContainer.module.scss
+++ b/packages/nextjs/src/components/layouts/LayoutContainer.module.scss
@@ -9,7 +9,7 @@
     .standard {
         padding-left: common.$padding-sides-mobile;
         padding-right: common.$padding-sides-mobile;
-        margin: $vertical-margin-default - #{common.$padding-sides-mobile};
+        margin: $vertical-margin-default -#{common.$padding-sides-mobile};
 
         @media #{common.$mq-screen-tablet} {
             padding-left: common.$padding-sides-tablet;


### PR DESCRIPTION
Før endring var kompilert kode slik: `margin:1rem-0.5rem`.
Etter endring er kompilert kode slik: `margin:1rem -0.5rem`.

Har ikke funnet ut hvor `.LayoutContainer_layout .LayoutContainer_standard` er i bruk, så testing trenger jeg hjelp med.