### PR TITLE
oversatt frontpage-current-topics til seksjon-for-aktuelle-temaer

### DIFF
--- a/packages/nextjs/src/components/parts/PartsMapper.tsx
+++ b/packages/nextjs/src/components/parts/PartsMapper.tsx
@@ -10,7 +10,6 @@ import { ComponentType } from 'types/component-props/_component-common';
 import { ContentProps } from 'types/content-props/_content-common';
 import { BEM, classNames } from 'utils/classnames';
 import { HtmlAreaPart } from 'components/parts/html-area/HtmlAreaPart';
-import { FrontpageCurrentTopicsPart } from 'components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart';
 import { FrontpageShortcutsPart } from 'components/parts/frontpage-shortcuts/FrontpageShortcutsPart';
 import { ProductCardPart } from 'components/parts/product-card/ProductCardPart';
 import { ProductCardMicroPart } from 'components/parts/product-card-micro/ProductCardMicroPart';
@@ -31,6 +30,7 @@ import { PublishingCalendarLegacyPart } from 'components/parts/_legacy/publishin
 import { PublishingCalendarEntryLegacyPart } from 'components/parts/_legacy/publishing-calendar/PublishingCalendarEntryLegacyPart';
 import { ComponentEditorProps } from 'components/ComponentMapper';
 import { FrontpagePersonShortcutsPart } from 'components/parts/frontpage-person-shortcuts/FrontpagePersonShortcutsPart';
+import { SeksjonForAktuelleTemaerPart } from './seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart';
 import { FiltreringsmenyPart } from './filtreringsmeny/FiltreringsmenyPart';
 import { KalkulatorPart } from './kalkulator/KalkulatorPart';
 import { VarselboksPart } from './varselboks/VarselboksPart';
@@ -92,8 +92,8 @@ const PartComponentMapper = ({
             return <SkjemadetaljerPart {...partProps} />;
         case PartType.SeksjonForKontaktinformasjon:
             return <SeksjonForKontaktinformasjonPart {...partProps} />;
-        case PartType.FrontpageCurrentTopics:
-            return <FrontpageCurrentTopicsPart {...partProps} />;
+        case PartType.SeksjonForAktuelleTemaer:
+            return <SeksjonForAktuelleTemaerPart {...partProps} />;
         case PartType.FrontpageShortcuts:
             return <FrontpageShortcutsPart {...partProps} />;
         case PartType.FrontpagePersonShortcuts:

--- a/packages/nextjs/src/components/parts/seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart.module.scss
+++ b/packages/nextjs/src/components/parts/seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart.module.scss
@@ -3,20 +3,20 @@
 .currentTopics {
     @include common.full-width-mixin();
     background-color: var(--bg-color, var(--a-bg-subtle));
-    padding-top: 2.75rem;
-    padding-bottom: 2.75rem;
+    padding-top: var(--a-spacing-11);
+    padding-bottom: var(--a-spacing-11);
 
     @media #{common.$mq-screen-mobile} {
-        padding-top: 2rem;
-        padding-bottom: 2rem;
+        padding-top: var(--a-spacing-8);
+        padding-bottom: var(--a-spacing-8);
     }
 }
 
 .header {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--a-spacing-6);
 
     @media #{common.$mq-screen-mobile} {
-        margin-bottom: 1rem;
+        margin-bottom: var(--a-spacing-4);
     }
 }
 
@@ -27,8 +27,8 @@
 
     @include common.grid-layout-mixin(
         $numCols: 2,
-        $rowGapMobileSmall: 0.75rem,
-        $columnGapMobileSmall: 0.75rem
+        $rowGapMobileSmall: var(--a-spacing-3),
+        $columnGapMobileSmall: var(--a-spacing-3)
     );
 }
 
@@ -44,7 +44,7 @@
     }
 
     @media #{common.$mq-screen-mobile-small} {
-        padding: 0.5rem 0.75rem;
+        padding: var(--a-spacing-2) --a-spacing-3;
     }
 }
 

--- a/packages/nextjs/src/components/parts/seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart.tsx
+++ b/packages/nextjs/src/components/parts/seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart.tsx
@@ -9,10 +9,9 @@ import { MoreLink } from 'components/_common/moreLink/MoreLink';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
 import { ContentListData } from 'types/content-props/content-list-props';
 import { LinkSelectable } from 'types/component-props/_mixins';
+import style from './SeksjonForAktuelleTemaerPart.module.scss';
 
-import style from './FrontpageCurrentTopics.module.scss';
-
-export type PartConfigFrontpageCurrentTopics = {
+export type PartConfigSeksjonForAktuelleTemaer = {
     title: string;
     contentList?: { data: ContentListData };
     link: LinkSelectable;
@@ -20,9 +19,9 @@ export type PartConfigFrontpageCurrentTopics = {
     itemColor?: string;
 };
 
-export const FrontpageCurrentTopicsPart = ({
+export const SeksjonForAktuelleTemaerPart = ({
     config,
-}: PartComponentProps<PartType.FrontpageCurrentTopics>) => {
+}: PartComponentProps<PartType.SeksjonForAktuelleTemaer>) => {
     const { language, editorView } = usePageContentProps();
     const { contentList, title, link, bgColor, itemColor } = config;
 

--- a/packages/nextjs/src/types/component-props/parts.ts
+++ b/packages/nextjs/src/types/component-props/parts.ts
@@ -10,7 +10,7 @@ import { PartConfigKontaktOssKanal } from 'components/parts/kontakt-oss-kanal/Ko
 import { PartConfigFiltreringsmeny } from 'components/parts/filtreringsmeny/FiltreringsmenyPart';
 import { PartConfigSkjemadetaljer } from 'components/parts/skjemadetaljer/SkjemadetaljerPart';
 import { PartConfigSeksjonForKontaktinformasjon } from 'components/parts/seksjon-for-kontaktinformasjon/SeksjonForKontaktinformasjonPart';
-import { PartConfigFrontpageCurrentTopics } from 'components/parts/frontpage-current-topics/FrontpageCurrentTopicsPart';
+import { PartConfigSeksjonForAktuelleTemaer } from 'components/parts/seksjon-for-aktuelle-temaer/SeksjonForAktuelleTemaerPart';
 import { PartConfigFrontpageShortcuts } from 'components/parts/frontpage-shortcuts/FrontpageShortcutsPart';
 import { PartConfigFrontpagePersonShortcuts } from 'components/parts/frontpage-person-shortcuts/FrontpagePersonShortcutsPart';
 import { PartConfigHeader } from 'components/parts/header/HeaderPart';
@@ -59,7 +59,7 @@ export enum PartType {
     Situasjonskort = 'no.nav.navno:areapage-situation-card',
     LoggedinCard = 'no.nav.navno:loggedin-card',
     SeksjonForKontaktinformasjon = 'no.nav.navno:frontpage-contact',
-    FrontpageCurrentTopics = 'no.nav.navno:frontpage-current-topics',
+    SeksjonForAktuelleTemaer = 'no.nav.navno:frontpage-current-topics',
     FrontpageShortcuts = 'no.nav.navno:frontpage-shortcuts',
     FrontpagePersonShortcuts = 'no.nav.navno:frontpage-person-shortcuts',
     UxSignalsWidget = 'no.nav.navno:uxsignals-widget',
@@ -103,7 +103,7 @@ type PartConfigs = {
     [PartType.Filtreringsmeny]: PartConfigFiltreringsmeny;
     [PartType.Skjemadetaljer]: PartConfigSkjemadetaljer;
     [PartType.SeksjonForKontaktinformasjon]: PartConfigSeksjonForKontaktinformasjon;
-    [PartType.FrontpageCurrentTopics]: PartConfigFrontpageCurrentTopics;
+    [PartType.SeksjonForAktuelleTemaer]: PartConfigSeksjonForAktuelleTemaer;
     [PartType.FrontpageShortcuts]: PartConfigFrontpageShortcuts;
     [PartType.FrontpagePersonShortcuts]: PartConfigFrontpagePersonShortcuts;
     [PartType.Header]: PartConfigHeader;


### PR DESCRIPTION
This pull request refactors and renames the "Frontpage Current Topics" component to "Seksjon For Aktuelle Temaer" across the codebase. The changes include updates to imports, type definitions, component logic, and styling to align with the new naming convention and improve maintainability.

### Component Refactoring and Renaming:
* Renamed the `FrontpageCurrentTopicsPart` component to `SeksjonForAktuelleTemaerPart` in `PartsMapper.tsx` and updated its usage in the `PartComponentMapper` function. [[1]](diffhunk://#diff-e705d4bd30b7df57b6fd41e76beb8de02cc40190baf4be6f31b311dce2033016L13) [[2]](diffhunk://#diff-e705d4bd30b7df57b6fd41e76beb8de02cc40190baf4be6f31b311dce2033016R33) [[3]](diffhunk://#diff-e705d4bd30b7df57b6fd41e76beb8de02cc40190baf4be6f31b311dce2033016L95-R96)
* Updated the corresponding SCSS file (`FrontpageCurrentTopics.module.scss`) to `SeksjonForAktuelleTemaerPart.module.scss` and replaced hardcoded spacing values with CSS variables for improved consistency. [[1]](diffhunk://#diff-bdce64a062411005f39cdd180dfc2b6a3721383363486e287780e0ff17d4738dL6-R19) [[2]](diffhunk://#diff-bdce64a062411005f39cdd180dfc2b6a3721383363486e287780e0ff17d4738dL30-R31) [[3]](diffhunk://#diff-bdce64a062411005f39cdd180dfc2b6a3721383363486e287780e0ff17d4738dL47-R47)
* Renamed the component file `FrontpageCurrentTopicsPart.tsx` to `SeksjonForAktuelleTemaerPart.tsx` and updated the type definitions and imports accordingly.

### Type and Enum Updates:
* Updated the `PartType` enum to replace `FrontpageCurrentTopics` with `SeksjonForAktuelleTemaer`.
* Updated the `PartConfigs` type and related imports to reflect the new component name and configuration type. [[1]](diffhunk://#diff-4e646302b0aa8fc5ce4b90b64759f4039dc0dadc1f8baeda118a3ef726a68005L13-R13) [[2]](diffhunk://#diff-4e646302b0aa8fc5ce4b90b64759f4039dc0dadc1f8baeda118a3ef726a68005L106-R106)