### PR TITLE
Lagt til valg for expandAll i contentProps

### DIFF
--- a/packages/nextjs/src/components/_common/expandable/Expandable.tsx
+++ b/packages/nextjs/src/components/_common/expandable/Expandable.tsx
@@ -32,9 +32,9 @@ export const Expandable = ({
     ariaLabel,
     isOpenDefault,
 }: Props) => {
-    const [isOpen, setIsOpen] = useState(isOpenDefault ?? false);
-    const trekkspillRef = useRef<HTMLDivElement | null>(null);
     const contentProps = usePageContentProps();
+    const [isOpen, setIsOpen] = useState(isOpenDefault ?? contentProps.expandAll ?? false);
+    const trekkspillRef = useRef<HTMLDivElement | null>(null);
     const { context } = getDecoratorParams(contentProps);
 
     useSnarveier({ shortcut: Snarveier.SEARCH, callback: () => setIsOpen(true) });

--- a/packages/nextjs/src/components/_common/trekkspill/Trekkspill.tsx
+++ b/packages/nextjs/src/components/_common/trekkspill/Trekkspill.tsx
@@ -22,7 +22,9 @@ export const Trekkspill = ({ accordion }: TrekkspillRef) => {
     const contentProps = usePageContentProps();
     const { context } = getDecoratorParams(contentProps);
     const { editorView, type } = contentProps;
-    const [openTrekkspill, setOpenTrekkspill] = useState<number[]>([]);
+    const [openTrekkspill, setOpenTrekkspill] = useState<number[]>(() =>
+        contentProps.expandAll ? accordion.map((_, index) => index) : []
+    );
 
     const expandAll = () => setOpenTrekkspill(accordion.map((_, index) => index));
     const validatePanel = (item: PanelItem) => Boolean(item.title && item.html);

--- a/packages/nextjs/src/components/parts/readMorePart/ReadMorePart.tsx
+++ b/packages/nextjs/src/components/parts/readMorePart/ReadMorePart.tsx
@@ -23,9 +23,9 @@ export type PartConfigReadMore = {
 };
 
 export const ReadMorePart = ({ config }: PartComponentProps<PartType.ReadMore>) => {
-    const [isOpen, setIsOpen] = useState(config?.isOpen ?? false);
-    const divRef = useRef<HTMLDivElement | null>(null);
     const contentProps = usePageContentProps();
+    const [isOpen, setIsOpen] = useState(config?.isOpen ?? contentProps.expandAll ?? false);
+    const divRef = useRef<HTMLDivElement | null>(null);
     const { context } = getDecoratorParams(contentProps);
 
     useSnarveier({

--- a/packages/nextjs/src/types/content-props/_content-common.ts
+++ b/packages/nextjs/src/types/content-props/_content-common.ts
@@ -208,6 +208,7 @@ export type ContentCommonProps<Type extends ContentType = ContentType> = {
     languages?: LanguageProps[];
     contentLayer?: string;
     redirectToLayer?: LayerLocale;
+    expandAll?: boolean;
 } & ContentAndMediaCommonProps &
     VersionSelectorProps;
 


### PR DESCRIPTION
Støtte for å ekspandere alt innhold via contentProps. Brukes av akrivet som render sider med render-from-props. Se egen PR: https://github.com/navikt/navno-cms-archive/pull/264