### PR TITLE
Støtter longTitle i oversiktssider

### DIFF
--- a/packages/nextjs/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
+++ b/packages/nextjs/src/components/pages/forms-overview-page/forms-list/FormsOverviewList.tsx
@@ -52,7 +52,6 @@ export const FormsOverviewList = (props: FormsOverviewProps) => {
                       keys: [
                           { name: 'sortTitle', weight: 10 },
                           { name: 'formDetailsTitles', weight: 2 },
-                          { name: 'keywords', weight: 2 },
                           { name: 'ingress', weight: 1 },
                           { name: 'formDetailsIngresses', weight: 1 },
                           { name: 'title', weight: 1 },

--- a/packages/nextjs/src/components/pages/oversikt-page/forms-list/OversiktList.tsx
+++ b/packages/nextjs/src/components/pages/oversikt-page/forms-list/OversiktList.tsx
@@ -28,7 +28,6 @@ const getWeights = (oversiktType: OversiktPageData['oversiktType']) => {
     ) {
         return [
             { name: 'title', weight: 10 },
-            { name: 'keywords', weight: 2 },
             { name: 'ingress', weight: 1 },
             { name: 'itemList.title', weight: 1 },
         ];
@@ -40,7 +39,7 @@ const getWeights = (oversiktType: OversiktPageData['oversiktType']) => {
         { name: 'title', weight: 10 },
         { name: 'ingress', weight: 8 },
         { name: 'subItems.title', weight: 2 },
-        { name: 'keywords', weight: 2 },
+        { name: 'subItems.longTitle', weight: 2 },
         { name: 'subItems.ingress', weight: 1 },
         { name: 'subItems.formNumbers', weight: 1 },
     ];

--- a/packages/nextjs/src/components/pages/overview-page/OverviewPage.tsx
+++ b/packages/nextjs/src/components/pages/overview-page/OverviewPage.tsx
@@ -28,7 +28,6 @@ export const OverviewPage = (props: OverviewPageProps) => {
                     { name: 'title', weight: 10 },
                     { name: 'ingress', weight: 1 },
                     { name: 'productLinks.title', weight: 1 },
-                    { name: 'keywords', weight: 2 },
                 ],
             },
         }).then((result) => {

--- a/packages/nextjs/src/types/content-props/forms-overview.ts
+++ b/packages/nextjs/src/types/content-props/forms-overview.ts
@@ -12,7 +12,6 @@ export type SkjemadetaljerListItemProps = {
     title: string;
     sortTitle: string;
     ingress: string;
-    keywords: string[];
     url?: string;
     type: ContentTypeInFormOverviewPages;
     targetLanguage: string;

--- a/packages/nextjs/src/types/content-props/oversikt-props.ts
+++ b/packages/nextjs/src/types/content-props/oversikt-props.ts
@@ -44,6 +44,7 @@ export type OversiktAudienceOptions = OptionSetSingle<{
 export type OversiktSubItem = {
     path: string;
     title: string;
+    longTitle: string;
     ingress: string;
     type: ContentTypeInOversiktPages;
     formNumbers: string[];

--- a/packages/nextjs/src/types/content-props/oversikt-props.ts
+++ b/packages/nextjs/src/types/content-props/oversikt-props.ts
@@ -54,7 +54,6 @@ export type OversiktItemListItem = {
     title: string;
     sortTitle: string;
     ingress: string;
-    keywords: string[];
     url: string;
     type: ContentTypeInOversiktPages;
     targetLanguage: string;

--- a/packages/nextjs/src/types/content-props/overview-props.ts
+++ b/packages/nextjs/src/types/content-props/overview-props.ts
@@ -28,7 +28,6 @@ export type OverviewPageProductItem = {
     productLinks: OverviewPageProductLink[];
     taxonomy: ProductTaxonomy[];
     title: string;
-    keywords?: string[];
 };
 
 export type OverviewPageData = {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
I skjemadetaljer har redaktørene et eget felt for Søketittel. (Ukjent hvorfor denne heter `longTitle`, men det får vi ikke gjort så mye med uten å migrere schema).

`longTitle` er søkbar i selve nav.no-søket, men ikke på oversiktssidene (spesielt skjemaoversikt). Denne fiksen gjør `longTitle` søkbar her også, men med mindre vekt en hovedtittelen slik at vi ikke endrer for mye rangering.

Fjerner også `keywords` fra typer. Disse tok vi ut fra innholdstypene, men vi glemte typedefinesjonen i frontend.

## Testing
Testet i dev.