### PR TITLE
tok bort aktuelt-sider fra redaktørvarsler og fikset broken css på redaktørvarsler

### DIFF
--- a/packages/nextjs/src/components/_editor-only/global-warnings/Redaktorvarsler.tsx
+++ b/packages/nextjs/src/components/_editor-only/global-warnings/Redaktorvarsler.tsx
@@ -11,7 +11,6 @@ import { HtmlAreaDiv } from './warnings/html-area-div/HtmlAreaDiv';
 export const isGodkjentSide = (contentType: string): boolean => {
     const godkjenteSider = [
         'no.nav.navno:situation-page',
-        'no.nav.navno:current-topic-page',
         'no.nav.navno:guide-page',
         'no.nav.navno:themed-article-page',
         'no.nav.navno:content-page-with-sidemenus',

--- a/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.module.scss
+++ b/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.module.scss
@@ -14,6 +14,9 @@
     justify-content: space-between;
     max-width: 100%;
     width: 100%;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    word-break: break-word;
 }
 
 .whiteBg {

--- a/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.tsx
+++ b/packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.tsx
@@ -10,8 +10,12 @@ type Props = PropsWithChildren<{
 
 export const PageWarning = ({ whiteBg, size = 'small', children }: Props) => {
     return (
-        <section className={classNames(style.container, whiteBg && style.whiteBg)}>
-            <Varselboks variant={'warning'} size={size} className={style.warning}>
+        <section className={style.container}>
+            <Varselboks
+                variant={'warning'}
+                size={size}
+                className={classNames(style.warning, whiteBg && style.whiteBg)}
+            >
                 {children}
             </Varselboks>
         </section>


### PR DESCRIPTION
This pull request includes updates to improve the styling and functionality of the `PageWarning` component and refines the logic for determining approved pages. The most important changes include adjustments to CSS for better text wrapping, restructuring of the `PageWarning` component for cleaner code, and updates to the list of approved page types.

### Styling improvements:
* [`packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.module.scss`](diffhunk://#diff-35822540668a990f5b09497b6704cfa689832b6348cdda3e68e4578555131281R17-R19): Added CSS rules (`overflow-wrap: anywhere`, `white-space: normal`, and `word-break: break-word`) to improve text wrapping and prevent overflow issues in the `PageWarning` component.

### Code restructuring:
* [`packages/nextjs/src/components/_page-warnings/pageWarning/PageWarning.tsx`](diffhunk://#diff-064753a44947f8e4534964502e6eda3d93766d49859928f65a3a340d8948153cL13-R18): Refactored the `PageWarning` component to move the `classNames` logic for conditional styling into the `Varselboks` component, resulting in cleaner and more readable code.

### Logic refinement:
* [`packages/nextjs/src/components/_editor-only/global-warnings/Redaktorvarsler.tsx`](diffhunk://#diff-e36bd0be3cbc7d93120c1968d81ff207ddb3ec9c928118f6867f480d032504e5L14): Removed `'no.nav.navno:current-topic-page'` from the list of approved page types in the `isGodkjentSide` function, reflecting updated requirements for approved pages.