### PR TITLE
Fjernet tekststørrelse og linjeavstand fra appContainer og fjernet styling filer fra eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,5 +32,10 @@
                 }
             }
         }
-    ]
+    ],
+    "parserOptions": {
+        "ecmaFeatures": {
+            "legacyDecorators": true
+        }
+    }
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -14,9 +14,11 @@
         "test": "TZ=Europe/Oslo jest --testPathIgnorePatterns=server/src"
     },
     "lint-staged": {
-        "*.{ts,tsx,css,scss}": [
-            "prettier --write",
+        "*.{ts,tsx}": [
             "eslint --max-warnings=0"
+        ],
+        "*.{ts,tsx,css,scss}": [
+            "prettier --write"
         ]
     },
     "dependenciesComments": {

--- a/packages/nextjs/src/components/PageWrapper.module.scss
+++ b/packages/nextjs/src/components/PageWrapper.module.scss
@@ -4,8 +4,6 @@
     max-width: common.$desktopMaxWidth;
     min-height: 22.5rem;
     margin: 0 auto;
-    font-size: var(--a-font-size-large);
-    line-height: var(--a-font-line-height-xlarge);
 
     @media #{common.$mq-screen-mobile} {
         padding: 0 common.$padding-sides-mobile 0 common.$padding-sides-mobile;


### PR DESCRIPTION
This pull request introduces updates to configuration files and styles, focusing on improving linting rules, enabling legacy decorators, and refining the styling of a component. Below is a summary of the most important changes.

### Configuration Updates:

* [`.eslintrc.json`](diffhunk://#diff-6884918dc8291219be508e05e28965b958c734def85324f3b53858ea4702090fL35-R40): Added `parserOptions` to enable support for legacy decorators by setting `ecmaFeatures.legacyDecorators` to `true`.
* [`packages/nextjs/package.json`](diffhunk://#diff-e5237f683dda3354b835c7c7c94b9759db2c743d4ba94d47d7f8b8e0b2bfb442L17-R21): Adjusted `lint-staged` rules to separate `eslint` and `prettier` commands for TypeScript files, ensuring `eslint` runs with `--max-warnings=0`.

### Styling Refinements:

* [`packages/nextjs/src/components/PageWrapper.module.scss`](diffhunk://#diff-1dc6f0613c4a761215febeb15bc774a8189229e4e9e9a8c811c2da20056b7c5dL7-L8): Removed large font size and line height variables, simplifying the styling of the `PageWrapper` component.