### PR TITLE
Flytte buildid metrikk til prometheus

### DIFF
--- a/packages/server/src/metrics/request-metrics.ts
+++ b/packages/server/src/metrics/request-metrics.ts
@@ -7,3 +7,10 @@ export const blockedRequestsCounter =
         help: 'Total number of requests blocked by path validation',
         labelNames: ['reason'],
     });
+
+export const buildIdMismatchCounter =
+    (register.getSingleMetric('next_data_build_id_mismatch_total') as Counter) ??
+    new Counter({
+        name: 'next_data_build_id_mismatch_total',
+        help: 'Total number of _next/data requests with a build id not matching the current one (expected to spike around deploys)',
+    });

--- a/packages/server/src/server-setup/server-setup.ts
+++ b/packages/server/src/server-setup/server-setup.ts
@@ -94,6 +94,9 @@ export const serverSetup = async (expressApp: Express, nextApp: InferredNextWrap
         // if the BUILD_ID file wasn't set in the first place.
         const targetBuildId = process.env.ENV === 'localhost' ? 'development' : currentBuildId;
 
+        // Next will force a reload in the client if the buildID does not match the latest build.
+        // We want to avoid this, so report a mismatch (for metrics) and rewrite the URL to the latest buildId so that the request can be served.
+        // This is an expected discrepancy after a deploy, but we still want to be able to track it in metrics.
         if (requestedBuildId !== targetBuildId) {
             buildIdMismatchCounter.inc();
             req.url = req.url.replace(requestedBuildId, targetBuildId);

--- a/packages/server/src/server-setup/server-setup.ts
+++ b/packages/server/src/server-setup/server-setup.ts
@@ -4,6 +4,7 @@ import { getNextBuildId } from 'next-utils';
 import { handleInvalidatePathsReq } from 'req-handlers/invalidate-paths';
 import { setCacheKey } from 'req-handlers/set-cache-key';
 import { handleInvalidateAllReq } from 'req-handlers/invalidate-all';
+import { buildIdMismatchCounter } from 'metrics/request-metrics';
 import { serverSetupDev } from 'server-setup/server-setup-dev';
 import { logger } from '@/shared/logger';
 import PageCacheHandler, { redisCache } from 'cache/page-cache-handler';
@@ -94,13 +95,7 @@ export const serverSetup = async (expressApp: Express, nextApp: InferredNextWrap
         const targetBuildId = process.env.ENV === 'localhost' ? 'development' : currentBuildId;
 
         if (requestedBuildId !== targetBuildId) {
-            logger.info('Build ID mismatch', {
-                metaData: {
-                    expectedBuildId: targetBuildId,
-                    receivedBuildId: requestedBuildId,
-                    path: req.path,
-                },
-            });
+            buildIdMismatchCounter.inc();
             req.url = req.url.replace(requestedBuildId, targetBuildId);
         }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
For å unngå at nav.no hard refreshes (Next-feature) i klienter som tilfeldigvis er inne på sidene idet vi gjør en deploy så håndterer vi buildId og router til den riktige. I stedet for å logge slik håndtering til OpenSearch (skaper mye støy), så logger vi heller som metrikk til Prometheus og putter i Grafana som et panel for referanse.

## Testing
Testet i dev