### PR TITLE
Validere kalender dato for parsing

### DIFF
--- a/packages/nextjs/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryLegacyPart.tsx
+++ b/packages/nextjs/src/components/parts/_legacy/publishing-calendar/PublishingCalendarEntryLegacyPart.tsx
@@ -42,9 +42,8 @@ export const sortEntries = (
 };
 
 const processEntry = (item: PublishingCalendarEntryProps): PublishingCalendarEntryData => {
-    const publDate = Number.isNaN(new Date(item.data.date).getTime())
-        ? null
-        : new Date(item.data.date);
+    const dateObj = new Date(item.data.date);
+    const publDate = Number.isNaN(dateObj.getTime()) ? null : dateObj;
 
     if (publDate) {
         publDate.setHours(8); //Statistikk publiseres kl 08.00


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Forhåndsvisning av dato for kalenderhendelse feiler hvis redaktøren klikker "lagre" uten å ha lagt inn dato. Den lar seg ikke publisere, men feilen er nok til å gi oss Internal Server Error i loggene.

Denne fiksen bør gjøre det litt mere stille i loggen.


## Testing
Testet i dev2