### PR TITLE
Fjerner redaktørvarsel som en nødløsning hvis processedHtml ikke finnes

### DIFF
--- a/packages/nextjs/src/components/_editor-only/global-warnings/warnings/part-utenfor-innholdsseksjon/PartUtenforInnholdsseksjon.tsx
+++ b/packages/nextjs/src/components/_editor-only/global-warnings/warnings/part-utenfor-innholdsseksjon/PartUtenforInnholdsseksjon.tsx
@@ -16,6 +16,10 @@ export const PartUtenforInnholdsseksjon = ({ content, className }: Props) => {
         if (pageContentHtmlAreaIsOutsideSections(node)) {
             const { path, config } = node;
 
+            if (!config.html?.processedHtml) {
+                return;
+            }
+
             warnings.push(
                 <ul key={`${path}-list`}>
                     <li key={`${path}-item`}>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sjekk på processedHtml krasjer siden når html ikke finnes, som kan være tilfelle ved sjekk på feil komponent.
Dette er en hastefiks som redder siden fra krasj, men det underliggende som utløser sjekken bør vi fortsatt kikke på.

## Testing
Testes i dev