### PR TITLE
Fikser feil hvor expandall=true ikke lenger fungerer

### DIFF
--- a/packages/nextjs/src/store/hooks/useCheckAndOpenTrekkspillPanel.ts
+++ b/packages/nextjs/src/store/hooks/useCheckAndOpenTrekkspillPanel.ts
@@ -8,13 +8,13 @@ export const useCheckAndOpenTrekkspillPanel = (
     expandAll: () => void
 ) => {
     const checkAndOpenPanels = useCallback(() => {
-        const targetId = window.location.hash.slice(1);
-        if (!targetId) return;
-
         if (window.location.search.includes('expandall=true')) {
             expandAll();
             return;
         }
+
+        const targetId = window.location.hash.slice(1);
+        if (!targetId) return;
 
         const targetElement = document.getElementById(targetId);
         const panelIndex = refs.findIndex((ref) => ref.current?.contains(targetElement));


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fikser hvor `expandall=true` ikke lenger fungerte for BOB.

Merk: Det er meningen at `expandall=true` skal override alt annet. Den skal ekspandere alle paneler uansett status og bruker kun av Bob, ikke i redaktørverktøy.

## Testing
Testes i dev2