### PR TITLE
Bruker tofixed for floating point precision error

### DIFF
--- a/packages/nextjs/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
+++ b/packages/nextjs/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
@@ -68,7 +68,7 @@ export const evaluateExpression = (
         const expressionWithDotSeparators = expressionSubstituted.replace(',', '.');
 
         const parsedExpression = jsep(expressionWithDotSeparators);
-        const result = evaluateExpressionJSEP(parsedExpression);
+        const result = Number(evaluateExpressionJSEP(parsedExpression).toFixed(1));
         return formatNumber({
             num: result,
             minDecimals: decimals,

--- a/packages/nextjs/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
+++ b/packages/nextjs/src/components/macros/global-value-with-math/MacroGlobalValueWithMath.tsx
@@ -68,7 +68,7 @@ export const evaluateExpression = (
         const expressionWithDotSeparators = expressionSubstituted.replace(',', '.');
 
         const parsedExpression = jsep(expressionWithDotSeparators);
-        const result = Number(evaluateExpressionJSEP(parsedExpression).toFixed(1));
+        const result = Number(evaluateExpressionJSEP(parsedExpression).toFixed(3));
         return formatNumber({
             num: result,
             minDecimals: decimals,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
I enkelte tilfeller oppstår det feil i utregning ved bruk av formler. Feilen er en kjent (og gammel) javascriptfeil.

Feks:

279933 * 0,3 + 242418 * 0,7

Riktig svar:
253672,5

Pga javascript-feil (IEEE 754 floating-point rounding error) blir tallet:
253672.49999999997

Dermed blir avrunding feil.

## Testing
Testet i Q6
