### PR TITLE
Fjerner timeout ved blocking av mistenkelig url

### DIFF
--- a/packages/server/src/req-handlers/path-validation-middleware.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.ts
@@ -109,7 +109,7 @@ export const buildPathValidationMiddleware =
                     const xpUrl = `${process.env.XP_ORIGIN}${req.path}`;
                     return res.redirect(307, xpUrl); // 307 = Temporary Redirect, preserves method
                 }
-                return next();
+                next();
             } else {
                 logger.warn(`Blocked unknown XP path: ${req.method} ${req.path} from ${req.ip}`);
                 return badRequest();

--- a/packages/server/src/req-handlers/path-validation-middleware.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.ts
@@ -70,14 +70,8 @@ export const buildPathValidationMiddleware =
                 // Flagg for at Bad request er håndtert kan ikke settes under testing
                 req.headers['x-nav-blocked-path'] = 'true';
             }
-            return new Promise<void>((resolve) => {
-                setTimeout(
-                    () => {
-                        nextApp.renderError(null, req, res, fullPath).then(resolve);
-                    },
-                    1000 + Math.random() * 2000
-                );
-            });
+
+            return nextApp.renderError(null, req, res, fullPath).catch(next);
         };
 
         // Check for excessively long paths early (prevents wasting CPU on regex for huge strings)
@@ -115,7 +109,7 @@ export const buildPathValidationMiddleware =
                     const xpUrl = `${process.env.XP_ORIGIN}${req.path}`;
                     return res.redirect(307, xpUrl); // 307 = Temporary Redirect, preserves method
                 }
-                next();
+                return next();
             } else {
                 logger.warn(`Blocked unknown XP path: ${req.method} ${req.path} from ${req.ip}`);
                 return badRequest();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ops får til tider varsel om treghet fra nav.no. Ved mange fuzz-forsøk (alle mulige varianter av paths som vi ikke godtar) så trigger det varsler hos Ops.

Jeg foreslår at vi dropper dette, i hvert fall nå i en periode hvor det har vært mye ustabilitet i nettverk og andre varsler.

## Testing
Testes i dev.