### PR TITLE
Blokkerer IIS backslash-forsøk

### DIFF
--- a/packages/server/src/req-handlers/path-validation-middleware.test.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.test.ts
@@ -143,11 +143,6 @@ describe('Path Validation Middleware', () => {
             expect(mockRes.statusCode).toBe(400);
             expect(nextFunction).not.toHaveBeenCalled();
         });
-        test('should block IIS backslash hack (%5C encoded)', () => {
-            runMiddleware('/index.asp%5C');
-            expect(renderErrorSpy).toHaveBeenCalled();
-            expect(nextFunction).not.toHaveBeenCalled();
-        });
         test('should block IIS backslash hack (lowercase %5c)', () => {
             runMiddleware('/index.asp%5c');
             expect(mockRes.statusCode).toBe(400);

--- a/packages/server/src/req-handlers/path-validation-middleware.test.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.test.ts
@@ -143,9 +143,29 @@ describe('Path Validation Middleware', () => {
             expect(mockRes.statusCode).toBe(400);
             expect(nextFunction).not.toHaveBeenCalled();
         });
-        test('should block backslash IIS hack', () => {
+        test('should block IIS backslash hack (%5C encoded)', () => {
             runMiddleware('/index.asp%5C');
             expect(renderErrorSpy).toHaveBeenCalled();
+            expect(nextFunction).not.toHaveBeenCalled();
+        });
+        test('should block IIS backslash hack (lowercase %5c)', () => {
+            runMiddleware('/index.asp%5c');
+            expect(mockRes.statusCode).toBe(400);
+            expect(nextFunction).not.toHaveBeenCalled();
+        });
+        test('should block IIS backslash hack (literal backslash)', () => {
+            runMiddleware('/index.asp\\');
+            expect(mockRes.statusCode).toBe(400);
+            expect(nextFunction).not.toHaveBeenCalled();
+        });
+        test('should block IIS backslash hack (mid-path backslash after extension)', () => {
+            runMiddleware('/index.php%5Cother');
+            expect(mockRes.statusCode).toBe(400);
+            expect(nextFunction).not.toHaveBeenCalled();
+        });
+        test('should block IIS backslash hack (double-encoded %255C)', () => {
+            runMiddleware('/index.asp%255C');
+            expect(mockRes.statusCode).toBe(400);
             expect(nextFunction).not.toHaveBeenCalled();
         });
     });

--- a/packages/server/src/req-handlers/path-validation-middleware.test.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.test.ts
@@ -143,6 +143,11 @@ describe('Path Validation Middleware', () => {
             expect(mockRes.statusCode).toBe(400);
             expect(nextFunction).not.toHaveBeenCalled();
         });
+        test('should block backslash IIS hack', () => {
+            runMiddleware('/index.asp%5C');
+            expect(renderErrorSpy).toHaveBeenCalled();
+            expect(nextFunction).not.toHaveBeenCalled();
+        });
     });
 
     describe('Path Traversal attempts', () => {

--- a/packages/server/src/req-handlers/path-validation-middleware.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.ts
@@ -7,7 +7,6 @@ import { InferredNextWrapperServer } from 'server';
 const MALICIOUS_PATTERNS = [
     // SQL Injection patterns
     /(%27)|'/i,
-    /(%5C)|'/i,
     /((%3D)|(=))[^\n]*((%27)|'|(--)|(%3B)|;)/i,
     /\w*((%27)|')((%6F)|o|(%4F))((%72)|r|(%52))/i,
     // XSS patterns
@@ -18,6 +17,11 @@ const MALICIOUS_PATTERNS = [
     /;|\||`|\$\(|&&/,
     // Path traversal
     /\.\.+[/\\]/,
+    // IIS backslash hack: %5C is decoded to \ by Express/nginx before reaching req.path.
+    // Also block the raw encoded form for environments that skip decoding.
+    /(%5C)|'/i,
+    /\\/,
+    /%5[cC]/,
     // Null bytes
     /\0|%00/,
     // Common attack vectors

--- a/packages/server/src/req-handlers/path-validation-middleware.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.ts
@@ -7,6 +7,7 @@ import { InferredNextWrapperServer } from 'server';
 const MALICIOUS_PATTERNS = [
     // SQL Injection patterns
     /(%27)|'/i,
+    /(%5C)|'/i,
     /((%3D)|(=))[^\n]*((%27)|'|(--)|(%3B)|;)/i,
     /\w*((%27)|')((%6F)|o|(%4F))((%72)|r|(%52))/i,
     // XSS patterns


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ingen sikkerhetsbrist egentlig, men skaper mindre støy i loggene.
%5C er en grep for å utnytte IIS-svakheter.

## Testing
Testes i dev