### PR TITLE
Fiks avkuttet fokusmarkering i innholdsmenyen

### DIFF
--- a/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicDesktopNavigation/DynamicDesktopNavigation.module.scss
+++ b/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicDesktopNavigation/DynamicDesktopNavigation.module.scss
@@ -8,6 +8,12 @@
     height: max-content;
     max-height: calc(100vh - var(--a-spacing-6) - var(--decorator-sticky-offset));
     padding-bottom: var(--a-spacing-6);
+
+    // Gir plass til focus outline som ellers blir kuttet av overflow: auto
+    padding-left: var(--a-spacing-3);
+    padding-right: var(--a-spacing-3);
+    margin-left: calc(-1 * var(--a-spacing-3));
+    margin-right: calc(-1 * var(--a-spacing-3));
 }
 
 .heading {


### PR DESCRIPTION
<img width="459" height="268" alt="Screenshot 2026-02-03 at 09 43 00" src="https://github.com/user-attachments/assets/62a5bb36-3fd4-4692-b4ba-c8923de6afd6" />
