### PR TITLE
Downgrade pnpm/action-setup from v6 to v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,9 @@ updates:
       pull-request-branch-name:
           separator: '-'
       open-pull-requests-limit: 10
+      ignore:
+          - dependency-name: 'pnpm/action-setup'
+            versions: ['6']
       groups:
           actions:
               patterns: ['*']

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Setup Pages
               uses: actions/configure-pages@v6
             - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:

--- a/.github/workflows/visual-changes-bot.yml
+++ b/.github/workflows/visual-changes-bot.yml
@@ -24,7 +24,7 @@ jobs:
               with:
                   ref: ${{ github.event_name == 'pull_request' && steps.comment-branch.outputs.head_ref || github.ref }}
             - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@v5
             - uses: actions/setup-node@v6
               with:
                   node-version: '24'


### PR DESCRIPTION
pnpm/action-setup v6 (auto-bumped by dependabot in #2833) uses corepack
internally, which corrupts pnpm-lock.yaml by prepending a 94-line YAML
document with pnpm's own dependencies. This breaks all `--frozen-lockfile`
installs.

Multiple upstream issues confirm v6 is broken:
- pnpm/action-setup#226
- pnpm/action-setup#228
- pnpm/action-setup#225
- pnpm/action-setup#227

### Changes
- Downgrade `pnpm/action-setup` from v6 to v5 in `deploy-storybook.yml` and `visual-changes-bot.yml`
- Add dependabot ignore rule for v6 (allows v7+ when available)