### PR TITLE
Fikse cors problem mot oera

### DIFF
--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -115,6 +115,21 @@ const corsHeaders = [
         key: 'Access-Control-Allow-Origin',
         value: isFailover ? process.env.APP_ORIGIN : process.env.ADMIN_ORIGIN,
     },
+    {
+        key: 'Access-Control-Allow-Methods',
+        value: 'GET, OPTIONS',
+    },
+    {
+        // Next.js pages-router data requests send a custom "x-nextjs-data" header,
+        // which triggers a CORS preflight. These must be allowed for cross-origin
+        // navigation to work (e.g. XP Content Studio preview fetching _next/data).
+        key: 'Access-Control-Allow-Headers',
+        value: 'x-nextjs-data, purpose, x-middleware-prefetch',
+    },
+    {
+        key: 'Access-Control-Max-Age',
+        value: '1800',
+    },
 ];
 
 console.log(

--- a/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
+++ b/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
@@ -13,6 +13,8 @@ type JsonCacheItem = {
     };
 };
 
+// Content Studio has no access directly to ansatt-ingress, so switch to
+// ekstern-ingress and add noRedirect to avoid backlash to ansatt.
 const adjustForPreviewMode = (url: string): string => {
     if (window.location.host.includes('oera.no')) {
         return `${url.replace('ansatt', 'ekstern')}?noRedirect=true`;

--- a/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
+++ b/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
@@ -13,6 +13,13 @@ type JsonCacheItem = {
     };
 };
 
+const adjustForPreviewMode = (url: string): string => {
+    if (window.location.host.includes('oera.no')) {
+        return `${url.replace('ansatt', 'ekstern')}?noRedirect=true`;
+    }
+    return url;
+};
+
 export const fetchPageCacheContent = async (path: string): Promise<ContentProps | null> => {
     if (!path) {
         return null;
@@ -20,7 +27,9 @@ export const fetchPageCacheContent = async (path: string): Promise<ContentProps 
 
     const jsonCacheUrl = `${urlPrefix}${stripXpPathPrefix(path.split('#')[0])}.json`;
 
-    return fetchJson<JsonCacheItem>(jsonCacheUrl, undefined, undefined, 2).then((cacheItem) => {
+    const adjustedUrl = adjustForPreviewMode(jsonCacheUrl);
+
+    return fetchJson<JsonCacheItem>(adjustedUrl, undefined, undefined, 2).then((cacheItem) => {
         return cacheItem?.pageProps?.content || null;
     });
 };

--- a/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
+++ b/packages/nextjs/src/utils/fetch/fetch-cache-content.ts
@@ -16,6 +16,10 @@ type JsonCacheItem = {
 // Content Studio has no access directly to ansatt-ingress, so switch to
 // ekstern-ingress and add noRedirect to avoid backlash to ansatt.
 const adjustForPreviewMode = (url: string): string => {
+    if (typeof window === 'undefined') {
+        return url;
+    }
+
     if (window.location.host.includes('oera.no')) {
         return `${url.replace('ansatt', 'ekstern')}?noRedirect=true`;
     }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Content Studio har ikke tilgang til ansatt-ingress når nav.no er wrappet i en preview. Derfor må json for hvert panel i oversiktssiden hentes fra ekstern-ingressen.

## Testing
Testet i dev1 og dev2