### PR TITLE
Mellomsteg: Fjerner steplist (ul) når denne er tom

### DIFF
--- a/packages/nextjs/src/components/layouts/mellomsteg/MellomstegLayout.tsx
+++ b/packages/nextjs/src/components/layouts/mellomsteg/MellomstegLayout.tsx
@@ -31,7 +31,6 @@ export const MellomstegLayout = ({
     analyticsComponent,
 }: Props) => {
     const { title, illustration, textAboveTitle, editorial, formNumbers, displayName } = data;
-
     const currentTitle = title ?? displayName;
 
     return (
@@ -45,7 +44,7 @@ export const MellomstegLayout = ({
             />
             <div className={style.content}>
                 {editorial && <ParsedHtml htmlProps={editorial} />}
-                <ul className={style.stepList}>{listItems}</ul>
+                {listItems && <ul className={style.stepList}>{listItems}</ul>}
                 {backLink ? (
                     <LenkeInline
                         href={backLink.target._path}

--- a/packages/nextjs/src/components/pages/contactStepPage/ContactStepPage.tsx
+++ b/packages/nextjs/src/components/pages/contactStepPage/ContactStepPage.tsx
@@ -23,20 +23,24 @@ export const ContactStepPage = ({ data }: ContactStepPageProps) => {
     return (
         <MellomstegLayout
             data={data}
-            listItems={linkPanels.map((linkPanel, index) => {
-                const linkPaneltitle = linkPanel.text ?? linkPanel.target.displayName;
-                return (
-                    <li key={`${linkPanel.target._path}-${index}`}>
-                        <FormIntermediateStepLink
-                            label={linkPaneltitle}
-                            explanation={linkPanel.ingress ?? ''}
-                            href={linkPanel.target._path}
-                            analyticsComponent={'ContactStepPage'}
-                            analyticsLabel={linkPaneltitle}
-                        />
-                    </li>
-                );
-            })}
+            listItems={
+                linkPanels.length > 0
+                    ? linkPanels.map((linkPanel, index) => {
+                          const linkPaneltitle = linkPanel.text ?? linkPanel.target.displayName;
+                          return (
+                              <li key={`${linkPanel.target._path}-${index}`}>
+                                  <FormIntermediateStepLink
+                                      label={linkPaneltitle}
+                                      explanation={linkPanel.ingress ?? ''}
+                                      href={linkPanel.target._path}
+                                      analyticsComponent={'ContactStepPage'}
+                                      analyticsLabel={linkPaneltitle}
+                                  />
+                              </li>
+                          );
+                      })
+                    : undefined
+            }
             analyticsComponent={'ContactStepPage'}
             backLink={
                 backLink?.target

--- a/packages/nextjs/src/components/pages/formIntermediateStepPage/FormIntermediateStepPage.tsx
+++ b/packages/nextjs/src/components/pages/formIntermediateStepPage/FormIntermediateStepPage.tsx
@@ -49,16 +49,20 @@ export const FormIntermediateStepPage = (props: FormIntermediateStepPageProps) =
                 title: currentStepData.title ?? displayName,
                 editorial: currentStepData.editorial,
             }}
-            listItems={currentStepData.steps.map((step) => (
-                <li key={step.label}>
-                    <FormIntermediateStepLink
-                        {...step}
-                        analyticsComponent={'FormIntermediateStepPage'}
-                        analyticsLabel={step.label}
-                        formNumber={step.formNumber}
-                    />
-                </li>
-            ))}
+            listItems={
+                currentStepData.steps.length > 0
+                    ? currentStepData.steps.map((step) => (
+                          <li key={step.label}>
+                              <FormIntermediateStepLink
+                                  {...step}
+                                  analyticsComponent={'FormIntermediateStepPage'}
+                                  analyticsLabel={step.label}
+                                  formNumber={step.formNumber}
+                              />
+                          </li>
+                      ))
+                    : undefined
+            }
             backLink={
                 backUrl
                     ? {


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Fjerner steplist (ul) når denne er tom. 
Gjelder `MellomstegLayout`, kalles fra 
- `FormIntermediateStepPage`
- `ContactStepPage`

## Testing
Har testet selv i dev2