### PR TITLE
Filtrer bort tomme h3-lenker i innholdsmenyen

### DIFF
--- a/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicDesktopNavigation/DynamicDesktopNavigation.tsx
+++ b/packages/nextjs/src/components/_common/pageNavigationMenu/DynamicDesktopNavigation/DynamicDesktopNavigation.tsx
@@ -91,7 +91,8 @@ export const DynamicDesktopNavigation = ({
                             anchorId: getAnchorId(linkText),
                             linkText,
                         } as AnchorLink;
-                    });
+                    })
+                    .filter((link) => link.anchorId && link.linkText);
 
                 const h3: AnchorLink[] = [...headerH3, ...relatedSituationsH3];
 


### PR DESCRIPTION
<img width="238" height="124" alt="image" src="https://github.com/user-attachments/assets/ba77f770-d7a6-4a2e-8777-b16cfd5506af" />

**Bakgrunn**: [Siteimprove](https://my2.siteimprove.com/Inspector/1002489/A11Y/Page?pageId=70624888929&impmd=6DD5538FAB0E174F64D81B4146785183&issue=cantTell+failed&wcag=twopointtwo&decision=dismissed+falsePositive+none#/sia-r11/failed/U3BFSGM5T0w=;MDNhMGY0NjM=) oppdaget at på https://www.nav.no/jobbe-i-utlandet dukket det opp et tomt element i innholdsmenyen.

**Rotårsak**: I XP er "Overstyr tittel" satt til `" "` (mellomrom). Ser ut som redaksjonell hack for å skjule tittelen "Andre tilbud". Etter `.trim()` blir dette en tom streng, og da får vi en h3-lenke uten anchorId eller tekst i menyen.

**Løsningsforlag**: Filtrer ut h3-lenker som mangler `anchorId` eller `linkText`.