### PR TITLE
Grå sirkel kontaktikoner

### DIFF
--- a/packages/nextjs/src/components/_common/kontakt-oss-kanal/_shared-utils/icon/Icon.module.scss
+++ b/packages/nextjs/src/components/_common/kontakt-oss-kanal/_shared-utils/icon/Icon.module.scss
@@ -1,19 +1,19 @@
 .icon {
     align-items: center;
     align-self: flex-start;
-    background-color: var(--ax-bg-accent-soft);
+    background-color: var(--kontakt-icon-bg, var(--ax-neutral-100));
     border-radius: var(--ax-radius-full);
     display: flex;
     flex: 1;
     justify-content: center;
-    min-height: var(--ax-space-40);
-    min-width: var(--ax-space-40);
-    max-height: var(--ax-space-40);
-    max-width: var(--ax-space-40);
-    margin-top: calc(-1 * var(--ax-space-6));
+    min-height: var(--ax-space-44);
+    min-width: var(--ax-space-44);
+    max-height: var(--ax-space-44);
+    max-width: var(--ax-space-44);
+    margin-top: -0.5rem;
 
     img {
-        width: var(--ax-space-20);
+        width: 25px;
         height: auto;
     }
 }

--- a/packages/nextjs/src/components/_common/kontakt-oss-kanal/_shared-utils/icon/Icon.module.scss
+++ b/packages/nextjs/src/components/_common/kontakt-oss-kanal/_shared-utils/icon/Icon.module.scss
@@ -1,19 +1,19 @@
 .icon {
     align-items: center;
     align-self: flex-start;
-    background-color: var(--ax-bg-default);
+    background-color: var(--ax-bg-accent-soft);
     border-radius: var(--ax-radius-full);
     display: flex;
     flex: 1;
     justify-content: center;
-    min-height: var(--ax-space-44);
-    min-width: var(--ax-space-44);
-    max-height: var(--ax-space-44);
-    max-width: var(--ax-space-44);
-    margin-top: -0.5rem;
+    min-height: var(--ax-space-40);
+    min-width: var(--ax-space-40);
+    max-height: var(--ax-space-40);
+    max-width: var(--ax-space-40);
+    margin-top: calc(-1 * var(--ax-space-6));
 
     img {
-        width: 25px;
+        width: var(--ax-space-20);
         height: auto;
     }
 }

--- a/packages/nextjs/src/components/layouts/flex-cols/FlexColsLayout.module.scss
+++ b/packages/nextjs/src/components/layouts/flex-cols/FlexColsLayout.module.scss
@@ -72,6 +72,7 @@
 
     &:has(:global(.part__contact-option)) {
         @include contactBackground();
+        --kontakt-icon-bg: var(--ax-bg-default);
         padding-top: var(--ax-space-80);
 
         .contentWrapper {

--- a/packages/nextjs/src/components/layouts/flex-cols/FlexColsLayout.module.scss
+++ b/packages/nextjs/src/components/layouts/flex-cols/FlexColsLayout.module.scss
@@ -5,6 +5,7 @@
     background-color: var(
         --ax-neutral-100
     ) !important; // To override inline colors set in XP (to be changed in the future)
+    --kontakt-icon-bg: var(--ax-bg-default);
     --size: 6px;
     --p: 3px;
     --R: 6px;
@@ -72,7 +73,6 @@
 
     &:has(:global(.part__contact-option)) {
         @include contactBackground();
-        --kontakt-icon-bg: var(--ax-bg-default);
         padding-top: var(--ax-space-80);
 
         .contentWrapper {

--- a/packages/nextjs/src/components/parts/seksjon-for-kontaktinformasjon/SeksjonForKontaktinformasjonPart.module.scss
+++ b/packages/nextjs/src/components/parts/seksjon-for-kontaktinformasjon/SeksjonForKontaktinformasjonPart.module.scss
@@ -3,7 +3,6 @@
 .container {
     @include common.full-width-mixin();
 
-    --kontakt-icon-bg: var(--ax-bg-default);
     background-color: var(--ax-brand-blue-100);
     padding-top: var(--ax-space-36);
     padding-bottom: var(--ax-space-44);

--- a/packages/nextjs/src/components/parts/seksjon-for-kontaktinformasjon/SeksjonForKontaktinformasjonPart.module.scss
+++ b/packages/nextjs/src/components/parts/seksjon-for-kontaktinformasjon/SeksjonForKontaktinformasjonPart.module.scss
@@ -3,6 +3,7 @@
 .container {
     @include common.full-width-mixin();
 
+    --kontakt-icon-bg: var(--ax-bg-default);
     background-color: var(--ax-brand-blue-100);
     padding-top: var(--ax-space-36);
     padding-bottom: var(--ax-space-44);


### PR DESCRIPTION
Snakket med Martin om å sette grå farge på sirkelen når bakgrunnen er hvit, som på f.eks. nav.no/arbeid

<img width="383" height="441" alt="image" src="https://github.com/user-attachments/assets/b9dfdee2-190a-4476-a5c7-4bddb5f5dd83" />



Fortsatt hvit sirkel på grå bakgrunn:
<img width="484" height="539" alt="image" src="https://github.com/user-attachments/assets/06706272-4e2a-45a4-a478-385a8040aac5" />

