### PR TITLE
Fix: Kan ikke sette inn innholdsseksjon på situasjonssider

### DIFF
--- a/packages/nextjs/src/components/layouts/single-col-page/SingleColPage.module.scss
+++ b/packages/nextjs/src/components/layouts/single-col-page/SingleColPage.module.scss
@@ -6,13 +6,22 @@
     }
 
     .wrapperDiv {
-        display: contents;
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
     }
 
     .region {
-        display: contents;
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
+
         > * {
             grid-column: content-start;
+        }
+
+        > :global(.part__page-navigation-menu) {
+            grid-row: 1 / 999;
         }
     }
 }


### PR DESCRIPTION
Fikser #2772

Erstatter display:contents med subgrid slik at XP-editoren finner regionen og viser "Sett inn"-sonen på bred skjerm også.

Testet selv lokalt

<img width="858" height="409" alt="image" src="https://github.com/user-attachments/assets/89976b69-4e50-4fd1-9343-a44c9b232341" />
