### PR TITLE
Flytte til navno-namespace - steg 1: Åpner accessPolicy for navno namespace

### DIFF
--- a/.github/workflows/deploy.dev2.yml
+++ b/.github/workflows/deploy.dev2.yml
@@ -23,7 +23,7 @@ jobs:
             ENV: dev2
             ADMIN_ORIGIN: https://portal-admin-q6.oera.no
             APP_ORIGIN: https://www-2.ansatt.dev.nav.no
-            REVALIDATOR_PROXY_ORIGIN: http://nav-enonicxp-frontend-revalidator-proxy-dev2
+            REVALIDATOR_PROXY_ORIGIN: http://nav-enonicxp-frontend-revalidator-proxy-dev2.navno
             DECORATOR_URL: https://dekoratoren-beta.intern.dev.nav.no
             XP_ORIGIN: https://www-q6.nav.no
             TELEMETRY_URL: https://telemetry.ekstern.dev.nav.no/collect

--- a/.nais/config-failover.yml
+++ b/.nais/config-failover.yml
@@ -40,7 +40,11 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
+          namespace: personbruker
+        - application: {{revalidatorApp}}
+          namespace: navno
         - application: {{dekoratorenApp}}
+          
       external:
         {{#each externalHosts as |host|}}
         - host: {{host}}

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -60,6 +60,9 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
+          namespace: personbruker
+        - application: {{revalidatorApp}}
+          namespace: navno
         - application: {{dekoratorenApp}}
       external:
         {{#each externalHosts as |host|}}
@@ -68,6 +71,9 @@ spec:
     inbound:
       rules:
         - application: {{revalidatorApp}}
+          namespace: personbruker
+        - application: {{revalidatorApp}}
+          namespace: navno
         - application: navno-xp-archive
   resources:
   {{#with resources}}

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -60,9 +60,7 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: personbruker
-        - application: {{revalidatorApp}}
-          namespace: navno
+          namespace: *
         - application: {{dekoratorenApp}}
       external:
         {{#each externalHosts as |host|}}
@@ -71,9 +69,7 @@ spec:
     inbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: personbruker
-        - application: {{revalidatorApp}}
-          namespace: navno
+          namespace: *
         - application: navno-xp-archive
   resources:
   {{#with resources}}

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -60,7 +60,7 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: *
+          namespace: "*"
         - application: {{dekoratorenApp}}
       external:
         {{#each externalHosts as |host|}}
@@ -69,7 +69,7 @@ spec:
     inbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: *
+          namespace: "*"
         - application: navno-xp-archive
   resources:
   {{#with resources}}

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -60,7 +60,7 @@ spec:
     outbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: "*"
+          namespace: "navno"
         - application: {{dekoratorenApp}}
       external:
         {{#each externalHosts as |host|}}
@@ -69,7 +69,7 @@ spec:
     inbound:
       rules:
         - application: {{revalidatorApp}}
-          namespace: "*"
+          namespace: "navno"
         - application: navno-xp-archive
   resources:
   {{#with resources}}


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Åpner inngående og utgående kall for `navno`. `personbruker` fjernes når alt er flyttet.
