### PR TITLE
la til prettier i pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,10 @@
 cd packages/nextjs
 npx eslint --max-warnings=0 '**/*.{ts,tsx}'
+npx prettier --write '**/*.{ts,tsx,css,scss}'
 cd ../server
 npx eslint --max-warnings=0 '**/*.{ts,tsx}'
+npx prettier --write '**/*.{ts,tsx,css,scss}'
 cd ../shared
 npx eslint --max-warnings=0 '**/*.{ts,tsx}'
+npx prettier --write '**/*.{ts,tsx,css,scss}'
 cd ../../

--- a/packages/nextjs/.eslintrc.json
+++ b/packages/nextjs/.eslintrc.json
@@ -10,7 +10,8 @@
         "next/core-web-vitals",
         "plugin:css-modules/recommended",
         "plugin:storybook/recommended",
-        "../../.eslintrc.json"
+        "../../.eslintrc.json",
+        "prettier"
     ],
     "ignorePatterns": ["next.config.js"],
     "root": true,

--- a/packages/nextjs/src/components/_common/contact-option/CallOption/CallOption.tsx
+++ b/packages/nextjs/src/components/_common/contact-option/CallOption/CallOption.tsx
@@ -107,7 +107,7 @@ export const CallOption = ({
                         <BodyShort as="span">{sharedTranslations.seeMoreOptions}</BodyShort>
                     </LenkeBase>
                 )}
-                </div>
+            </div>
         </div>
     );
 };

--- a/packages/nextjs/src/components/_common/headers/Header.module.scss
+++ b/packages/nextjs/src/components/_common/headers/Header.module.scss
@@ -1,5 +1,5 @@
 .header {
-  scroll-margin-top: 2.5lh;
+    scroll-margin-top: 2.5lh;
 }
 
 .anchorLink {

--- a/packages/nextjs/src/components/_common/headers/Heading.tsx
+++ b/packages/nextjs/src/components/_common/headers/Heading.tsx
@@ -18,8 +18,13 @@ export const Heading = ({ children, size, level, anchorId, className }: Props) =
     const anchor = anchorId ? (anchorId.startsWith('#') ? anchorId : `#${anchorId}`) : undefined;
     const fallbackSizeByLevel = levelToSize[level] || 'large';
 
-    return (        
-        <DsHeading id={anchorId} size={size || fallbackSizeByLevel} level={level} className={classNames(style.header, className)}>
+    return (
+        <DsHeading
+            id={anchorId}
+            size={size || fallbackSizeByLevel}
+            level={level}
+            className={classNames(style.header, className)}
+        >
             {anchor && (level === '2' || level === '3') ? (
                 <a href={anchor} className={style.anchorLink}>
                     {children}

--- a/packages/nextjs/src/components/_common/moreLink/MoreLink.tsx
+++ b/packages/nextjs/src/components/_common/moreLink/MoreLink.tsx
@@ -10,7 +10,7 @@ type Props = {
     analyticsGroup?: string;
 };
 
-export const MoreLink = ( props: Props) => {
+export const MoreLink = (props: Props) => {
     if (!props.link) {
         return null;
     }

--- a/packages/nextjs/src/components/_common/parsedHtml/ParsedHtml.tsx
+++ b/packages/nextjs/src/components/_common/parsedHtml/ParsedHtml.tsx
@@ -75,7 +75,7 @@ const getNonEmptyChildren = ({ children }: Element): Element['children'] => {
 
 type Props = {
     htmlProps: ProcessedHtmlProps | string;
-    pSize?: 'large' | 'small'
+    pSize?: 'large' | 'small';
 };
 
 export const ParsedHtml = ({ htmlProps, pSize }: Props) => {

--- a/packages/nextjs/src/components/_common/press-landing/PressNewsItem.tsx
+++ b/packages/nextjs/src/components/_common/press-landing/PressNewsItem.tsx
@@ -48,7 +48,9 @@ export const PressNewsItem = ({ newsItem }: Props) => {
                     </LenkeBase>
                 </Heading>
                 {newsItem.data?.ingress && (
-                    <div className={style.ingress}>{shortenText(newsItem.data.ingress, 240, 30)}</div>
+                    <div className={style.ingress}>
+                        {shortenText(newsItem.data.ingress, 240, 30)}
+                    </div>
                 )}
                 <div className={style.newsTagline}>
                     {icon && <StaticImage imageData={icon} />}

--- a/packages/nextjs/src/components/parts/frontpage-person-shortcuts/FrontpagePersonShortcutsPart.tsx
+++ b/packages/nextjs/src/components/parts/frontpage-person-shortcuts/FrontpagePersonShortcutsPart.tsx
@@ -74,9 +74,7 @@ export const FrontpagePersonShortcutsPart = ({
                                     {href.includes('utbetalingsdatoer') && (
                                         <CalendarIcon title="Kalender" />
                                     )}
-                                    {href.includes('satser') && (
-                                        <WalletIcon title="Lommebok" />
-                                    )}
+                                    {href.includes('satser') && <WalletIcon title="Lommebok" />}
                                     {href.includes('soknader') && (
                                         <TasklistStartIcon title="Oppgaveliste start" />
                                     )}

--- a/packages/nextjs/src/types/component-props/layouts/section-with-header.ts
+++ b/packages/nextjs/src/types/component-props/layouts/section-with-header.ts
@@ -21,5 +21,3 @@ export interface SectionWithHeaderProps extends LayoutBaseProps {
     } & Partial<HeaderWithAnchorMixin> &
         Pick<LayoutCommonConfigMixin, 'bgColor'>;
 }
-
-

--- a/packages/nextjs/src/types/component-props/pages/single-col-page.ts
+++ b/packages/nextjs/src/types/component-props/pages/single-col-page.ts
@@ -14,4 +14,3 @@ export interface SingleColPageProps extends LayoutBaseProps {
     };
     config: {};
 }
-

--- a/packages/server/.eslintrc.json
+++ b/packages/server/.eslintrc.json
@@ -7,7 +7,8 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:prettier/recommended",
-        "../../.eslintrc.json"
+        "../../.eslintrc.json",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/packages/shared/.eslintrc.json
+++ b/packages/shared/.eslintrc.json
@@ -7,7 +7,8 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:prettier/recommended",
-        "../../.eslintrc.json"
+        "../../.eslintrc.json",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {


### PR DESCRIPTION
This pull request introduces several changes aimed at improving code formatting consistency, enhancing readability, and ensuring adherence to style guidelines. The key updates include integrating Prettier into the development workflow, improving ESLint configurations, and refining code formatting across various files.

### Development Workflow Enhancements:
* Added Prettier commands to the `.husky/pre-commit` hook to automatically format `ts`, `tsx`, `css`, and `scss` files before committing.

### ESLint Configuration Updates:
* Updated `packages/nextjs/.eslintrc.json` to include the Prettier plugin for enforcing consistent code style.
* Updated `packages/server/.eslintrc.json` and `packages/shared/.eslintrc.json` to include the Prettier plugin alongside existing configurations. [[1]](diffhunk://#diff-c83d3d4d3b7d7499e9e67dbde8d1b578259e2bfff0e067bc476862d12b22f775L10-R11) [[2]](diffhunk://#diff-a28c14b1725822b130ede042aaa800d8c0d93a7d4b9076010361c217b32e29b6L10-R11)