### PR TITLE
Sett simple dekoratør server-side

### DIFF
--- a/packages/nextjs/src/components/PageWrapper.tsx
+++ b/packages/nextjs/src/components/PageWrapper.tsx
@@ -97,7 +97,7 @@ export const PageWrapper = ({ content, children }: Props) => {
 
         // Prevents focus from "sticking" after async-navigation to a new page
         const focusedElement = document.activeElement as HTMLElement | null;
-        if (focusedElement?.blur) {
+        if (typeof focusedElement?.blur === 'function') {
             focusedElement.blur();
         }
 

--- a/packages/nextjs/src/components/pages/formIntermediateStepPage/FormIntermediateStepPage.tsx
+++ b/packages/nextjs/src/components/pages/formIntermediateStepPage/FormIntermediateStepPage.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import { setParams } from '@navikt/nav-dekoratoren-moduler';
+import React from 'react';
 import { translator } from 'translations';
 import { SelectableStep, StepBase } from 'types/content-props/form-intermediate-step';
 import { useFormIntermediateStepPage } from 'components/pages/formIntermediateStepPage/useFormIntermediateStepPage';
@@ -41,15 +40,6 @@ export const FormIntermediateStepPage = (props: FormIntermediateStepPageProps) =
     const { data, displayName, language } = props;
     const { currentStepData, backUrl } = useFormIntermediateStepPage(props);
     const getTranslations = translator('form', language);
-
-    // Mellomsteg skal bruke simple decorator
-    useEffect(() => {
-        setParams({ simple: true });
-
-        return () => {
-            setParams({ simple: false });
-        };
-    }, []);
 
     return (
         <MellomstegLayout

--- a/packages/nextjs/src/utils/decorator-utils.ts
+++ b/packages/nextjs/src/utils/decorator-utils.ts
@@ -84,6 +84,8 @@ export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
     const chatbotDisabled =
         data?.chatbotToggle === false || editorView === 'edit' || editorView === 'inline';
     const pageType = innholdsTypeMap[content.type];
+    const isFormIntermediateStepPage = content.type === ContentType.FormIntermediateStepPage;
+
     return {
         ...defaultParams,
         ...(context && { context }),
@@ -103,5 +105,6 @@ export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
         ...(feedbackEnabled && { feedback: true }),
         chatbot: !chatbotDisabled,
         utilsBackground: hasWhiteHeader(content) ? 'white' : 'gray',
+        ...(isFormIntermediateStepPage && { simple: true }),
     };
 };

--- a/packages/nextjs/src/utils/decorator-utils.ts
+++ b/packages/nextjs/src/utils/decorator-utils.ts
@@ -84,7 +84,7 @@ export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
     const chatbotDisabled =
         data?.chatbotToggle === false || editorView === 'edit' || editorView === 'inline';
     const pageType = innholdsTypeMap[content.type];
-    const isFormIntermediateStepPage = content.type === ContentType.FormIntermediateStepPage;
+    const useSimpleDecorator = content.type === ContentType.FormIntermediateStepPage;
 
     return {
         ...defaultParams,
@@ -105,6 +105,6 @@ export const getDecoratorParams = (content: ContentProps): DecoratorParams => {
         ...(feedbackEnabled && { feedback: true }),
         chatbot: !chatbotDisabled,
         utilsBackground: hasWhiteHeader(content) ? 'white' : 'gray',
-        ...(isFormIntermediateStepPage && { simple: true }),
+        simple: useSimpleDecorator,
     };
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Setter simple dekoratør server side for å hindre "[flashing](https://github.com/navikt/nav-enonicxp-frontend/issues/2439)" på mellomstegsidene, f.eks. https://www-2.ansatt.dev.nav.no/start/soknad-aap
- Hindrer ikke alltid flashing ved første navigering, men hindrer ihvertfall flashing på reload

## Testing

- Testet i dev2
