### PR TITLE
Sikrer mer robust failoverbygg

### DIFF
--- a/packages/nextjs/src/pages/[...pathRouter].tsx
+++ b/packages/nextjs/src/pages/[...pathRouter].tsx
@@ -12,16 +12,23 @@ import { fetchPrerenderPaths } from 'utils/fetch/fetch-prerender-paths';
 const isFailover = process.env.IS_FAILOVER_INSTANCE === 'true';
 
 const getStaticPropsFailover: GetStaticProps = async (context) => {
-    const pageProps = await fetchPageProps({
-        routerQuery: context?.params?.pathRouter,
-        noRedirect: true,
-    });
+    try {
+        const pageProps = await fetchPageProps({
+            routerQuery: context?.params?.pathRouter,
+            noRedirect: true,
+        });
 
-    if (isPropsWithContent(pageProps.props)) {
-        pageProps.props.content.isFailover = true;
+        if (isPropsWithContent(pageProps.props)) {
+            pageProps.props.content.isFailover = true;
+        }
+
+        return pageProps;
+    } catch (error) {
+        logger.error('Error fetching page props in failover mode:', error);
+        return {
+            notFound: true,
+        };
     }
-
-    return pageProps;
 };
 
 const getStaticPathsFailover = async () => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Legger inn en try catch for håndtering av feilede props. Foreslår at vi tar denne ut først og så kan vi kikke på mekanismer for varsling eller rapportering i Slack-kanal når det er issues med failover.

## Testing
Testet i dev