### PR TITLE
redaktørvarsler vises kun på valgte sider

### DIFF
--- a/packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
+++ b/packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx
@@ -30,6 +30,19 @@ export const RenderToEditorGlobalWarnings = ({ children }: { children: React.Rea
 };
 
 export const EditorGlobalWarnings = ({ content }: { content: ContentProps }) => {
+    const godkjenteSider = [
+        'no.nav.navno:situation-page',
+        'no.nav.navno:current-topic-page',
+        'no.nav.navno:guide-page',
+        'no.nav.navno:themed-article-page',
+        'no.nav.navno:content-page-with-sidemenus',
+        'no.nav.navno:tools-page',
+        'no.nav.navno:generic-page',
+    ];
+
+    if (!godkjenteSider.includes(content.type)) {
+        return;
+    }
     const hasErrors = (): boolean => {
         return (
             KortUrlWarning({ content }) !== null ||
@@ -44,7 +57,7 @@ export const EditorGlobalWarnings = ({ content }: { content: ContentProps }) => 
         <>
             {hasErrors() && (
                 <Alert variant="warning">
-                    Redaktørvarsel:
+                    <strong>Redaktørvarsel:</strong>
                     <br />
                     Disse problemene må rettes før publisering:
                     <ul>


### PR DESCRIPTION
This pull request introduces a validation mechanism to filter content types and improves the formatting of editor warnings in the `EditorGlobalWarnings` component. The most important changes are outlined below:

### Content type validation:

* Added a `godkjenteSider` array to define a whitelist of allowed content types. The component now checks if the `content.type` is included in this list before proceeding; otherwise, it returns early. (`packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx`, [packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsxR33-R45](diffhunk://#diff-3a1e4813cbc4098409f5187ad19b9e232d6c78783a2688696fa0d747ec31b6a7R33-R45))

### Improved warning formatting:

* Updated the "Redaktørvarsel" message to include a bold `<strong>` tag for better emphasis in the warning alert. (`packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsx`, [packages/nextjs/src/components/_editor-only/global-warnings/EditorGlobalWarnings.tsxL47-R60](diffhunk://#diff-3a1e4813cbc4098409f5187ad19b9e232d6c78783a2688696fa0d747ec31b6a7L47-R60))