### PR TITLE
Dynamisk innholdsnavigasjon

### DIFF
--- a/packages/nextjs/src/components/_common/headers/Header.module.scss
+++ b/packages/nextjs/src/components/_common/headers/Header.module.scss
@@ -1,5 +1,10 @@
 .header {
     scroll-margin-top: 2.5lh;
+
+    :global(.page__page-with-side-menus) & {
+        // Matcher nedre rootMargin (HEADING_TARGET_RATIO minus en liten buffer) i DynamicNavigation
+        scroll-margin-top: 19.99995vh;
+    }
 }
 
 .anchorLink {

--- a/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicNavigation.module.scss
+++ b/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicNavigation.module.scss
@@ -1,0 +1,90 @@
+@use 'common' as common;
+
+.pageNavigationMenu {
+    @media #{common.$mq-screen-desktop} {
+        margin: var(--a-spacing-6) 0;
+        max-height: calc(100vh - (var(--a-spacing-6) * 2) - var(--decorator-sticky-offset));
+        overflow: auto;
+    }
+}
+
+.heading {
+    padding: var(--a-spacing-2) 0 var(--a-spacing-3);
+    margin-bottom: 0 !important;
+    display: flex;
+    align-items: center;
+    gap: var(--a-spacing-2);
+
+    @media #{common.$mq-screen-desktop} {
+        background-image: linear-gradient(to bottom, white 65%, rgba(255, 255, 255, 0.75) 75%, transparent);
+        position: sticky;
+        top: -1px;
+        z-index: 10;
+    }
+}
+
+.headingIcon {
+    font-size: var(--a-font-size-heading-medium);
+}
+
+.list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    padding-left: var(--a-spacing-5);
+
+    ul {
+        margin-top: var(--a-spacing-2);
+        margin-left: var(--a-spacing-3);
+        padding-left: 0;
+        border-left: 1px solid var(--a-border-subtle);
+
+        // Do not show expanded submenus on mobile (TODO: screen reader support?)
+        @media #{common.$mq-screen-tablet-and-mobile} {
+            display: none !important;
+        }
+    }
+
+     li + li {
+        margin-top: var(--a-spacing-2);
+    }
+}
+
+.link {
+    color: inherit;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--a-border-subtle);
+    display: block;
+    position: relative;
+    padding-block: var(--a-spacing-1);
+    padding-inline-start: var(--a-spacing-3);
+    margin-inline-start: -2px;
+
+    &:hover {
+        text-decoration-color: inherit;
+    }
+
+    @media #{common.$mq-screen-desktop} {
+        &::before {
+            content: '';
+            position: absolute;
+            inset-block: 0;
+            inset-inline-start: 0;
+            inline-size: 4px;
+            background: transparent;
+            height: 0;
+            top: 50%;
+
+            @media (prefers-reduced-motion: no-preference) {
+                transition: all 0.25s;
+                animation-timing-function: cubic-bezier(0.8, 0.27, 0.11, 0.68);
+            }
+        }
+
+        &[aria-current="true"]::before {
+            background: var(--a-border-action);
+            height: 100%;
+            top: 0;
+        }
+    }
+}

--- a/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicNavigation.tsx
+++ b/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicNavigation.tsx
@@ -1,0 +1,258 @@
+import React, { useEffect, useId, useMemo, useState, useRef } from 'react';
+import debounce from 'lodash.debounce';
+import { BodyLong, Heading } from '@navikt/ds-react';
+import { FileTextIcon } from '@navikt/aksel-icons';
+import { ContentProps } from 'types/content-props/_content-common';
+import { PartType } from 'types/component-props/parts';
+import { translator } from 'translations';
+import { usePageContentProps } from 'store/pageContext';
+import { AnalyticsEvents } from 'utils/analytics';
+import { classNames } from 'utils/classnames';
+import { getAnchorId } from 'components/_common/relatedSituations/RelatedSituations';
+import { LenkeBase } from 'components/_common/lenke/lenkeBase/LenkeBase';
+import { EditorHelp } from 'components/_editor-only/editorHelp/EditorHelp';
+import { AnchorLink } from 'components/parts/page-navigation-menu/PageNavigationMenuPart';
+
+import style from './DynamicNavigation.module.scss';
+
+const HEADING_TARGET_RATIO = 0.2; // Prosentandel av viewport-høyden for å markere overskrift som aktiv
+
+const getValidLinks = (anchorLinks: AnchorLink[]): AnchorLink[] =>
+    anchorLinks.filter(link => link.anchorId && link.linkText && !link.isDupe);
+
+type Props = {
+    anchorLinks?: AnchorLink[];
+    pageProps: ContentProps;
+    title?: string;
+    className?: string;
+};
+
+export const DynamicNavigation = ({ anchorLinks = [], pageProps, title, className }: Props) => {
+    const { language } = usePageContentProps();
+
+    const headingId = `heading-dynamic-navigation-menu-${useId()}`;
+    const analyticsComponent = 'Dynamisk meny for intern-navigasjon';
+
+    const [activeAnchor, setActiveAnchor] = useState<string | null>(null);
+    const clickedAnchorRef = useRef<string | null>(null);
+    const clickedAnchorResetTimerRef = useRef<number | undefined>(undefined);
+
+    const links = useMemo(() => getValidLinks(anchorLinks), [anchorLinks]);
+    const pageContentComponents = useMemo(() => (pageProps as any)?.page?.regions?.pageContent?.components as any[] | undefined, [pageProps]);
+
+    // Grupper H2- og H3-overskrifter basert på sideinnholdet for å bygge hierarkisk meny
+    const groupedLinks = useMemo(() => links.map((h2) => {
+        const section = pageContentComponents?.find(component => component?.config?.anchorId === h2.anchorId);
+
+        const introComponents: any[] = section?.regions?.intro?.components ?? [];
+        const contentComponents: any[] = section?.regions?.content?.components ?? [];
+        const sectionComponents: any[] = [...introComponents, ...contentComponents];
+
+        const headerH3: AnchorLink[] = sectionComponents
+            .filter(component =>
+                component?.descriptor === PartType.Header &&
+                component?.config?.titleTag === 'h3' &&
+                component?.config?.anchorId &&
+                component?.config?.title
+            )
+            .map(component => ({
+                anchorId: component.config.anchorId as string,
+                linkText: component.config.title as string,
+            }));
+
+        const relatedSituationsH3: AnchorLink[] = sectionComponents
+            .filter(component => component?.descriptor === PartType.RelatedSituations)
+            .map(component => {
+                const linkText = ((component?.config?.title as string) || translator('related', language)('otherOffers')).trim();
+                return {
+                    anchorId: getAnchorId(linkText),
+                    linkText,
+                } as AnchorLink;
+            });
+
+        const h3: AnchorLink[] = [...headerH3, ...relatedSituationsH3];
+
+        return { h2, h3 };
+    }), [links, pageContentComponents, language]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        // Flat liste over overskrifter: H2 etterfulgt av sine H3-er, hver med eksisterende DOM-element
+        const headingItems = groupedLinks
+            .flatMap(group => [group.h2.anchorId, ...group.h3.map(link => link.anchorId)])
+            .map(id => ({ id, el: document.getElementById(id) as HTMLElement }))
+            .filter(item => !!item.el);
+        if (headingItems.length === 0) return;
+
+        const visibleHeadings: Set<string> = new Set();
+        let currentDocHeight = Math.floor(document.body.clientHeight);
+
+        // Observer H2- og H3-elementer på siden og marker den nærmeste synlige som aktiv
+        const createObserver = (documentHeight: number) =>
+            new IntersectionObserver(
+                entries => {
+                    entries.forEach(entry => {
+                        const target = entry.target as HTMLElement;
+                        const id = target.id;
+                        if (!id) return;
+                        if (entry.isIntersecting) {
+                            visibleHeadings.add(id);
+                        } else {
+                            visibleHeadings.delete(id);
+                        }
+                    });
+
+                    // Finn aktiv overskrift: iterer i hierarkisk rekkefølge og ta den siste som er synlig
+                    let nextActive: string | null = null;
+                    for (const item of headingItems) {
+                        if (visibleHeadings.has(item.id)) nextActive = item.id;
+                    }
+
+                    // Lås aktiv overskrift frem til den er synlig dersom vi scroller mot et klikket mål - hvis ikke, oppdater aktiv overskrift ved scroll
+                    const clicked = clickedAnchorRef.current;
+                    if (clicked) {
+                        if (nextActive === clicked) {
+                            clickedAnchorRef.current = null;
+                            setActiveAnchor(prev => (prev !== nextActive ? nextActive : prev));
+                        }
+                    } else {
+                        setActiveAnchor(prev => (prev !== nextActive ? nextActive : prev));
+                    }
+                },
+                {
+                    // Bruk documentHeight som øvre rootMargin slik at overskrifter over viewport fortsatt regnes som "synlige"
+                    // og en negativ nedre rootMargin for å foretrekke den nærmeste overskriften mot toppen
+                    rootMargin: `${documentHeight}px 0px -${(1 - HEADING_TARGET_RATIO) * 100}% 0px`,
+                    threshold: 0,
+                }
+            );
+
+        let observer = createObserver(currentDocHeight);
+        headingItems.forEach(item => observer.observe(item.el));
+
+        // Erstatter gjeldende IntersectionObserver ved endret dokumenthøyde for å sette korrekt rootMargin
+        const onResize = debounce(() => {
+            const newHeight = Math.floor(document.body.clientHeight);
+            if (newHeight === currentDocHeight) return;
+
+            currentDocHeight = newHeight;
+            observer.disconnect();
+            observer = createObserver(newHeight);
+            headingItems.forEach(item => observer.observe(item.el));
+        }, 150);
+
+        window.addEventListener('resize', onResize);
+
+        return () => {
+            window.removeEventListener('resize', onResize);
+            onResize.cancel();
+            observer.disconnect();
+        };
+    }, [groupedLinks]);
+
+    // Sikre at vi ikke hopper mellom aktive overskrifter ved automatisk scroll til hash i URL
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        const applyHashScroll = () => {
+            const hash = window.location.hash.slice(1);
+            if (!hash) return;
+
+            const isValidHeading = groupedLinks.some(g => g.h2.anchorId === hash || g.h3.some(s => s.anchorId === hash));
+            if (!isValidHeading) return;
+
+            window.clearTimeout(clickedAnchorResetTimerRef.current);
+            clickedAnchorRef.current = hash;
+            setActiveAnchor(hash);
+
+            // Fallback dersom IntersectionObserver ikke trigger slipper vi låsen etter en kort periode slik at aktiv overskrift kan endres igjen
+            clickedAnchorResetTimerRef.current = window.setTimeout(() => {
+                clickedAnchorRef.current = null;
+                clickedAnchorResetTimerRef.current = undefined;
+            }, 1000);
+        };
+
+        // Kjør ved første innlasting for å håndtere eksisterende hash i URL
+        if (window.location.hash) {
+            applyHashScroll();
+        }
+
+        window.addEventListener('popstate', applyHashScroll);
+        window.addEventListener('hashchange', applyHashScroll);
+
+        return () => {
+            window.removeEventListener('popstate', applyHashScroll);
+            window.removeEventListener('hashchange', applyHashScroll);
+            window.clearTimeout(clickedAnchorResetTimerRef.current);
+        };
+    }, [groupedLinks]);
+
+    // If no links found, show editor help
+    if (links.length === 0) {
+        return (
+            <EditorHelp text="Kunne ikke lage lenker til intern navigasjon. Enten finnes det ingen Innholdsseksjoner på denne siden, eller alle er satt til 'ikke vis under innhold'. Hvis siden nettopp er opprettet, forsøk å klikke 'marker som klar' eller last hele siden på nytt." />
+        );
+    }
+
+    return (
+        <nav aria-labelledby={headingId} className={classNames(style.pageNavigationMenu, className)}>
+            <Heading size="xsmall" id={headingId} className={style.heading}>
+                <FileTextIcon aria-hidden={true} className={style.headingIcon} />
+                {title}
+            </Heading>
+            <ul className={style.list}>
+                {groupedLinks.map(({ h2, h3 }) => {
+                    const isH2Active = activeAnchor === h2.anchorId;
+                    const isChildActive = h3.some(s => s.anchorId === activeAnchor);
+                    const isExpanded = isH2Active || isChildActive;
+                    const submenuId = `${h2.anchorId}-submenu`;
+                    return (
+                    <li key={h2.anchorId}>
+                        <LenkeBase
+                            href={`#${h2.anchorId}`}
+                            analyticsEvent={AnalyticsEvents.NAVIGATION}
+                            analyticsLinkGroup={'Innhold'}
+                            analyticsComponent={analyticsComponent}
+                            analyticsLabel={h2.linkText}
+                            className={style.link}
+                            aria-current={isH2Active ? 'true' : undefined}
+                            aria-expanded={h3.length > 0 ? (isExpanded ? 'true' : 'false') : undefined}
+                            aria-controls={h3.length > 0 ? submenuId : undefined}
+                        >
+                            <BodyLong as="span" size="small" className={style.linkText}>
+                                {h2.linkText}
+                            </BodyLong>
+                        </LenkeBase>
+
+                        {h3.length > 0 && (
+                            <ul
+                                className={classNames(style.list, !isExpanded && 'sr-only')}
+                                id={submenuId}
+                            >
+                                {h3.map(sub => (
+                                    <li key={sub.anchorId}>
+                                        <LenkeBase
+                                            href={`#${sub.anchorId}`}
+                                            analyticsEvent={AnalyticsEvents.NAVIGATION}
+                                            analyticsLinkGroup={'Innhold'}
+                                            analyticsComponent={analyticsComponent}
+                                            analyticsLabel={sub.linkText}
+                                            className={style.link}
+                                            aria-current={activeAnchor === sub.anchorId ? 'true' : undefined}
+                                        >
+                                            <BodyLong as="span" size="small" className={style.linkText}>
+                                                {sub.linkText}
+                                            </BodyLong>
+                                        </LenkeBase>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </li>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+};

--- a/packages/nextjs/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
+++ b/packages/nextjs/src/components/layouts/page-with-side-menus/PageWithSideMenus.tsx
@@ -4,12 +4,14 @@ import { PageWithSideMenusProps } from 'types/component-props/pages/page-with-si
 import { LayoutContainer } from 'components/layouts/LayoutContainer';
 import Region from 'components/layouts/Region';
 import { PageNavigationMenu } from 'components/_common/pageNavigationMenu/PageNavigationMenu';
+import { DynamicNavigation } from 'components/_common/pageNavigationMenu/DynamicNavigation';
 import { AktuelleMalgrupper } from 'components/_common/aktuelleMalgrupper/AktuelleMalgrupper';
 import { GeneralPageHeader } from 'components/_common/headers/generalPageHeader/GeneralPageHeader';
 import { PageUpdatedInfo } from 'components/_common/pageUpdatedInfo/PageUpdatedInfo';
 import { usePageContentProps } from 'store/pageContext';
 import { translator } from 'translations';
 import { classNames } from 'utils/classnames';
+import { useLegacyNav } from 'utils/useLegacyNav';
 import styles from './PageWithSideMenus.module.scss';
 
 type Props = {
@@ -21,6 +23,7 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
     const { language, languages } = usePageContentProps();
     const getLabel = translator('internalNavigation', language);
+    const legacyNav = useLegacyNav();
 
     if (!regions || !config) {
         return null;
@@ -47,12 +50,19 @@ export const PageWithSideMenus = ({ pageProps, layoutProps }: Props) => {
                 {!isNewLayoutPage && <Region pageProps={pageProps} regionProps={topPageContent} />}
                 {isNewLayoutPage && <AktuelleMalgrupper />}
 
-                {showInternalNav && (
+                {showInternalNav && legacyNav && (
                     <PageNavigationMenu
-                        className={styles.pageNavigationMenu}
                         anchorLinks={anchorLinks}
                         title={getLabel('pageNavigationMenu')}
                         isChapterNavigation={true}
+                    />
+                )}
+                {showInternalNav && !legacyNav && (
+                    <DynamicNavigation
+                        className={styles.pageNavigationMenu}
+                        anchorLinks={anchorLinks}
+                        pageProps={pageProps}
+                        title={getLabel('pageNavigationMenu')}
                     />
                 )}
                 <Region pageProps={pageProps} regionProps={pageContent} />

--- a/packages/nextjs/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
+++ b/packages/nextjs/src/components/layouts/section-with-header/SectionWithHeaderLayout.tsx
@@ -9,6 +9,7 @@ import { XpImage } from 'components/_common/image/XpImage';
 import { FilterBar } from 'components/_common/filter-bar/FilterBar';
 import { EditorHelp } from 'components/_editor-only/editorHelp/EditorHelp';
 import { classNames } from 'utils/classnames';
+import { useLegacyNav } from 'utils/useLegacyNav';
 
 import styleV1 from './SectionWithHeaderLayout.module.scss';
 import styleV2 from './SectionWithHeaderLayoutV2.module.scss';
@@ -37,6 +38,7 @@ const templateV2 = new Set([
 
 export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
     const { regions, config } = layoutProps;
+    const legacyNav = useLegacyNav();
 
     if (!config) {
         return <EditorHelp type={'error'} text={'Feil: Komponenten mangler data'} />;
@@ -106,7 +108,7 @@ export const SectionWithHeaderLayout = ({ pageProps, layoutProps }: Props) => {
                     {title}
                 </Heading>
             )}
-            {showSubsectionNavigation && (
+            {showSubsectionNavigation && legacyNav && (
                 <SectionNavigation introRegion={regions.intro} contentRegion={regions.content} />
             )}
             {shouldShowIntroRegion && <Region pageProps={pageProps} regionProps={regions.intro} />}

--- a/packages/nextjs/src/utils/useLegacyNav.ts
+++ b/packages/nextjs/src/utils/useLegacyNav.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns true when URL contains nav=legacy, otherwise false.
+ * Defaults to false during SSR to avoid hydration mismatches.
+ */
+export const useLegacyNav = (): boolean => {
+    const [isLegacy, setIsLegacy] = useState(false);
+
+    useEffect(() => {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            const nav = (params.get('nav') || '').toLowerCase();
+            setIsLegacy(nav === 'legacy' || nav === 'old' || nav === '1');
+        } catch (_) {
+            // Ignore parsing errors, stick to default (false)
+        }
+    }, []);
+
+    return isLegacy;
+};


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Innholdsnavigasjon som følger scroll. Implementert på alle sider som bruker `PageWithSideMenus`. Kan trigge gammel navigasjon ved å legge til `?nav=legacy` i URLen.

## Testing

Har testet i dev2

## Dette trenger jeg å få et ekstra blikk på

- Må vi matche `analyticsComponent` med slik det var tidligere for å tracke click i en eventuel A/B-test?
- Hva gjør vi med sider som ikke eksponerer H3?