### PR TITLE
Opprydding: Setter Props med Children til PropsWithChildren

### DIFF
--- a/packages/nextjs/src/components/PageWrapper.tsx
+++ b/packages/nextjs/src/components/PageWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { useRouter } from 'next/compat/router';
 import { onBreadcrumbClick, onLanguageSelect, setParams } from '@navikt/nav-dekoratoren-moduler';
 import { ContentProps } from 'types/content-props/_content-common';
@@ -20,16 +20,12 @@ import { PageWarnings } from './_page-warnings/PageWarnings';
 
 import styles from './PageWrapper.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     content: ContentProps;
-    children: React.ReactNode;
-};
+}>;
 
-export const PageWrapper = (props: Props) => {
-    const { content, children } = props;
-
+export const PageWrapper = ({ content, children }: Props) => {
     const isEditorView = !!content.editorView;
-
     const router = useRouter();
 
     useEffect(() => {
@@ -48,7 +44,7 @@ export const PageWrapper = (props: Props) => {
             });
         }
 
-        if (!router) {
+        if (!router || isEditorView) {
             return;
         }
 
@@ -58,10 +54,6 @@ export const PageWrapper = (props: Props) => {
         onLanguageSelect((language) =>
             router.push(getInternalRelativePath(language.url as string, isEditorView))
         );
-
-        if (isEditorView) {
-            return;
-        }
 
         const linkInterceptor = hookAndInterceptInternalLink(router, isEditorView);
         const linkPrefetcher = prefetchOnMouseover(router);

--- a/packages/nextjs/src/components/_common/alertBox/AlertBox.tsx
+++ b/packages/nextjs/src/components/_common/alertBox/AlertBox.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Alert, AlertProps } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import style from './AlertBox.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     variant: AlertProps['variant'];
     size?: AlertProps['size'];
     inline?: AlertProps['inline'];
     className?: string;
-    children: React.ReactNode;
-} & React.HTMLAttributes<HTMLDivElement>;
+}> &
+    React.HTMLAttributes<HTMLDivElement>;
 
 const role = {
     success: 'status',

--- a/packages/nextjs/src/components/_common/authDependantRender/AuthDependantRender.tsx
+++ b/packages/nextjs/src/components/_common/authDependantRender/AuthDependantRender.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { useAuthState } from 'store/hooks/useAuthState';
 import { AuthStateType } from 'store/slices/authState';
 import { usePageContentProps } from 'store/pageContext';
 import { useLayoutEffectClientSide } from 'utils/react';
 
-type Props = {
+type Props = PropsWithChildren<{
     renderOn: AuthStateType | 'always';
-    children: React.ReactNode;
-};
+}>;
 
 export const AuthDependantRender = ({ children, renderOn = 'always' }: Props) => {
     const { editorView } = usePageContentProps();

--- a/packages/nextjs/src/components/_common/button/Button.tsx
+++ b/packages/nextjs/src/components/_common/button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Button as DsButton, ButtonProps } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
@@ -13,7 +13,7 @@ import { getDecoratorParams } from 'utils/decorator-utils';
 import { useLayoutConfig } from 'components/layouts/useLayoutConfig';
 import style from './Button.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     href?: string;
     variant?: ButtonProps['variant'];
     size?: ButtonProps['size'];
@@ -25,13 +25,12 @@ type Props = {
     prefetch?: boolean;
     onClick?: (e: React.MouseEvent) => void;
     className?: string;
-    children: React.ReactNode;
     analyticsEvent?: AnalyticsEvents;
     analyticsComponent?: string;
     analyticsLabel?: string;
     lenkestyling?: boolean;
     typeButton?: boolean;
-};
+}>;
 
 export const Button = ({
     href,

--- a/packages/nextjs/src/components/_common/contact-option/_shared-utils/ContactOptionLayout/ContactOptionLayout.tsx
+++ b/packages/nextjs/src/components/_common/contact-option/_shared-utils/ContactOptionLayout/ContactOptionLayout.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import style from './ContactOptionLayout.module.scss';
 
-interface Props {
+type Props = PropsWithChildren<{
     icon: React.ReactNode;
-    children: React.ReactNode;
-}
+}>;
 
 export const ContactOptionLayout = ({ icon, children }: Props) => {
     return (

--- a/packages/nextjs/src/components/_common/contact-option/_shared-utils/ContactOptionLenkebase/ContactOptionLenkebase.tsx
+++ b/packages/nextjs/src/components/_common/contact-option/_shared-utils/ContactOptionLenkebase/ContactOptionLenkebase.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
 import { AnalyticsEvents } from 'utils/analytics';
 import style from './ContactOptionLenkebase.module.scss';
 
-interface Props {
+type Props = PropsWithChildren<{
     href: string;
     analyticsLinkGroup?: string;
     analyticsComponent?: string;
     analyticsEvent?: AnalyticsEvents;
-    children: React.ReactNode;
-}
+}>;
 
 export const ContactOptionLenkebase = ({
     href,

--- a/packages/nextjs/src/components/_common/expandable/Expandable.tsx
+++ b/packages/nextjs/src/components/_common/expandable/Expandable.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { PropsWithChildren, useRef, useState } from 'react';
 import { ExpansionCard } from '@navikt/ds-react';
 import { BarChartIcon, BriefcaseClockIcon, CalendarIcon, TasklistIcon } from '@navikt/aksel-icons';
 import { AnalyticsEvents, logAnalyticsEvent } from 'utils/analytics';
@@ -12,16 +12,15 @@ import { ProductDetailType } from 'types/content-props/product-details';
 import { useCheckAndOpenPanel } from 'store/hooks/useCheckAndOpenPanel';
 import style from './Expandable.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     title: string;
     anchorId?: string;
     analyticsOriginTag?: string;
     className?: string;
-    children: React.ReactNode;
     expandableType?: ProductDetailType | 'documentation_requirements';
     ariaLabel?: string;
     isOpenDefault?: boolean;
-};
+}>;
 
 export const Expandable = ({
     title,

--- a/packages/nextjs/src/components/_common/filtered-content/FilteredContent.tsx
+++ b/packages/nextjs/src/components/_common/filtered-content/FilteredContent.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { FilterSelection } from 'types/component-props/_mixins';
 import { useFilterState } from 'store/hooks/useFilteredContent';
 
-type Props = {
+type Props = PropsWithChildren<{
     filters?: string[];
-    children: React.ReactNode;
-};
+}>;
 
 const checkForFilterMatch = (filters: string[], selectedFilters: FilterSelection) =>
     filters.some((filter) => selectedFilters.includes(filter));

--- a/packages/nextjs/src/components/_common/headers/Heading.tsx
+++ b/packages/nextjs/src/components/_common/headers/Heading.tsx
@@ -2,8 +2,6 @@ import React, { PropsWithChildren } from 'react';
 import { Heading as DsHeading } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { Level, levelToSize, Size } from 'types/typo-style';
-
-// eslint-disable-next-line css-modules/no-unused-class
 import style from './Header.module.scss';
 
 type Props = PropsWithChildren<{

--- a/packages/nextjs/src/components/_common/headers/Heading.tsx
+++ b/packages/nextjs/src/components/_common/headers/Heading.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Heading as DsHeading } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { Level, levelToSize, Size } from 'types/typo-style';
@@ -6,13 +6,12 @@ import { Level, levelToSize, Size } from 'types/typo-style';
 // eslint-disable-next-line css-modules/no-unused-class
 import style from './Header.module.scss';
 
-type Props = {
-    children: React.ReactNode;
+type Props = PropsWithChildren<{
     level: Level;
     size?: Size;
     anchorId?: string;
     className?: string;
-};
+}>;
 
 export const Heading = ({ children, size, level, anchorId, className }: Props) => {
     const anchor = anchorId ? (anchorId.startsWith('#') ? anchorId : `#${anchorId}`) : undefined;

--- a/packages/nextjs/src/components/_common/headers/generalPageHeader/GeneralPageHeaderTagLine.tsx
+++ b/packages/nextjs/src/components/_common/headers/generalPageHeader/GeneralPageHeaderTagLine.tsx
@@ -15,7 +15,7 @@ function isValidAudience(value: string): value is Audience {
     return (Object.values(Audience) as string[]).includes(value);
 }
 
-export const GeneralPageHeaderTagLine = (props: Props) => {
+export const GeneralPageHeaderTagLine = ({ tagLine }: Props) => {
     const { data, language } = usePageContentProps<ProductPageProps>();
 
     const getAudienceLabel = translator('audience', language);
@@ -57,11 +57,11 @@ export const GeneralPageHeaderTagLine = (props: Props) => {
     };
 
     const audienceAffirmation = buildAudienceAffirmation();
-    const showLine = props.tagLine && audienceAffirmation;
+    const showLine = tagLine && audienceAffirmation;
 
     return (
         <BodyShort className={style.tagline} size="small">
-            {props.tagLine}
+            {tagLine}
             {showLine && `  —  `}
             {audienceAffirmation}
         </BodyShort>

--- a/packages/nextjs/src/components/_common/infoBox/InfoBox.tsx
+++ b/packages/nextjs/src/components/_common/infoBox/InfoBox.tsx
@@ -1,11 +1,8 @@
+import { PropsWithChildren } from 'react';
 import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import styles from './InfoBox.module.scss';
 
-type InfoBoxProps = {
-    children: React.ReactNode;
-};
-
-export const InfoBox = ({ children }: InfoBoxProps) => {
+export const InfoBox = ({ children }: PropsWithChildren) => {
     return (
         <AlertBox variant="info" size="small" inline={true} className={styles.infoBox}>
             {children}

--- a/packages/nextjs/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
+++ b/packages/nextjs/src/components/_common/lenke/lenkeBase/LenkeBase.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, PropsWithChildren } from 'react';
 import Link from 'next/link';
 import { adminOrigin, isNofollowUrl, xpDraftPathPrefix } from 'utils/urls';
 import { AnalyticsEvents, logAnalyticsEvent } from 'utils/analytics';
@@ -25,7 +25,7 @@ const BadLinkWarning = ({ children }: { children: React.ReactNode }) => (
  * This is necessary as there are many other apps sharing the nav.no domain, and attempting async navigation to other
  * apps may result in errors
  **/
-type Props = {
+type Props = PropsWithChildren<{
     href: string;
     shallow?: boolean;
     prefetch?: boolean;
@@ -33,8 +33,8 @@ type Props = {
     analyticsComponent?: string;
     analyticsLinkGroup?: string;
     analyticsLabel?: string;
-    children: React.ReactNode;
-} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+}> &
+    React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const LenkeBase = ({
     href,

--- a/packages/nextjs/src/components/_common/lenke/lenkeStandalone/LenkeStandalone.tsx
+++ b/packages/nextjs/src/components/_common/lenke/lenkeStandalone/LenkeStandalone.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { BodyLong, BodyShort } from '@navikt/ds-react';
 import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { classNames } from 'utils/classnames';
@@ -7,7 +7,7 @@ import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
 
 import style from './LenkeStandalone.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     href: string;
     label?: string;
     className?: string;
@@ -17,8 +17,8 @@ type Props = {
     withChevron?: boolean;
     withArrow?: boolean;
     analyticsLabel?: string;
-    children: React.ReactNode;
-} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+}> &
+    React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const LenkeStandalone = ({
     href,

--- a/packages/nextjs/src/components/_common/lenkepanel-legacy/LenkepanelNavNo.tsx
+++ b/packages/nextjs/src/components/_common/lenkepanel-legacy/LenkepanelNavNo.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { Heading, LinkPanel } from '@navikt/ds-react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
 import style from './LenkepanelNavNo.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     href: string;
     tittel: string;
     ikon?: React.ReactNode;
@@ -13,8 +13,8 @@ type Props = {
     component?: string;
     linkGroup?: string;
     className?: string;
-    children?: React.ReactNode;
-} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+}> &
+    React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const LenkepanelNavNo = ({
     href,

--- a/packages/nextjs/src/components/_common/linkpanel/LinkPanelNavno/LinkPanelNavno.tsx
+++ b/packages/nextjs/src/components/_common/linkpanel/LinkPanelNavno/LinkPanelNavno.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
 import { Button } from 'components/_common/button/Button';
 import styles from './LinkPanelNavno.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     href: string;
     linkText: string;
     linkColor?: 'blue' | 'black';
     analyticsLinkGroup?: string;
-    children?: React.ReactNode;
     onClickEvent?: (e: any) => void;
-} & React.HTMLAttributes<HTMLAnchorElement>;
+}> &
+    React.HTMLAttributes<HTMLAnchorElement>;
 
 export const LinkPanelNavno = ({
     href,

--- a/packages/nextjs/src/components/_common/linkpanel/LinkPanelNavnoSimple/LinkPanelNavnoSimple.tsx
+++ b/packages/nextjs/src/components/_common/linkpanel/LinkPanelNavnoSimple/LinkPanelNavnoSimple.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { classNames } from 'utils/classnames';
 import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
 
 import style from './LinkPanelNavnoSimple.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     href: string;
     analyticsLinkGroup?: string;
     icon?: React.ReactNode;
-    children: React.ReactNode;
-} & React.ComponentProps<typeof LenkeBase>;
+}> &
+    React.ComponentProps<typeof LenkeBase>;
 
 // This component is meant to be used with "simple" content, ie just a line of text
 // and an optional icon. Use <LinkPanelNavno>-component for panels with more complex

--- a/packages/nextjs/src/components/_common/metatags/HeadWithMetatags.tsx
+++ b/packages/nextjs/src/components/_common/metatags/HeadWithMetatags.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import Head from 'next/head';
 import { ContentProps, ContentType } from 'types/content-props/_content-common';
 import { appOrigin, getPublicPathname } from 'utils/urls';
 import { trimIfString } from 'utils/string';
 
-type Props = {
+type Props = PropsWithChildren<{
     content: ContentProps;
-    children?: React.ReactNode;
-};
+}>;
 
 const DESCRIPTION_MAX_LENGTH = 250;
 

--- a/packages/nextjs/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
+++ b/packages/nextjs/src/components/_common/productPanelExpandable/ProductPanelExpandable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, PropsWithChildren } from 'react';
 import { BodyLong, BodyShort, ExpansionCard, Loader } from '@navikt/ds-react';
 import { PictogramsProps } from 'types/content-props/pictograms';
 import { AnalyticsEvents, logAnalyticsEvent } from 'utils/analytics';
@@ -13,7 +13,7 @@ import { classNames } from 'utils/classnames';
 
 import style from './ProductPanelExpandable.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     header: string;
     ingress?: string;
     illustration: PictogramsProps;
@@ -23,8 +23,7 @@ type Props = {
     isLoading?: boolean;
     error?: string | null;
     withCopyLink?: boolean;
-    children: React.ReactNode;
-};
+}>;
 
 export const ProductPanelExpandable = ({
     header,

--- a/packages/nextjs/src/components/_editor-only/editorLinkWrapper/EditorLinkWrapper.tsx
+++ b/packages/nextjs/src/components/_editor-only/editorLinkWrapper/EditorLinkWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { usePageContentProps } from 'store/pageContext';
 import { getRelativePathIfInternal } from 'utils/urls';
 
@@ -8,11 +8,7 @@ import { getRelativePathIfInternal } from 'utils/urls';
 // passing the relevant props to a <span> element instead.
 //
 
-type Props = {
-    children: React.ReactNode;
-};
-
-export const EditorLinkWrapper = ({ children }: Props) => {
+export const EditorLinkWrapper = ({ children }: PropsWithChildren) => {
     const { editorView } = usePageContentProps();
 
     if (editorView !== 'edit') {

--- a/packages/nextjs/src/components/_editor-only/version-history/VersionHistory.tsx
+++ b/packages/nextjs/src/components/_editor-only/version-history/VersionHistory.tsx
@@ -10,7 +10,11 @@ import { VersionSelector } from './selector/VersionSelector';
 import { VersionStatus } from './status/VersionStatus';
 import style from './VersionHistory.module.scss';
 
-export const VersionHistory = ({ content }: { content: ContentProps }) => {
+type Props = {
+    content: ContentProps;
+};
+
+export const VersionHistory = ({ content }: Props) => {
     const { timeRequested, language } = content;
 
     const [selectorIsOpen, setSelectorIsOpen] = useState(false);

--- a/packages/nextjs/src/components/_editor-only/version-history/VersionHistory.tsx
+++ b/packages/nextjs/src/components/_editor-only/version-history/VersionHistory.tsx
@@ -8,14 +8,9 @@ import { translator } from 'translations';
 import { Chevron } from 'components/_common/chevron/Chevron';
 import { VersionSelector } from './selector/VersionSelector';
 import { VersionStatus } from './status/VersionStatus';
-
 import style from './VersionHistory.module.scss';
 
-type Props = {
-    content: ContentProps;
-};
-
-export const VersionHistory = ({ content }: Props) => {
+export const VersionHistory = ({ content }: { content: ContentProps }) => {
     const { timeRequested, language } = content;
 
     const [selectorIsOpen, setSelectorIsOpen] = useState(false);

--- a/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.tsx
+++ b/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { AlertBox } from 'components/_common/alertBox/AlertBox';
 import { classNames } from 'utils/classnames';
 
 import style from './PageWarning.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     whiteBg?: boolean;
     size?: React.ComponentProps<typeof AlertBox>['size'];
-    children: React.ReactNode;
-};
+}>;
 
 export const PageWarning = ({ whiteBg, size = 'small', children }: Props) => {
     return (

--- a/packages/nextjs/src/components/layouts/LayoutContainer.tsx
+++ b/packages/nextjs/src/components/layouts/LayoutContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { ContentProps } from 'types/content-props/_content-common';
 import { LayoutComponentProps } from 'types/component-props/layouts';
 import { BEM, classNames } from 'utils/classnames';
@@ -9,12 +9,12 @@ import { useLayoutConfig } from './useLayoutConfig';
 
 import style from './LayoutContainer.module.scss';
 
-type Props = {
+type Props = PropsWithChildren<{
     pageProps: ContentProps;
     layoutProps: LayoutComponentProps;
     layoutStyle?: React.CSSProperties;
-    children: React.ReactNode;
-} & React.HTMLAttributes<HTMLDivElement>;
+}> &
+    React.HTMLAttributes<HTMLDivElement>;
 
 export const LayoutContainer = ({
     layoutProps,

--- a/packages/nextjs/src/components/pages/office-page/officeDetails/officeInformation/OfficeInformation.tsx
+++ b/packages/nextjs/src/components/pages/office-page/officeDetails/officeInformation/OfficeInformation.tsx
@@ -10,7 +10,7 @@ import { officeDetailsFormatAddress } from 'components/pages/office-page/officeD
 
 import styles from './OfficeInformation.module.scss';
 
-export interface OfficeInformationProps {
+interface OfficeInformationProps {
     officeData: OfficeDetailsData;
     initialOpen?: boolean;
 }

--- a/packages/nextjs/src/components/parts/office-editorial-detail/PlaceholderIndicator.tsx
+++ b/packages/nextjs/src/components/parts/office-editorial-detail/PlaceholderIndicator.tsx
@@ -1,9 +1,6 @@
+import { PropsWithChildren } from 'react';
 import styles from './PlaceholderIndicator.module.scss';
 
-type PlaceholderIndicatorProps = {
-    children: React.ReactNode;
-};
-
-export const PlaceholderIndicator = ({ children }: PlaceholderIndicatorProps) => {
+export const PlaceholderIndicator = ({ children }: PropsWithChildren) => {
     return <div className={styles.placeholderIndicator}>{children}</div>;
 };


### PR DESCRIPTION
This pull request introduces consistent use of the PropsWithChildren utility type across multiple components to simplify and standardize prop definitions. It also includes minor refactoring to improve readability and maintainability.

Standardization of Prop Definitions
	•	All component Props types have been updated to use PropsWithChildren for handling children, replacing explicit React.ReactNode definitions. This change affects components such as PageWrapper, AlertBox, AuthDependantRender, Button, and others.

Refactoring for Readability
	•	The GeneralPageHeaderTagLine component was simplified by destructuring the tagLine prop directly, removing repeated references to props.

These changes aim to enhance code clarity and reduce boilerplate, making the codebase easier to maintain in the future.