### PR TITLE
Håndterer videresending til innholdsobjekt

### DIFF
--- a/packages/nextjs/src/types/component-props/_mixins.ts
+++ b/packages/nextjs/src/types/component-props/_mixins.ts
@@ -1,5 +1,5 @@
 import { ContentListProps } from 'types/content-props/content-list-props';
-import { ContentProps } from 'types/content-props/_content-common';
+import { ContentAndMediaCommonProps, ContentProps } from 'types/content-props/_content-common';
 import { PictogramsProps } from 'types/content-props/pictograms';
 import { Taxonomy } from 'types/taxonomies';
 import { AuthStateType } from 'store/slices/authState';
@@ -97,6 +97,7 @@ export type ProductDataMixin = {
     illustration: PictogramsProps;
     area: Area[];
     externalProductUrl?: string;
+    externalContentRedirect?: ContentAndMediaCommonProps;
 };
 
 export type LinkSelectable = OptionSetSingle<{

--- a/packages/nextjs/src/utils/redirects.ts
+++ b/packages/nextjs/src/utils/redirects.ts
@@ -10,16 +10,25 @@ const redirectTypes: { [type in ContentType]?: boolean } = {
 };
 
 type ContentWithExternalProductUrl = ContentProps & {
-    data: Pick<ProductDataMixin, 'externalProductUrl'>;
+    data: Pick<ProductDataMixin, 'externalProductUrl' | 'externalContentRedirect'>;
 };
 
-const hasExternalProductUrl = (content: ContentProps): content is ContentWithExternalProductUrl => {
-    return !!(content as ContentWithExternalProductUrl).data?.externalProductUrl;
+const getExternalRedirectUrl = (content: ContentWithExternalProductUrl): string | null => {
+    if (content.isDraft || content.isPagePreview) {
+        return null;
+    }
+
+    const externalProductUrl =
+        content.data.externalProductUrl || content.data.externalContentRedirect?._path;
+
+    return externalProductUrl ?? null;
 };
 
 const getTargetPath = (content: ContentProps) => {
-    if (hasExternalProductUrl(content)) {
-        return content.isDraft || content.isPagePreview ? null : content.data.externalProductUrl;
+    const externalRedirectUrl = getExternalRedirectUrl(content as ContentWithExternalProductUrl);
+
+    if (externalRedirectUrl) {
+        return externalRedirectUrl;
     }
 
     switch (content.type) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sider (spesielt skyggesider) kan i dag videresende til URL. Redaktørene trenger også å kunne videresende til et konkret innholdsobjekt (via _path) som gir bedre visning av interne avhengigheter i XP.

## Testing
Testes i dev