### PR TITLE
Luft rundt UX Signals widget

### DIFF
--- a/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.module.scss
+++ b/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.module.scss
@@ -23,3 +23,8 @@
         margin: 0;
     }
 }
+
+/*Fjerner unødvendig luft under widget, dersom den ligger over første kapittel */
+:global(.part:first-of-type) .uxSignalsWidget {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## Oppsummering av hva som er gjort

* Økte marginen over og under widget fra `--a-spacing-4` til `--a-spacing-7`. 
* Nullstiller marginen på bunnen av widgeten dersom den ligger i toppen

## Testing
Kun sjekket med manipulering av devtools, siden det var vrient å teste når frontend kjører med `npm run dev-custom`.