### PR TITLE
Korrigerer feil lablet kontorside

### DIFF
--- a/packages/nextjs/src/types/content-props/_content-common.ts
+++ b/packages/nextjs/src/types/content-props/_content-common.ts
@@ -122,7 +122,7 @@ export const innholdsTypeMap: Record<ContentType, string> = {
     [ContentType.Pictograms]: 'Piktogram',
     [ContentType.PressLandingPage]: 'Landingsside for presse',
     [ContentType.OfficeEditorialPage]: 'Kontorside for redaktørinnhold',
-    [ContentType.OfficePage]: 'Kontorside (gammel)',
+    [ContentType.OfficePage]: 'Kontorside',
     [ContentType.PageList]: 'Artikkelliste',
     [ContentType.Artikkel]: 'Artikkel',
     [ContentType.Kapittel]: 'Kapittel',


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ser ut til at kontorsidene blir lablet med "gammel". Innholdstypen office-page er den som brukes på dagens kontorsider, så det er feil såvidt jeg kan se.

Det skaper dessverre litt støy i metabase en stund fremover med mindre vi har måter å endre alle "Kontorside (gammel)"?