### PR TITLE
Mer presis overstyring av farge for piktogram

### DIFF
--- a/packages/nextjs/src/components/parts/seksjon-for-snarveier/SeksjonForSnarveier.module.scss
+++ b/packages/nextjs/src/components/parts/seksjon-for-snarveier/SeksjonForSnarveier.module.scss
@@ -80,10 +80,11 @@
 .item_provider {
     :global(.back) {
         svg {
-            path,
-            rect,
-            circle {
+            [fill] {
                 fill: var(--bg-color, var(--a-red-100));
+            }
+            [stroke] {
+                stroke: var(--bg-color, var(--a-red-100));
             }
         }
     }


### PR DESCRIPTION
Litt spissere styling som kun overstyrer farge på elementer i piktogram basert på om elementet har `fill` eller `stroke`.