### PR TITLE
Korrigerer til riktig bruk av spacing i kapittellenker

### DIFF
--- a/packages/nextjs/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.module.scss
+++ b/packages/nextjs/src/components/parts/_legacy/main-article-chapter-navigation/MainArticleChapterNavigation.module.scss
@@ -20,7 +20,7 @@
 
         .item {
             display: block;
-            font-size: var(--a-spacing-05);
+            font-size: var(--a-spacing-5);
             margin: 0 var(--a-spacing-2);
             padding: var(--a-spacing-3) var(--a-spacing-2);
             position: relative;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
--a-spacing-05 finnes ikke i aksel og gjør at lenkene blir små og uleselige. Jeg endrer til --a-spacing-5 for å gjøre det leselig og så kan vi ta en runde til senere andre steder hvor --a-spacing-05 er brukt.

## Testing
Testes i dev