### PR TITLE
Fjerner ariaLabel på ProductDetailsPart 

### DIFF
--- a/packages/nextjs/src/components/parts/product-details/ProductDetailsPart.tsx
+++ b/packages/nextjs/src/components/parts/product-details/ProductDetailsPart.tsx
@@ -60,25 +60,12 @@ export const ProductDetailsPart = ({ config }: PartComponentProps<PartType.Produ
     };
 
     const expandableType = config.detailType as unknown as ExpandableMixin['type'];
-    const visibilityType = config.processingTimesVisibility;
-    const getProductDetailsLabel = translator('productDetailTypes', pageContent.language);
-    const getVisibilityLabel = translator('processingTimesVisibilityTypes', pageContent.language);
-    const ariaLabel =
-        expandableType === ProductDetailType.PROCESSING_TIMES && visibilityType
-            ? `${getProductDetailsLabel(ProductDetailType.PROCESSING_TIMES)} ${getVisibilityLabel(
-                  visibilityType
-              )}`
-            : undefined;
 
     return (
         <div className={style.productDetails}>
             <PageContextProvider content={pageContent}>
                 <FilteredContent {...config}>
-                    <ExpandableComponentWrapper
-                        type={expandableType}
-                        ariaLabel={ariaLabel}
-                        {...config}
-                    >
+                    <ExpandableComponentWrapper type={expandableType} {...config}>
                         {components.map((component) => (
                             <ComponentMapper
                                 key={component.path}


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Fjerner generisk ariaLabel på produktdetaljer, skjermleser vil uansett lese opp teksten på den ekspanderbare knappen.
Unngår da at label blir noe annet en teksten på knappen (UU brudd)

## Testing
Har testet selv lokalt, kan testes på dev3
https://www-3.ansatt.dev.nav.no/aap#sok

