### PR TITLE
Justerer overskrifter over filtrering på oversiktssider

### DIFF
--- a/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilterBase/OversiktFilterBase.module.scss
+++ b/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilterBase/OversiktFilterBase.module.scss
@@ -1,6 +1,7 @@
 .oversiktFilter {
     display: flex;
     flex-direction: column;
+    margin-bottom: var(--a-spacing-8);
 }
 
 .filterWrapper {

--- a/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilterBase/OversiktFilterBase.tsx
+++ b/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilterBase/OversiktFilterBase.tsx
@@ -13,6 +13,7 @@ type Props<Type extends Area> = {
     selectionCallback: (filter: Type) => void;
     selected: Type;
     options: Type[];
+    hideLabel?: boolean;
 };
 
 export const OversiktFilterBase = <Type extends Area>({
@@ -20,6 +21,7 @@ export const OversiktFilterBase = <Type extends Area>({
     selectionCallback,
     selected,
     options,
+    hideLabel = false,
 }: Props<Type>) => {
     const { language } = usePageContentProps();
     const translations = translator('oversikt', language)(type);
@@ -27,9 +29,11 @@ export const OversiktFilterBase = <Type extends Area>({
 
     return (
         <section className={styles.oversiktFilter}>
-            <Heading size={'xsmall'} level={'3'}>
-                {translations['choose']}
-            </Heading>
+            {!hideLabel && (
+                <Heading size="xsmall" level="3">
+                    {translations['choose']}
+                </Heading>
+            )}
             <Chips className={styles.filterWrapper}>
                 {options.map((option) => {
                     const optionLabel = optionsTranslations(option);

--- a/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilters.module.scss
+++ b/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilters.module.scss
@@ -1,5 +1,0 @@
-.filters {
-    & > :not(:last-child) {
-        margin-bottom: var(--a-spacing-8);
-    }
-}

--- a/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilters.tsx
+++ b/packages/nextjs/src/components/_common/oversikt-filters/OversiktFilters.tsx
@@ -6,8 +6,6 @@ import { OversiktFilterableItem, useOversiktFilters } from 'store/hooks/useOvers
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 
-import style from './OversiktFilters.module.scss';
-
 type Props = {
     filterableItems: OversiktFilterableItem[];
     showTextInputFilter: boolean;
@@ -29,15 +27,24 @@ export const OversiktFilters = (props: Props) => {
     if (!showAreaFilter && !showTextInputFilter) {
         return null;
     }
-    const searchLabel = translator('oversikt', language)('filterOrSearch');
+
+    const searchLabel = () => {
+        if (showAreaFilter && showTextInputFilter) {
+            return translator('oversikt', language)('omradeEllerSok');
+        } else if (showAreaFilter && !showTextInputFilter) {
+            return translator('oversikt', language)('omrade');
+        } else if (showTextInputFilter && !showAreaFilter) {
+            return translator('oversikt', language)('sok');
+        }
+    };
 
     return (
-        <div className={style.filters}>
-            <Heading className="sr-only" level={'2'} size={'xsmall'}>
-                {searchLabel}
+        <>
+            <Heading level="2" size="xsmall">
+                {searchLabel()}
             </Heading>
-            {showAreaFilter && <OversiktOmradeFilter items={filterableItems} />}
-            {showTextInputFilter && <OversiktTextFilter hideLabel={false} />}
-        </div>
+            {showAreaFilter && <OversiktOmradeFilter items={filterableItems} hideLabel />}
+            {showTextInputFilter && <OversiktTextFilter hideLabel />}
+        </>
     );
 };

--- a/packages/nextjs/src/components/_common/oversikt-filters/oversikt-omradefilter/OversiktOmradeFilter.tsx
+++ b/packages/nextjs/src/components/_common/oversikt-filters/oversikt-omradefilter/OversiktOmradeFilter.tsx
@@ -36,9 +36,10 @@ const analyticsAreas = {
 
 type Props = {
     items: OversiktFilterableItem[];
+    hideLabel?: boolean;
 };
 
-export const OversiktOmradeFilter = ({ items }: Props) => {
+export const OversiktOmradeFilter = ({ items, hideLabel }: Props) => {
     const { omradeFilter, setOmradeFilter } = useOversiktFilters();
     const contentProps = usePageContentProps();
     const { context } = getDecoratorParams(contentProps);
@@ -60,10 +61,11 @@ export const OversiktOmradeFilter = ({ items }: Props) => {
 
     return (
         <OversiktFilterBase
-            type={'areas'}
+            type="areas"
             selectionCallback={handleFilterUpdate}
             selected={omradeFilter}
             options={[Area.ALL, ...areasPresent]}
+            hideLabel={hideLabel}
         />
     );
 };

--- a/packages/nextjs/src/components/_common/oversikt-filters/summary/OversiktFiltersSummary.module.scss
+++ b/packages/nextjs/src/components/_common/oversikt-filters/summary/OversiktFiltersSummary.module.scss
@@ -4,7 +4,6 @@
     align-items: center;
     flex-wrap: wrap-reverse;
     gap: var(--a-spacing-4);
-    margin-top: var(--a-spacing-6);
     margin-bottom: 0;
     border-bottom: 1px solid var(--a-border-subtle);
     width: 100%;

--- a/packages/nextjs/src/components/_common/oversikt-filters/summary/OversiktFiltersSummary.tsx
+++ b/packages/nextjs/src/components/_common/oversikt-filters/summary/OversiktFiltersSummary.tsx
@@ -2,28 +2,27 @@ import React from 'react';
 import { BodyLong, Heading } from '@navikt/ds-react';
 import { translator } from 'translations';
 import { usePageContentProps } from 'store/pageContext';
-
 import style from './OversiktFiltersSummary.module.scss';
 
 type Props = {
-    numMatches: number;
-    numTotal: number;
+    antallTreff: number;
+    totaltAntall: number;
 };
 
-export const OversiktFiltersSummary = ({ numMatches, numTotal }: Props) => {
+export const OversiktFiltersSummary = ({ antallTreff, totaltAntall }: Props) => {
     const { language } = usePageContentProps();
     const oversiktTranslations = translator('oversikt', language);
 
     return (
         <>
             <div className={style.summary}>
-                <Heading level={'2'} size={'xsmall'} role="status">
+                <Heading level="2" size="xsmall" role="status">
                     {oversiktTranslations('numHits')
-                        .replace('$1', numMatches.toString())
-                        .replace('$2', numTotal.toString())}
+                        .replace('$1', antallTreff.toString())
+                        .replace('$2', totaltAntall.toString())}
                 </Heading>
             </div>
-            {numMatches === 0 && (
+            {antallTreff === 0 && (
                 <BodyLong className={style.nohits}>{oversiktTranslations('noHits')}</BodyLong>
             )}
         </>

--- a/packages/nextjs/src/components/_common/oversikt-filters/text-filter/OversiktTextFilter.module.scss
+++ b/packages/nextjs/src/components/_common/oversikt-filters/text-filter/OversiktTextFilter.module.scss
@@ -1,6 +1,7 @@
 .oversiktSearch {
     display: flex;
     flex-direction: column;
+    margin-bottom: var(--a-spacing-8);
 
     &:focus {
         outline: none;

--- a/packages/nextjs/src/components/_common/oversikt-filters/text-filter/OversiktTextFilter.tsx
+++ b/packages/nextjs/src/components/_common/oversikt-filters/text-filter/OversiktTextFilter.tsx
@@ -24,11 +24,11 @@ const analyticsRedaction = (value: string) =>
         ? `tekst (${value.length})`
         : `nummer (${Math.round(Math.log10(Number(value))) + 1})`;
 
-export const OversiktTextFilter = ({ hideLabel }: Props) => {
+export const OversiktTextFilter = ({ hideLabel = false }: Props) => {
     const { setTextFilter } = useOversiktFilters();
     const contentProps = usePageContentProps();
     const { context } = getDecoratorParams(contentProps);
-    const label = translator('oversikt', contentProps.language)('search');
+    const label = translator('oversikt', contentProps.language)('sok');
     const inputId = useId();
     const [textInput, setTextInput] = useState('');
 

--- a/packages/nextjs/src/components/pages/oversikt-page/forms-list/OversiktList.tsx
+++ b/packages/nextjs/src/components/pages/oversikt-page/forms-list/OversiktList.tsx
@@ -82,8 +82,8 @@ export const OversiktList = (props: OversiktPageProps) => {
             />
             {numFilterTypes > 0 && (
                 <OversiktFiltersSummary
-                    numMatches={filteredList.length}
-                    numTotal={itemList.length}
+                    antallTreff={filteredList.length}
+                    totaltAntall={itemList.length}
                 />
             )}
             <ul className={style.list}>
@@ -92,7 +92,7 @@ export const OversiktList = (props: OversiktPageProps) => {
                         <OversiktListPanel
                             panelDetails={listItem}
                             oversiktType={oversiktType}
-                            formNumberSelected={formNumberFromSearch}
+                            skjemanummerValgt={formNumberFromSearch}
                         />
                     </li>
                 ))}

--- a/packages/nextjs/src/components/pages/oversikt-page/forms-list/panel/OversiktListPanel.tsx
+++ b/packages/nextjs/src/components/pages/oversikt-page/forms-list/panel/OversiktListPanel.tsx
@@ -36,10 +36,10 @@ const getSkjemadetaljerDisplayOptions = (
 type Props = {
     panelDetails: OversiktItemListItem;
     oversiktType: OversiktType;
-    formNumberSelected?: string;
+    skjemanummerValgt?: string;
 };
 
-export const OversiktListPanel = ({ panelDetails, oversiktType, formNumberSelected }: Props) => {
+export const OversiktListPanel = ({ panelDetails, oversiktType, skjemanummerValgt }: Props) => {
     const {
         anchorId,
         illustration,
@@ -125,7 +125,7 @@ export const OversiktListPanel = ({ panelDetails, oversiktType, formNumberSelect
                             <Skjemadetaljer
                                 skjemadetaljer={panelDetail.data}
                                 displayConfig={getSkjemadetaljerDisplayOptions(oversiktType)}
-                                formNumberSelected={formNumberSelected}
+                                formNumberSelected={skjemanummerValgt}
                                 key={panelDetail._id}
                             />
                         );

--- a/packages/nextjs/src/store/hooks/useOverviewFilters.ts
+++ b/packages/nextjs/src/store/hooks/useOverviewFilters.ts
@@ -79,7 +79,7 @@ export const useOverviewFilters = () => {
     );
 
     const setAreaFilter = useCallback(
-        (area: Area) => dispatch(setAreaFilterAction({ omrade: area })),
+        (area: Area) => dispatch(setAreaFilterAction({ area })),
         [dispatch]
     );
 

--- a/packages/nextjs/src/store/hooks/useOverviewFilters.ts
+++ b/packages/nextjs/src/store/hooks/useOverviewFilters.ts
@@ -79,7 +79,7 @@ export const useOverviewFilters = () => {
     );
 
     const setAreaFilter = useCallback(
-        (area: Area) => dispatch(setAreaFilterAction({ area })),
+        (area: Area) => dispatch(setAreaFilterAction({ omrade: area })),
         [dispatch]
     );
 

--- a/packages/nextjs/src/translations/default.ts
+++ b/packages/nextjs/src/translations/default.ts
@@ -220,8 +220,9 @@ export const translationsBundleNb = {
     oversikt: {
         noHits: 'Ingen treff med de valgte filtrene.',
         numHits: 'Viser $1 av $2',
-        search: 'Søk',
-        filterOrSearch: 'Bruk filter eller søk',
+        sok: 'Søk',
+        omradeEllerSok: 'Velg område eller søk',
+        omrade: 'Velg område',
         loading: 'Laster innhold...',
         resetFilters: 'Nullstill filter',
         any: 'Fra A til Å',

--- a/packages/nextjs/src/translations/en.ts
+++ b/packages/nextjs/src/translations/en.ts
@@ -208,8 +208,9 @@ export const translationsBundleEn: PartialTranslations = {
     oversikt: {
         noHits: 'No hits with the selected filters.',
         numHits: 'Showing $1 out of $2',
-        search: 'Search',
-        filterOrSearch: 'Use filters or search',
+        sok: 'Search',
+        omradeEllerSok: 'Choose area or search',
+        omrade: 'Choose area',
         loading: 'Loading content...',
         resetFilters: 'Reset filters',
         any: 'From A to Z',

--- a/packages/nextjs/src/translations/nn.ts
+++ b/packages/nextjs/src/translations/nn.ts
@@ -192,8 +192,9 @@ export const translationsBundleNn: PartialTranslations = {
     oversikt: {
         noHits: 'Ingen treff med dei valde filtera.',
         numHits: 'Viser $1 av $2',
-        search: 'Søk',
-        filterOrSearch: 'Bruk filter eller søk',
+        sok: 'Søk',
+        omradeEllerSok: 'Vel område eller søk',
+        omrade: 'Vel område',
         loading: 'Laster innhald...',
         resetFilters: 'Nullstill filter',
         any: 'Frå A til Å',


### PR DESCRIPTION
Justerer overskrifter over filtrering på oversiktssider

Velg område eller søk
<img width="1103" height="366" alt="image" src="https://github.com/user-attachments/assets/53f8f99a-fd55-45be-b5f2-59e3bfd4ba9f" />

Velg område
<img width="940" height="268" alt="image" src="https://github.com/user-attachments/assets/95136828-2aa6-42fa-bc96-8c32540a8bc3" />

Søk
<img width="1003" height="241" alt="image" src="https://github.com/user-attachments/assets/157cb895-d292-4636-9658-d26518e4b497" />


This pull request refactors and improves the filter components and their usage in the "oversikt" (overview) pages. The main changes include making filter labels more flexible, updating translation keys for clarity and consistency, and simplifying the filter layout and styling. Additionally, there are some prop renamings to improve code readability and maintainability.

### Filter label flexibility and component improvements

* Added a `hideLabel` prop to `OversiktFilterBase`, `OversiktOmradeFilter`, and `OversiktTextFilter`, allowing filter labels to be shown or hidden as needed. The default value is set to `false` for backward compatibility. [[1]](diffhunk://#diff-3fffa0d2b20372fd5bbba2fe1fd498cf0aa168c6516d72615ea5ed10a851f240R16-R36) [[2]](diffhunk://#diff-f592ec1b8273e3c196816840107fc7c7acea677c37197733e9bd00e14534bb7cR39-R42) [[3]](diffhunk://#diff-901b6ffbefffe7fae527ece0f6cd8bdd1ab0d499a5eb5b03b8350739565bfabdL27-R31)
* Updated `OversiktFilters` to use the new `hideLabel` prop and improved how the section heading label is determined based on which filters are visible.

### Translation and naming consistency

* Replaced translation keys like `search` and `filterOrSearch` with more descriptive and consistent keys such as `sok`, `omradeEllerSok`, and `omrade` across Norwegian Bokmål, Nynorsk, and English translation files. Updated code to use these new keys. [[1]](diffhunk://#diff-c0229e2a64ea5e1737a70f3123f029f4572bf5d03f8e1e234e50932732609d28L223-R225) [[2]](diffhunk://#diff-bcfa46adbb4a16547ca92884f33310fc96d626d984fbe78fdcf75007e506dbe9L211-R213) [[3]](diffhunk://#diff-986c909ba530bc0574822a6fd1431205c75a3f941d67c7e717fb892e21aec0ffL195-R197) [[4]](diffhunk://#diff-901b6ffbefffe7fae527ece0f6cd8bdd1ab0d499a5eb5b03b8350739565bfabdL27-R31) [[5]](diffhunk://#diff-0164a7d54098436de9689128d7dfd61e27194e54b7c0ba74eeb16dd8fa5f2d46L32-R48)
* Renamed several props for clarity, such as `numMatches` → `antallTreff`, `numTotal` → `totaltAntall`, and `formNumberSelected` → `skjemanummerValgt`, updating all usages accordingly. [[1]](diffhunk://#diff-23e3d5e6da3a43525707467254a72deb33332e846566fb106508e8476d5f31eaL5-R25) [[2]](diffhunk://#diff-c2bb6a044fc2788afbb1616eba3990c94f9e84d4816a24194097bb4b605628f3L85-R86) [[3]](diffhunk://#diff-c2bb6a044fc2788afbb1616eba3990c94f9e84d4816a24194097bb4b605628f3L95-R95) [[4]](diffhunk://#diff-c5b1291f9cf68d7081fd353dc914e0e806cb3cc0240c43fbf1f82df6fdf15fd5L39-R42) [[5]](diffhunk://#diff-c5b1291f9cf68d7081fd353dc914e0e806cb3cc0240c43fbf1f82df6fdf15fd5L128-R128)

### Layout and styling adjustments

* Moved vertical spacing responsibility from the parent filter container to the individual filter components by adding `margin-bottom` in their respective `.scss` files, and removed the now-unnecessary parent container spacing. [[1]](diffhunk://#diff-8bc09a53bac9db50780c961530161edc32c026c6c14cd56d9c624f15aab0c3a0R4) [[2]](diffhunk://#diff-372fdfd6360bec93c300fc511a17318d42291a4b57bf447191f26ee5d0178089R4) [[3]](diffhunk://#diff-af97094cb532d9b2fedb20e2e162072f60c8cbb89c14be704c046f917783aa51L1-L5)
* Removed unused imports and cleaned up code for better maintainability.

These changes collectively improve the flexibility, clarity, and maintainability of the filter components and their usage throughout the application.