### PR TITLE
Ikke redirect fra intern

### DIFF
--- a/packages/server/src/server-setup/server-setup-dev.ts
+++ b/packages/server/src/server-setup/server-setup-dev.ts
@@ -34,7 +34,7 @@ export const serverSetupDev = (expressApp: Express, nextApp: InferredNextWrapper
     if (APP_ORIGIN.endsWith(DEV_NAIS_DOMAIN)) {
         expressApp.all('/*path', (req, res, next) => {
             if (!req.hostname.endsWith(DEV_NAIS_DOMAIN)) {
-                return res.redirect(302, `${APP_ORIGIN}${req.path}`);
+                // return res.redirect(302, `${APP_ORIGIN}${req.path}`);
             }
 
             next();

--- a/packages/server/src/server-setup/server-setup-dev.ts
+++ b/packages/server/src/server-setup/server-setup-dev.ts
@@ -33,8 +33,12 @@ export const serverSetupDev = (expressApp: Express, nextApp: InferredNextWrapper
 
     if (APP_ORIGIN.endsWith(DEV_NAIS_DOMAIN)) {
         expressApp.all('/*path', (req, res, next) => {
+            const { noRedirect } = req.query;
+            if (noRedirect) {
+                return next();
+            }
             if (!req.hostname.endsWith(DEV_NAIS_DOMAIN)) {
-                // return res.redirect(302, `${APP_ORIGIN}${req.path}`);
+                return res.redirect(302, `${APP_ORIGIN}${req.path}`);
             }
 
             next();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Tillater flagg for å hindre redirect til ansatt-ingress (gjelder kun i dev1/dev2). Det trengs for at XP skal kunne sjekke om en kort-url er ledig.

## Testing
Testes i dev