### PR TITLE
Retter opp kontakt-part i frontend for støtte av makro

### DIFF
--- a/packages/nextjs/src/components/_common/chatbot/ChatbotLinkPanel.tsx
+++ b/packages/nextjs/src/components/_common/chatbot/ChatbotLinkPanel.tsx
@@ -3,13 +3,14 @@ import { openChatbot } from '@navikt/nav-dekoratoren-moduler';
 import { LinkPanelNavno } from 'components/_common/linkpanel/LinkPanelNavno/LinkPanelNavno';
 import { FrontpageContactAlert } from 'components/parts/frontpage-contact/FrontpageContactAlert';
 import { ParsedHtml } from 'components/_common/parsedHtml/ParsedHtml';
+import { ProcessedHtmlProps } from 'types/processed-html-props';
 import style from './ChatbotLinkPanel.module.scss';
 
 type Props = {
     analyticsGroup: string;
     linkText: string;
     alertText?: string;
-    ingress: string;
+    ingress: string | ProcessedHtmlProps;
 };
 
 export const ChatbotLinkPanel = ({ analyticsGroup, linkText, alertText, ingress }: Props) => {

--- a/packages/nextjs/src/components/macros/MacroMapper.tsx
+++ b/packages/nextjs/src/components/macros/MacroMapper.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 // Refactor the macro types before fixing the type errors in this file
 import React from 'react';
+import { logger } from '@/shared/logger';
 import { MacroPropsCommon, MacroType } from 'types/macro-props/_macros-common';
 import { MacroProductCardMicro } from 'components/macros/product-card-micro/MacroProductCardMicro';
 import { MacroTall } from 'components/macros/tall/MacroTall';

--- a/packages/nextjs/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
+++ b/packages/nextjs/src/components/parts/frontpage-contact/FrontpageContactPart.tsx
@@ -59,18 +59,15 @@ export const FrontpageContactPart = ({ config }: PartComponentProps<PartType.Fro
         const specialOpeningHours = sharedContact?.specialOpeningHours;
 
         const chatTitle = config.chatTitle || sharedContact?.title || '';
-        const chatIngress =
-            config.chatIngress ||
-            specialOpeningHours?.overrideText ||
-            sharedContact?.ingress?.processedHtml ||
-            '';
+        const chatHtml =
+            config.chatIngress || specialOpeningHours?.overrideText || sharedContact?.ingress || '';
 
         const chatAlertText = config.chatAlertText || sharedContact?.alertText || '';
 
-        return { chatTitle, chatIngress, chatAlertText };
+        return { chatTitle, chatHtml, chatAlertText };
     };
 
-    const { chatTitle, chatIngress, chatAlertText } = getChatIngress();
+    const { chatTitle, chatHtml, chatAlertText } = getChatIngress();
 
     return (
         <section className={style.container}>
@@ -82,7 +79,7 @@ export const FrontpageContactPart = ({ config }: PartComponentProps<PartType.Fro
                     analyticsGroup={title}
                     linkText={chatTitle}
                     alertText={chatAlertText}
-                    ingress={chatIngress}
+                    ingress={chatHtml}
                 />
                 <LinkPanelNavno
                     href={contactUsUrl}


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Henter ut hele html-objektet dersom teksten henter fra sharedContact slik at makroene også kommer med.
- Manglet 'logger' i import. 

## Testing
Testet i dev