### PR TITLE
Tillat at trekkspill kan lukkes selv om expandall er true

### DIFF
--- a/packages/nextjs/src/store/hooks/useCheckAndOpenPanel.ts
+++ b/packages/nextjs/src/store/hooks/useCheckAndOpenPanel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 
 export const useCheckAndOpenPanel = (
@@ -7,13 +7,28 @@ export const useCheckAndOpenPanel = (
     ref: React.RefObject<HTMLDivElement | null>,
     anchorId?: string
 ) => {
+    const hasHandledExpandAll = useRef(false);
+    const isOpenRef = useRef(isOpen);
+
+    useEffect(() => {
+        isOpenRef.current = isOpen;
+    }, [isOpen]);
+
     const checkAndOpenPanel = useCallback(() => {
-        if (isOpen) return;
+        if (isOpenRef.current) return;
+
+        if (!hasHandledExpandAll.current) {
+            hasHandledExpandAll.current = true;
+            if (window.location.search.includes('expandall=true')) {
+                setIsOpen(true);
+                return;
+            }
+        }
 
         const targetId = window.location.hash.slice(1);
         if (!targetId) return;
 
-        if (window.location.search.includes('expandall=true') || targetId === anchorId) {
+        if (targetId === anchorId) {
             setIsOpen(true);
             return;
         }
@@ -23,7 +38,7 @@ export const useCheckAndOpenPanel = (
             setIsOpen(true);
             setTimeout(() => smoothScrollToTarget(targetId), 500);
         }
-    }, [isOpen, setIsOpen, ref, anchorId]);
+    }, [anchorId, ref, setIsOpen]);
 
     useEffect(() => {
         window.addEventListener('hashchange', checkAndOpenPanel);

--- a/packages/nextjs/src/store/hooks/useCheckAndOpenTrekkspillPanel.ts
+++ b/packages/nextjs/src/store/hooks/useCheckAndOpenTrekkspillPanel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { smoothScrollToTarget } from 'utils/scroll-to';
 
 export const useCheckAndOpenTrekkspillPanel = (
@@ -7,10 +7,20 @@ export const useCheckAndOpenTrekkspillPanel = (
     refs: React.RefObject<HTMLDivElement | null>[],
     expandAll: () => void
 ) => {
+    const hasCalledExpandAll = useRef(false);
+    const openPanelsRef = useRef(openPanels);
+
+    useEffect(() => {
+        openPanelsRef.current = openPanels;
+    }, [openPanels]);
+
     const checkAndOpenPanels = useCallback(() => {
-        if (window.location.search.includes('expandall=true')) {
-            expandAll();
-            return;
+        if (!hasCalledExpandAll.current) {
+            hasCalledExpandAll.current = true;
+            if (window.location.search.includes('expandall=true')) {
+                expandAll();
+                return;
+            }
         }
 
         const targetId = window.location.hash.slice(1);
@@ -19,11 +29,11 @@ export const useCheckAndOpenTrekkspillPanel = (
         const targetElement = document.getElementById(targetId);
         const panelIndex = refs.findIndex((ref) => ref.current?.contains(targetElement));
 
-        if (panelIndex !== -1 && !openPanels.includes(panelIndex)) {
-            setOpenPanels([...openPanels, panelIndex]);
+        if (panelIndex !== -1 && !openPanelsRef.current.includes(panelIndex)) {
+            setOpenPanels([...openPanelsRef.current, panelIndex]);
             setTimeout(() => smoothScrollToTarget(targetId), 500);
         }
-    }, [openPanels, refs, setOpenPanels, expandAll]);
+    }, [refs, setOpenPanels, expandAll]);
 
     useEffect(() => {
         window.addEventListener('hashchange', checkAndOpenPanels);


### PR DESCRIPTION
Tillat at trekkspill etc kan lukkes selv om vi har `expandall=true` i URLen. Fikser også en infinite loop ved å trekke `openPanels` ut av `useCallback`. Gjorde det samme med `isOpen` så disse funksjonene ikke kjører mer enn de trenger.