### PR TITLE
Hardkoder data-nosnippet på oversiktssider

### DIFF
--- a/packages/nextjs/src/components/pages/oversikt-page/OversiktPage.tsx
+++ b/packages/nextjs/src/components/pages/oversikt-page/OversiktPage.tsx
@@ -56,7 +56,7 @@ export const OversiktPage = (props: OversiktPageProps) => {
     const audienceSubCategoryLinks = getLinksIfTransportPage(audienceAsArray);
 
     return (
-        <article className={style.page}>
+        <article className={style.page} data-nosnippet>
             <IllustrationStatic illustration={illustration} className={style.pictogram} />
             <div className={style.content}>
                 <OversiktHeader {...props} />


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter data-nosnippet på oversiktssider med mål om å slå av robots-nosnippets i CS. Målet er å teste om vi kan få Google til å faktisk hente description-metadataene istedet.

## Testing
Testes i dev