### PR TITLE
fjern overflødig side-avstand på noen sidetyper, på mobil

### DIFF
--- a/packages/nextjs/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
+++ b/packages/nextjs/src/components/layouts/page-with-side-menus/PageWithSideMenus.module.scss
@@ -8,8 +8,6 @@
 
     @media #{common.$mq-screen-mobile} {
         display: block;
-        margin: 0rem 0.5rem;
-        width: calc(100% - 1rem);
     }
 
     :global(.region__intro) {

--- a/packages/nextjs/src/components/pages/current-topic-page/CurrentTopicPage.module.scss
+++ b/packages/nextjs/src/components/pages/current-topic-page/CurrentTopicPage.module.scss
@@ -7,11 +7,6 @@ $margin: 2rem;
     flex-direction: column;
     padding-top: 2rem;
     padding-bottom: 3rem;
-
-    @media #{common.$mq-screen-mobile} {
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
 }
 
 .contentAligner {

--- a/packages/nextjs/src/components/pages/situation-page/SituationPage.module.scss
+++ b/packages/nextjs/src/components/pages/situation-page/SituationPage.module.scss
@@ -4,12 +4,6 @@
     display: flex;
     flex-direction: column;
 
-    @media #{common.$mq-screen-mobile} {
-        display: block;
-        margin: 0rem 0.5rem;
-        width: calc(100% - 1rem);
-    }
-
     :global(.region__pageContent) {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Eksempler:

https://www.nav.no/aap
https://www.nav.no/alene-med-barn
https://www.nav.no/brukerundersokelser

Før:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/9310e2cd-b278-42e3-8727-1201c2dc6bf7" />

Etter:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/c4c83e85-ccf7-4df8-9eb5-0571740c3dae" />

Før:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/d2660de0-c164-4356-9f0f-1eb3a88aa419" />

Etter:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/e688689e-1f17-4eb6-a50c-51337d3acad3" />
