### PR TITLE
Prom improvements

### DIFF
--- a/packages/nextjs/src/components/_common/varselboks/Varselboks.tsx
+++ b/packages/nextjs/src/components/_common/varselboks/Varselboks.tsx
@@ -8,6 +8,7 @@ type Props = PropsWithChildren<{
     size?: AlertProps['size'];
     inline?: AlertProps['inline'];
     className?: string;
+    'data-color'?: string;
 }> &
     React.HTMLAttributes<HTMLDivElement>;
 

--- a/packages/server/jest.config.mjs
+++ b/packages/server/jest.config.mjs
@@ -11,5 +11,6 @@ export default {
     moduleNameMapper: {
         '@/shared/(.*)': '<rootDir>/../shared/src/$1',
         '^cache/(.*)$': '<rootDir>/src/cache/$1',
+        '^metrics/(.*)$': '<rootDir>/src/metrics/$1',
     },
 };

--- a/packages/server/src/cache/page-cache-handler.ts
+++ b/packages/server/src/cache/page-cache-handler.ts
@@ -38,7 +38,7 @@ export default class PageCacheHandler {
             }
 
             if (fromLocalCache && isCacheEntryValid(fromLocalCache)) {
-                pageCacheOperationsCounter.inc({ operation: 'get', source: 'local' });
+                pageCacheOperationsCounter.inc({ operation: 'get', source: 'next' });
                 return fromLocalCache;
             }
 
@@ -52,7 +52,7 @@ export default class PageCacheHandler {
 
             const fromRedisCache = await redisCache.getRender(key);
             if (!fromRedisCache) {
-                pageCacheOperationsCounter.inc({ operation: 'get', source: 'miss' });
+                pageCacheOperationsCounter.inc({ operation: 'get', source: 'xp' });
                 return null;
             }
 
@@ -74,7 +74,7 @@ export default class PageCacheHandler {
             lastModified: Date.now(),
         };
 
-        pageCacheOperationsCounter.inc({ operation: 'set', source: 'local' });
+        pageCacheOperationsCounter.inc({ operation: 'set', source: 'next' });
         localCache.set(key, cacheItem);
         redisCache.setRender(key, cacheItem);
     }

--- a/packages/server/src/cache/page-cache-handler.ts
+++ b/packages/server/src/cache/page-cache-handler.ts
@@ -5,6 +5,7 @@ import { CacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
 import { RedisCache } from '@/shared/redis_local';
 import { pathToCacheKey } from '@/shared/cache-key';
 import { logger } from '@/shared/logger';
+import { pageCacheOperationsCounter } from 'metrics/request-metrics';
 
 export const redisCache = new RedisCache();
 
@@ -37,6 +38,7 @@ export default class PageCacheHandler {
             }
 
             if (fromLocalCache && isCacheEntryValid(fromLocalCache)) {
+                pageCacheOperationsCounter.inc({ operation: 'get', source: 'local' });
                 return fromLocalCache;
             }
 
@@ -50,9 +52,11 @@ export default class PageCacheHandler {
 
             const fromRedisCache = await redisCache.getRender(key);
             if (!fromRedisCache) {
+                pageCacheOperationsCounter.inc({ operation: 'get', source: 'miss' });
                 return null;
             }
 
+            pageCacheOperationsCounter.inc({ operation: 'get', source: 'redis' });
             localCache.set(key, fromRedisCache);
 
             return fromRedisCache;
@@ -70,6 +74,7 @@ export default class PageCacheHandler {
             lastModified: Date.now(),
         };
 
+        pageCacheOperationsCounter.inc({ operation: 'set', source: 'local' });
         localCache.set(key, cacheItem);
         redisCache.setRender(key, cacheItem);
     }

--- a/packages/server/src/health/health-metrics.ts
+++ b/packages/server/src/health/health-metrics.ts
@@ -1,11 +1,15 @@
-import { Counter, Gauge } from 'prom-client';
+import { Counter, Gauge, register } from 'prom-client';
 
-export const healthProbeFailuresCounter = new Counter({
-    name: 'health_probe_failures_total',
-    help: 'Total number of failed health probes',
-});
+export const healthProbeFailuresCounter =
+    (register.getSingleMetric('health_probe_failures_total') as Counter) ??
+    new Counter({
+        name: 'health_probe_failures_total',
+        help: 'Total number of failed health probes',
+    });
 
-export const healthStatusGauge = new Gauge({
-    name: 'health_status',
-    help: 'Health status (1 = healthy, 0 = unhealthy)',
-});
+export const healthStatusGauge =
+    (register.getSingleMetric('health_status') as Gauge) ??
+    new Gauge({
+        name: 'health_status',
+        help: 'Health status (1 = healthy, 0 = unhealthy)',
+    });

--- a/packages/server/src/metrics/request-metrics.ts
+++ b/packages/server/src/metrics/request-metrics.ts
@@ -1,0 +1,13 @@
+import { Counter } from 'prom-client';
+
+export const blockedRequestsCounter = new Counter({
+    name: 'blocked_requests_total',
+    help: 'Total number of requests blocked by path validation',
+    labelNames: ['reason'],
+});
+
+export const pageCacheOperationsCounter = new Counter({
+    name: 'page_cache_operations_total',
+    help: 'Total page cache operations',
+    labelNames: ['operation', 'source'],
+});

--- a/packages/server/src/metrics/request-metrics.ts
+++ b/packages/server/src/metrics/request-metrics.ts
@@ -1,13 +1,17 @@
-import { Counter } from 'prom-client';
+import { Counter, register } from 'prom-client';
 
-export const blockedRequestsCounter = new Counter({
-    name: 'blocked_requests_total',
-    help: 'Total number of requests blocked by path validation',
-    labelNames: ['reason'],
-});
+export const blockedRequestsCounter =
+    (register.getSingleMetric('blocked_requests_total') as Counter) ??
+    new Counter({
+        name: 'blocked_requests_total',
+        help: 'Total number of requests blocked by path validation',
+        labelNames: ['reason'],
+    });
 
-export const pageCacheOperationsCounter = new Counter({
-    name: 'page_cache_operations_total',
-    help: 'Total page cache operations',
-    labelNames: ['operation', 'source'],
-});
+export const pageCacheOperationsCounter =
+    (register.getSingleMetric('page_cache_operations_total') as Counter) ??
+    new Counter({
+        name: 'page_cache_operations_total',
+        help: 'Total page cache operations',
+        labelNames: ['operation', 'source'],
+    });

--- a/packages/server/src/req-handlers/path-validation-middleware.ts
+++ b/packages/server/src/req-handlers/path-validation-middleware.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { logger } from '@/shared/logger';
 import { XP_PATHS } from '@/shared/constants';
 import { InferredNextWrapperServer } from 'server';
+import { blockedRequestsCounter } from 'metrics/request-metrics';
 
 // Common injection patterns to block
 const MALICIOUS_PATTERNS = [
@@ -81,6 +82,7 @@ export const buildPathValidationMiddleware =
 
         // Check for excessively long paths early (prevents wasting CPU on regex for huge strings)
         if (fullPath.length > 500) {
+            blockedRequestsCounter.inc({ reason: 'long_path' });
             logger.warn(
                 `Blocked excessively long path: ${req.method} ${fullPath.substring(0, 100)}... from ${req.ip}`
             );
@@ -91,13 +93,14 @@ export const buildPathValidationMiddleware =
         try {
             decodedPath = decodeURIComponent(fullPath);
         } catch {
-            // Malformed URI - treat as suspicious
+            blockedRequestsCounter.inc({ reason: 'malformed_uri' });
             logger.warn(`Blocked malformed URI: ${req.method} ${fullPath} from ${req.ip}`);
             return badRequest();
         }
 
         // Block direct access to Enonic XP root paths
         if (BLOCKED_ROOT_PATHS.has(fullPath) || BLOCKED_ROOT_PATHS.has(decodedPath)) {
+            blockedRequestsCounter.inc({ reason: 'xp_path_blocked' });
             logger.warn(`Blocked root XP path access: ${req.method} ${fullPath} from ${req.ip}`);
             return badRequest();
         }
@@ -116,10 +119,12 @@ export const buildPathValidationMiddleware =
                 }
                 next();
             } else {
+                blockedRequestsCounter.inc({ reason: 'xp_path_blocked' });
                 logger.warn(`Blocked unknown XP path: ${req.method} ${req.path} from ${req.ip}`);
                 return badRequest();
             }
         } else if (posXPprefix > 0) {
+            blockedRequestsCounter.inc({ reason: 'xp_path_blocked' });
             logger.warn(`Blocked invalid XP path: ${req.method} ${req.path} from ${req.ip}`);
             return badRequest();
         }
@@ -127,6 +132,7 @@ export const buildPathValidationMiddleware =
         // Check for repeated patterns (potential attack)
         const repeatedPattern = /(.{10,})\1{3,}/;
         if (repeatedPattern.test(fullPath)) {
+            blockedRequestsCounter.inc({ reason: 'repeated_pattern' });
             logger.warn(
                 `Blocked repeated pattern attack: ${req.method} ${fullPath.substring(0, 100)}... from ${req.ip}`
             );
@@ -136,6 +142,7 @@ export const buildPathValidationMiddleware =
         // Check for excessive path segments (potential DoS)
         const segments = fullPath.split('/').filter((s) => s.length > 0);
         if (segments.length > 50) {
+            blockedRequestsCounter.inc({ reason: 'excessive_segments' });
             logger.warn(
                 `Blocked excessive path segments: ${req.method} ${fullPath} from ${req.ip}`
             );
@@ -145,6 +152,7 @@ export const buildPathValidationMiddleware =
         // Check for malicious patterns in the path
         for (const pattern of MALICIOUS_PATTERNS) {
             if (pattern.test(fullPath) || pattern.test(decodedPath)) {
+                blockedRequestsCounter.inc({ reason: 'malicious_pattern' });
                 logger.warn(
                     `Blocked suspicious request pattern: ${req.method} ${fullPath} from ${req.ip}`
                 );
@@ -157,6 +165,7 @@ export const buildPathValidationMiddleware =
             (ext) => fullPath.toLowerCase().endsWith(ext) || decodedPath.toLowerCase().endsWith(ext)
         );
         if (hasBlockedExtension) {
+            blockedRequestsCounter.inc({ reason: 'blocked_extension' });
             logger.warn(
                 `Blocked suspicious file extension: ${req.method} ${fullPath} from ${req.ip}`
             );

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,10 +13,24 @@ import { initFatalProcessErrorHandling } from 'health/process-error-handler';
 
 export type InferredNextWrapperServer = ReturnType<typeof createNextApp>;
 
+const getRouteCategory = (path: string): string => {
+    if (path.startsWith('/_next/data/')) return 'data';
+    if (path.startsWith('/_next/image')) return 'image';
+    if (path.startsWith('/_next/static/')) return 'static';
+    if (path.startsWith('/api/internal') || path.startsWith('/internal/')) return 'internal';
+    if (path.startsWith('/api/')) return 'api';
+    if (path.startsWith('/invalidate')) return 'invalidate';
+    if (path.startsWith('/gfx/') || /\.(ico|svg|png|webmanifest)$/.test(path)) return 'static';
+    return 'page';
+};
+
 const promMiddleware = promBundle({
     metricsPath: '/internal/metrics',
-    customLabels: { hpa: 'rate' },
+    customLabels: { hpa: 'rate', route_category: 'page' },
     includePath: false,
+    transformLabels: (labels, req) => {
+        labels.route_category = getRouteCategory(req.path);
+    },
     promClient: {
         collectDefaultMetrics: {},
     },
@@ -32,6 +46,9 @@ nextApp.prepare().then(async () => {
     const expressApp = express();
     const port = process.env.PORT || 3000;
     const isFailover = process.env.IS_FAILOVER_INSTANCE === 'true';
+
+    // Metrics must be first to capture ALL requests (including blocked ones)
+    expressApp.use(promMiddleware);
 
     // Check path for attack patterns and redirect to XP if valid request to backend
     expressApp.use(buildPathValidationMiddleware(nextApp));
@@ -52,8 +69,6 @@ nextApp.prepare().then(async () => {
         });
         next();
     });
-
-    expressApp.use(promMiddleware);
 
     if (isFailover) {
         serverSetupFailover(expressApp, nextApp);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -10,17 +10,20 @@ import { serverSetup } from 'server-setup/server-setup';
 import { buildPathValidationMiddleware } from 'req-handlers/path-validation-middleware';
 import { getHealthMonitor, initHealthMonitor } from 'health/health-monitor';
 import { initFatalProcessErrorHandling } from 'health/process-error-handler';
+import { blockedRequestsCounter } from 'metrics/request-metrics';
 
 export type InferredNextWrapperServer = ReturnType<typeof createNextApp>;
 
-const getRouteCategory = (path: string): string => {
-    if (path.startsWith('/_next/data/')) return 'data';
-    if (path.startsWith('/_next/image')) return 'image';
-    if (path.startsWith('/_next/static/')) return 'static';
-    if (path.startsWith('/api/internal') || path.startsWith('/internal/')) return 'internal';
-    if (path.startsWith('/api/')) return 'api';
-    if (path.startsWith('/invalidate')) return 'invalidate';
-    if (path.startsWith('/gfx/') || /\.(ico|svg|png|webmanifest)$/.test(path)) return 'static';
+const getRouteCategory = (routePath: string): string => {
+    if (routePath.startsWith('/_next/data/')) return 'data';
+    if (routePath.startsWith('/_next/image')) return 'image';
+    if (routePath.startsWith('/_next/static/')) return 'static';
+    if (routePath.startsWith('/api/internal') || routePath.startsWith('/internal/'))
+        return 'internal';
+    if (routePath.startsWith('/api/')) return 'api';
+    if (routePath.startsWith('/invalidate')) return 'invalidate';
+    if (routePath.startsWith('/gfx/') || /\.(ico|svg|png|webmanifest)$/i.test(routePath))
+        return 'static';
     return 'page';
 };
 
@@ -83,15 +86,12 @@ nextApp.prepare().then(async () => {
 
         // Handle URIErrors from malformed URL encoding (likely fuzzy testing)
         if (error instanceof URIError || message?.includes('Failed to decode param')) {
+            blockedRequestsCounter.inc({ reason: 'malformed_uri' });
             logger.warn('Malformed URL encoding detected', {
                 error,
                 metaData: { path, status: 400, msg },
             });
-            // Add 15 second delay to deter bulk fuzz testing attempts
-            res.status(400);
-            setTimeout(() => {
-                res.send('Bad Request');
-            }, 15000);
+            res.status(400).send('Bad Request');
             return;
         }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Utvider prom-middleware og logger feks cache-requests for next, redis og xp.
Logger metrikker for ugyldige url'er (fuzz-forsøk etc)
Kategoriserer requests (page, _next, interne routes etc) slik at vi kan differensiere.


## Testing
Testet i dev