### PR TITLE
Varsel om å samtykke til cookies ved bruk av UX Signals-widget

### DIFF
--- a/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
+++ b/packages/nextjs/src/components/_common/uxsignalsWidget/UxSignalsWidget.tsx
@@ -71,7 +71,12 @@ const UxSignalsWidgetComponent = ({ embedCode }: UxSignalsWidgetProps) => {
     return (
         <aside>
             <div data-uxsignals-embed={embedCode} className={style.uxSignalsWidget} />
-            <EditorHelp text={'UX Signals rekrutterings-widget'} type={'info'} />
+            <EditorHelp
+                text={
+                    'UX Signals rekrutterings-widget: Husk at du må ha gitt samtykke til informasjonskapsler (cookies) for at denne widgeten skal synes i forhåndsvisningen. Du kan endre samtykket i footeren.'
+                }
+                type={'info'}
+            />
         </aside>
     );
 };

--- a/packages/nextjs/src/components/parts/uxsignals-widget/UxSignalsWidgetPart.tsx
+++ b/packages/nextjs/src/components/parts/uxsignals-widget/UxSignalsWidgetPart.tsx
@@ -2,34 +2,17 @@ import React from 'react';
 import { EditorHelp } from 'components/_editor-only/editorHelp/EditorHelp';
 import { UxSignalsWidget } from 'components/_common/uxsignalsWidget/UxSignalsWidget';
 import { PartComponentProps, PartType } from 'types/component-props/parts';
-import { usePageContentProps } from 'store/pageContext';
 
 export type PartConfigUxSignalsWidget = {
     embedCode: string;
 };
 
 export const UxSignalsWidgetPart = ({ config }: PartComponentProps<PartType.UxSignalsWidget>) => {
-    const { editorView } = usePageContentProps();
     if (!config?.embedCode) {
         return (
             <EditorHelp text={'Tom UXSignals komponent, sett inn en embed-kode'} type={'error'} />
         );
     }
 
-    const cookieInformation =
-        editorView === 'edit' ? (
-            <EditorHelp
-                text={
-                    'Merk! For å se undersøkelsen fra UX Signal i forhåndsvisningen i Enonic, må du samtykke til bruk av informasjonskapsler på nav.no. Du kan endre samtykke for informasjonskapsler på i footeren.'
-                }
-                type={'info'}
-            />
-        ) : null;
-
-    return (
-        <>
-            {cookieInformation}
-            <UxSignalsWidget embedCode={config.embedCode} />
-        </>
-    );
+    return <UxSignalsWidget embedCode={config.embedCode} />;
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det har vært litt forvirring rundt hvorfor UX Signals-widget ikke vises og det koker ned til at redaktørene har sagt nei til sporing. Da vises ikke UX Signals i forhåndsvisning heller. 

Denne PR'en legger bare inn en tekst som minner redaktørene om samtykket. Vi kunne nok lagt på en override, men redaktørene har også rett til å ikke gi samtykke på nav.no...

## Testing
Testet i dev