### PR TITLE
Vis skjemanummer inline i Content Studio

### DIFF
--- a/packages/nextjs/src/components/_common/formDetails/FormDetails.tsx
+++ b/packages/nextjs/src/components/_common/formDetails/FormDetails.tsx
@@ -108,7 +108,7 @@ export const FormDetails = ({
                     ))}
                 </div>
             )}
-            {(hasVisibleFormNumbers || editorView === 'edit') && (
+            {(hasVisibleFormNumbers || editorView === 'inline' || editorView === 'edit') && (
                 <Detail className={style.formNumbers}>
                     {formNumbers?.map((formNumber) => (
                         <FormNumberTag


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Gjør det en enklere for redaktørene å sjekke at skjemanummerne i skjemadetaljer ser riktig ut, uten å måtte åpne i edit-mode

![image](https://github.com/user-attachments/assets/418e7b10-633f-408c-ab5d-f645dcb981f4)

