### PR TITLE
Reintroduserer typescript-plugin-css-modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7436,6 +7436,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/postcss-modules-local-by-default": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.2.tgz",
+            "integrity": "sha512-CtYCcD+L+trB3reJPny+bKWKMzPfxEyQpKIwit7kErnOexf5/faaGpkFy4I5AwbV4hp1sk7/aTg0tt0B67VkLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
+        "node_modules/@types/postcss-modules-scope": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/postcss-modules-scope/-/postcss-modules-scope-3.0.4.tgz",
+            "integrity": "sha512-//ygSisVq9kVI0sqx3UPLzWIMCmtSVrzdljtuaAEJtGoGnpjBikZ2sXO5MpH9SnWX9HRfXxHifDAXcQjupWnIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
         "node_modules/@types/qs": {
             "version": "6.9.18",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -10308,6 +10328,19 @@
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "license": "MIT"
         },
+        "node_modules/copy-anything": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
+            "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-what": "^3.14.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
         "node_modules/core-js-compat": {
             "version": "3.41.0",
             "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
@@ -11289,6 +11322,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/errno": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "prr": "~1.0.1"
+            },
+            "bin": {
+                "errno": "cli.js"
             }
         },
         "node_modules/error-ex": {
@@ -14773,6 +14820,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-what": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+            "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-wsl": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -17688,6 +17742,84 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/less": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/less/-/less-4.4.0.tgz",
+            "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "copy-anything": "^2.0.1",
+                "parse-node-version": "^1.0.1",
+                "tslib": "^2.3.0"
+            },
+            "bin": {
+                "lessc": "bin/lessc"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "make-dir": "^2.1.0",
+                "mime": "^1.4.1",
+                "needle": "^3.1.0",
+                "source-map": "~0.6.0"
+            }
+        },
+        "node_modules/less/node_modules/image-size": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+            "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "image-size": "bin/image-size.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/less/node_modules/make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/less/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/less/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17923,6 +18055,13 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "dev": true,
             "license": "MIT"
         },
@@ -18577,6 +18716,38 @@
         "node_modules/nav-enonicxp-frontend-shared": {
             "resolved": "packages/shared",
             "link": true
+        },
+        "node_modules/needle": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+            "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/needle/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -19431,6 +19602,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-node-version": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/parse5": {
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
@@ -19602,6 +19783,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/pino": {
@@ -20161,6 +20353,14 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
@@ -20894,6 +21094,13 @@
             "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
             "license": "MIT"
         },
+        "node_modules/reserved-words": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+            "integrity": "sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -21395,6 +21602,14 @@
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
             }
+        },
+        "node_modules/sax": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -22527,6 +22742,95 @@
                 }
             }
         },
+        "node_modules/stylus": {
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.62.0.tgz",
+            "integrity": "sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@adobe/css-tools": "~4.3.1",
+                "debug": "^4.3.2",
+                "glob": "^7.1.6",
+                "sax": "~1.3.0",
+                "source-map": "^0.7.3"
+            },
+            "bin": {
+                "stylus": "bin/stylus"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://opencollective.com/stylus"
+            }
+        },
+        "node_modules/stylus/node_modules/@adobe/css-tools": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+            "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/stylus/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/stylus/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/stylus/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/stylus/node_modules/sax": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+            "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -23319,6 +23623,89 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-plugin-css-modules": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.2.0.tgz",
+            "integrity": "sha512-c5pAU5d+m3GciDr/WhkFldz1NIEGBafuP/3xhFt9BEXS2gmn/LvjkoZ11vEBIuP8LkXfPNhOt1BUhM5efFuwOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/postcss-modules-local-by-default": "^4.0.2",
+                "@types/postcss-modules-scope": "^3.0.4",
+                "dotenv": "^16.4.2",
+                "icss-utils": "^5.1.0",
+                "less": "^4.2.0",
+                "lodash.camelcase": "^4.3.0",
+                "postcss": "^8.4.35",
+                "postcss-load-config": "^3.1.4",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.4",
+                "postcss-modules-scope": "^3.1.1",
+                "reserved-words": "^0.1.2",
+                "sass": "^1.70.0",
+                "source-map-js": "^1.0.2",
+                "tsconfig-paths": "^4.2.0"
+            },
+            "optionalDependencies": {
+                "stylus": "^0.62.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.0.0"
+            }
+        },
+        "node_modules/typescript-plugin-css-modules/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/typescript-plugin-css-modules/node_modules/lilconfig": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/typescript-plugin-css-modules/node_modules/postcss-load-config": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+            "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lilconfig": "^2.0.5",
+                "yaml": "^1.10.2"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            },
+            "peerDependencies": {
+                "postcss": ">=8.0.9",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "postcss": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ua-parser-js": {
@@ -24346,7 +24733,8 @@
                 "sass": "1.86.3",
                 "storybook": "9.0.18",
                 "storybook-addon-pseudo-states": "9.0.18",
-                "ts-jest": "29.4.0"
+                "ts-jest": "29.4.0",
+                "typescript-plugin-css-modules": "^5.2.0"
             }
         },
         "packages/nextjs/node_modules/@img/sharp-darwin-arm64": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -83,7 +83,8 @@
         "sass": "1.86.3",
         "storybook": "9.0.18",
         "storybook-addon-pseudo-states": "9.0.18",
-        "ts-jest": "29.4.0"
+        "ts-jest": "29.4.0",
+        "typescript-plugin-css-modules": "5.2.0"
     },
     "overrides": {
         "react": "19.1.0",

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -14,6 +14,14 @@
         "jsx": "preserve",
         "incremental": true,
         "downlevelIteration": true,
+        "plugins": [
+            {
+                "name": "typescript-plugin-css-modules",
+                "options": {
+                    "classnameTransform": "dashesOnly"
+                }
+            }
+        ],
         "lib": ["dom", "dom.iterable", "esnext"],
         "skipLibCheck": true,
         "paths": {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjernet denne forrige uke fordi stylus hadde en sikkerhetshendelse som førte til at den ble slettet. Det førte til at frontend feilet på "npm i". Sikkerhetsbristen viste seg å være en falsk positiv fra npmjs sin side, så jeg tenker det er helt OK å ta denne inn igjen.
