### PR TITLE
Tvinge formNumbers som array. 

### DIFF
--- a/packages/nextjs/src/components/_common/formDetails/FormDetails.tsx
+++ b/packages/nextjs/src/components/_common/formDetails/FormDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Detail, Heading } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
+import { forceArray } from 'utils/arrays';
 import { ParsedHtml } from 'components/_common/parsedHtml/ParsedHtml';
 import { FormDetailsData, Variation } from 'types/content-props/form-details';
 import { InfoBox } from 'components/_common/infoBox/InfoBox';
@@ -110,7 +111,7 @@ export const FormDetails = ({
             )}
             {(hasVisibleFormNumbers || editorView === 'inline' || editorView === 'edit') && (
                 <Detail className={style.formNumbers}>
-                    {formNumbers?.map((formNumber) => (
+                    {forceArray(formNumbers).map((formNumber) => (
                         <FormNumberTag
                             className={
                                 formNumber === formNumberToHighlight ? style.highlight : undefined


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sider med skjemadetaljer får enkelte ganger inn formNumbers som string. Det er en underliggende feil et sted, så dette er en nødfiks akkurat nå.


## Testing
Testes i dev