### PR TITLE
Sorterte listen også etter søk

### DIFF
--- a/packages/nextjs/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/packages/nextjs/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -60,7 +60,10 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
                       ],
                   },
         }).then((result) => {
-            setFilteredList(result);
+            const sorted = [...result].sort((a, b) =>
+                a.sortTitle.localeCompare(b.sortTitle, 'nb', { sensitivity: 'base' })
+            );
+            setFilteredList(sorted);
         });
     }, [getFilteredList, formDetailsList, formNumberFromSearch]);
 


### PR DESCRIPTION
Sorterer nå alfabetisk også etter at søket/filtreringen er gjennomført

Før:
![image](https://github.com/user-attachments/assets/7e389690-08bc-4ac9-9bb9-96e3725b33f4)

Etter:
![image](https://github.com/user-attachments/assets/2f0f9471-5d6a-4501-ae34-788f18a91bbd)
