### PR TITLE
Add logAnalyticsEvent and Events proxy to mock analytics functionality

### DIFF
--- a/packages/nextjs/.storybook/main.ts
+++ b/packages/nextjs/.storybook/main.ts
@@ -22,7 +22,7 @@ const config: StorybookConfig = {
                 alias: {
                     ...config.resolve?.alias,
                     common: path.resolve(__dirname, '../src/common.scss'),
-                    '@navikt/nav-dekoratoren-moduler': path.resolve(
+                    '@navikt/nav-dekoratoren-moduler$': path.resolve(
                         __dirname,
                         'mocks/nav-dekoratoren-moduler.js'
                     ),

--- a/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
+++ b/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
@@ -4,3 +4,15 @@ export const getCurrentConsent = () => ({
 });
 
 export const setParams = () => {};
+
+export const logAnalyticsEvent = () => Promise.resolve();
+
+// Mirrors the Events export from @navikt/nav-dekoratoren-moduler.
+// Proxy returns the property name as string for any access, so any new event
+// added upstream still resolves to a usable value in Storybook.
+export const Events = new Proxy(
+    {},
+    {
+        get: (_target, prop) => (typeof prop === 'string' ? prop : undefined),
+    }
+);

--- a/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
+++ b/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
@@ -1,3 +1,5 @@
+export { Events } from '@navikt/analytics-types';
+
 export const getCurrentConsent = () => ({
     consent: { analytics: true, surveys: true },
     userActionTaken: true,
@@ -6,13 +8,3 @@ export const getCurrentConsent = () => ({
 export const setParams = () => {};
 
 export const logAnalyticsEvent = () => Promise.resolve();
-
-// Mirrors the Events export from @navikt/nav-dekoratoren-moduler.
-// Proxy returns the property name as string for any access, so any new event
-// added upstream still resolves to a usable value in Storybook.
-export const Events = new Proxy(
-    {},
-    {
-        get: (_target, prop) => (typeof prop === 'string' ? prop : undefined),
-    }
-);

--- a/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
+++ b/packages/nextjs/.storybook/mocks/nav-dekoratoren-moduler.js
@@ -1,4 +1,4 @@
-export { Events } from '@navikt/analytics-types';
+export { Events } from '@navikt/nav-dekoratoren-moduler/csr/index.js';
 
 export const getCurrentConsent = () => ({
     consent: { analytics: true, surveys: true },


### PR DESCRIPTION
Fikser noen stories som feilet slik:

<img width="1088" height="536" alt="image" src="https://github.com/user-attachments/assets/f442c15c-5427-4c89-ae20-c59e3b56b9a5" />

(Tenker også å lage et issue på at visual changes bot bør flagge mer tydelig tester som krasjer)