### PR TITLE
Fikse socket drop for valkey

### DIFF
--- a/packages/shared/src/redis_local.ts
+++ b/packages/shared/src/redis_local.ts
@@ -30,8 +30,8 @@ const clientOptions: RedisClientOptions = {
     password: process.env.VALKEY_PASSWORD_PAGECACHE,
     // Disable the offline queue so that if Valkey is down, we don't queue up requests and block the Node process.
     disableOfflineQueue: true,
-    // Send a periodic PING to keep idle connections alive. Without this, low-traffic environments (e.g. dev)
-    // let sockets sit idle until Valkey/the load balancer reaps them, causing a steady stream of reconnect errors.
+    // Send a periodic PING to keep idle connections alive. This is to avoid Valkey closing the connection, which
+    // happens in dev with low traffic.
     pingInterval: 30000,
     socket: {
         keepAlive: true,

--- a/packages/shared/src/redis_local.ts
+++ b/packages/shared/src/redis_local.ts
@@ -30,6 +30,9 @@ const clientOptions: RedisClientOptions = {
     password: process.env.VALKEY_PASSWORD_PAGECACHE,
     // Disable the offline queue so that if Valkey is down, we don't queue up requests and block the Node process.
     disableOfflineQueue: true,
+    // Send a periodic PING to keep idle connections alive. Without this, low-traffic environments (e.g. dev)
+    // let sockets sit idle until Valkey/the load balancer reaps them, causing a steady stream of reconnect errors.
+    pingInterval: 30000,
     socket: {
         keepAlive: true,
         connectTimeout: 10000,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Connection drop er egentlig ikke noe som påvirker innbyggerne, for en ny connection settes opp igjen, men for ordens skyld kan vi sette pingInterval som holder connection åpen hele tiden.

Årsaken til at den droppes i dev mer enn i prod er at det er mindre trafikk i dev som gir lengre tid mellom hver request. Dermed dropper Valkey-instansen socket-koblingen oftere.

## Testing
Testet i dev