### PR TITLE
Fikse sorterings issue

### DIFF
--- a/packages/nextjs/src/store/hooks/useOversiktFilters.ts
+++ b/packages/nextjs/src/store/hooks/useOversiktFilters.ts
@@ -38,7 +38,12 @@ const _getFilteredList = async <ItemType extends OversiktFilterableItem>({
     );
 
     if (!textFilterActual || !fuseOptions) {
-        return itemsMatchingToggleFilters;
+        // Sort using Norwegian locale to ensure Å comes last
+        return itemsMatchingToggleFilters.sort((a, b) => {
+            const titleA = (a as any).sortTitle || (a as any).title || '';
+            const titleB = (b as any).sortTitle || (b as any).title || '';
+            return titleA.localeCompare(titleB, 'no-NO');
+        });
     }
 
     return getFuseSearchFunc(itemsMatchingToggleFilters, fuseOptions).then((fuseSearchFunc) => {

--- a/packages/nextjs/src/store/hooks/useOversiktFilters.ts
+++ b/packages/nextjs/src/store/hooks/useOversiktFilters.ts
@@ -13,6 +13,8 @@ import { getFuseSearchFunc } from 'utils/text-search-utils';
 
 export type OversiktFilterableItem = {
     area: Area[];
+    sortTitle?: string;
+    title?: string;
 };
 
 type FilteredListProps<ItemType extends OversiktFilterableItem> = {
@@ -40,8 +42,8 @@ const _getFilteredList = async <ItemType extends OversiktFilterableItem>({
     if (!textFilterActual || !fuseOptions) {
         // Sort using Norwegian locale to ensure Å comes last
         return itemsMatchingToggleFilters.sort((a, b) => {
-            const titleA = (a as any).sortTitle || (a as any).title || '';
-            const titleB = (b as any).sortTitle || (b as any).title || '';
+            const titleA = a.sortTitle || a.title || '';
+            const titleB = b.sortTitle || b.title || '';
             return titleA.localeCompare(titleB, 'no-NO');
         });
     }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sorterer elementer korrekt alfabetisk i henhold til locale, men bare dersom det ikke er gjort et tekstsøk i oversiktssiden.
- Merk: sorterer localCompare med "no-NO" bestandig, i tilfelle tittel ikke er oversatt men begynner med "Å", også på engelsk. Hvis ikke havner den langt oppe sammen med "A". Dette bør ikke påvirke noe annet siden vi uansett kun har bokmål, nynorsk og engelsk språk i oversiktssidene.

## Testing
Testes i dev