### PR TITLE
Øker minnegrense i prod

### DIFF
--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -3,19 +3,19 @@ revalidatorApp: nav-enonicxp-frontend-revalidator-proxy
 failoverApp: nav-enonicxp-frontend-failover
 dekoratorenApp: nav-dekoratoren
 externalHosts:
-    - www.nav.no
-    - www-failover.nav.no
+  - www.nav.no
+  - www-failover.nav.no
 secret: nav-enonicxp
 ingresses:
-    - https://www.nav.no
+  - https://www.nav.no
 resources:
-    requests:
-        cpu: 600m
-        memory: 2560Mi
-    limits:
-        memory: 4096Mi
+  requests:
+    cpu: 600m
+    memory: 2560Mi
+  limits:
+    memory: 4096Mi
 valkey:
-    plan: startup-4
-    project: nav-prod
-    instance: pagecache
-    endpointId: 76685598-1048-4f56-b34a-9769ef747a92
+  plan: startup-4
+  project: nav-prod
+  instance: pagecache
+  endpointId: 76685598-1048-4f56-b34a-9769ef747a92

--- a/.nais/vars/vars-prod.yml
+++ b/.nais/vars/vars-prod.yml
@@ -3,19 +3,19 @@ revalidatorApp: nav-enonicxp-frontend-revalidator-proxy
 failoverApp: nav-enonicxp-frontend-failover
 dekoratorenApp: nav-dekoratoren
 externalHosts:
-  - www.nav.no
-  - www-failover.nav.no
+    - www.nav.no
+    - www-failover.nav.no
 secret: nav-enonicxp
 ingresses:
-  - https://www.nav.no
+    - https://www.nav.no
 resources:
-  requests:
-    cpu: 600m
-    memory: 1536Mi
-  limits:
-    memory: 4096Mi
+    requests:
+        cpu: 600m
+        memory: 2560Mi
+    limits:
+        memory: 4096Mi
 valkey:
-  plan: startup-4
-  project: nav-prod
-  instance: pagecache
-  endpointId: 76685598-1048-4f56-b34a-9769ef747a92
+    plan: startup-4
+    project: nav-prod
+    instance: pagecache
+    endpointId: 76685598-1048-4f56-b34a-9769ef747a92


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ser ut til at poddene hele tiden når taket for garantert minne. De går over en stund før det ser ut tilat de kneler. Foreslår i en periode å øke minne for å se om det flater seg ut eller om vi må gjøre andre tiltak.


## Testing
Dette er minnebruk i prod, så må nesten bare da det ut der.