### PR TITLE
Wrappe tekst inn i html macro

### DIFF
--- a/packages/nextjs/src/components/_common/parsedHtml/ParsedHtml.tsx
+++ b/packages/nextjs/src/components/_common/parsedHtml/ParsedHtml.tsx
@@ -21,6 +21,7 @@ import { MacroMapper } from 'components/macros/MacroMapper';
 import { EditorHelp } from 'components/_editor-only/editorHelp/EditorHelp';
 import { LenkeInline } from 'components/_common/lenke/lenkeInline/LenkeInline';
 import { Table } from 'components/_common/table/Table';
+import { forceArray } from 'utils/arrays';
 
 const blockLevelMacros: ReadonlySet<string> = new Set([
     MacroType.Infokort,
@@ -36,13 +37,31 @@ const blockLevelMacros: ReadonlySet<string> = new Set([
     MacroType.Skjemadetaljer,
 ]);
 
+const isBlockLevelMacro = (node: DOMNode): node is Element =>
+    isTag(node) &&
+    node.name === processedHtmlMacroTag &&
+    blockLevelMacros.has(node.attribs?.['data-macro-name']);
+
 const hasBlockLevelMacroChildren = (element: Element) => {
-    return element.children?.some(
-        (child) =>
-            isTag(child) &&
-            child.name === processedHtmlMacroTag &&
-            blockLevelMacros.has(child.attribs?.['data-macro-name'])
-    );
+    return element.children?.some((child) => isBlockLevelMacro(child as DOMNode));
+};
+
+const isEmptyNode = (child: DOMNode): boolean => {
+    if (isTag(child)) {
+        // Macros and image tags are allowed to be empty
+        if (child.name === processedHtmlMacroTag || (child.name === 'img' && child.attribs?.src)) {
+            return false;
+        }
+
+        return getNonEmptyChildren(child).length === 0;
+    }
+
+    if (isText(child)) {
+        const stringData = child.data?.replace?.(/&nbsp;/g, ' ').trim();
+        return !stringData;
+    }
+
+    return false;
 };
 
 const getNonEmptyChildren = ({ children }: Element): Element['children'] => {
@@ -50,46 +69,117 @@ const getNonEmptyChildren = ({ children }: Element): Element['children'] => {
         return [];
     }
 
-    return children.filter((child) => {
-        if (isTag(child)) {
-            // Macros and image tags are allowed to be empty
-            if (
-                child.name === processedHtmlMacroTag ||
-                (child.name === 'img' && child.attribs?.src)
-            ) {
-                return true;
-            }
+    return children.filter((child) => !isEmptyNode(child as DOMNode));
+};
 
-            const grandChildren = getNonEmptyChildren(child);
-            return grandChildren.length > 0;
+const hasNonEmptyContent = (nodes: DOMNode[]) => nodes.some((node) => !isEmptyNode(node));
+
+// A paragraph's children, split into alternating segments of block-level
+// macros and the plain inline content that surrounds them.
+type PSegment = { kind: 'macro'; node: Element } | { kind: 'content'; nodes: DOMNode[] };
+
+const splitParagraphChildren = (children: Element['children']): PSegment[] => {
+    const segments: PSegment[] = [];
+    let currentContent: DOMNode[] = [];
+
+    const flushContent = () => {
+        if (currentContent.length > 0) {
+            segments.push({ kind: 'content', nodes: currentContent });
+            currentContent = [];
         }
+    };
 
-        if (isText(child)) {
-            const stringData = child.data?.replace?.(/&nbsp;/g, ' ').trim();
-            return !!stringData;
+    children.forEach((child) => {
+        const domNode = child as DOMNode;
+        if (isBlockLevelMacro(domNode)) {
+            flushContent();
+            segments.push({ kind: 'macro', node: domNode });
+        } else {
+            currentContent.push(domNode);
         }
-
-        return true;
     });
+    flushContent();
+
+    return segments;
 };
 
 type Props = {
     htmlProps: ProcessedHtmlProps | string;
     pSize?: 'large' | 'small';
+    // Content to merge into the last rendered paragraph, e.g. inline text that
+    // immediately followed this html-fragment macro on the same source line.
+    appendContent?: React.ReactNode;
 };
 
-export const ParsedHtml = ({ htmlProps, pSize }: Props) => {
+// Renders trailing/appended content as its own paragraph. Used as a fallback
+// wherever the content it would normally be merged into fails to render.
+const renderAppendContentFallback = (appendContent: React.ReactNode, pSize?: 'large' | 'small') => (
+    <BodyLong key="appended-trailing-content" spacing size={pSize ?? 'medium'}>
+        {appendContent}
+    </BodyLong>
+);
+
+const isWhitespaceOnlyString = (node: React.ReactNode): node is string =>
+    typeof node === 'string' && !node.trim();
+
+// Finds the index of the last node that isn't a trailing whitespace-only text
+// node, e.g. a stray newline between the last paragraph and the array's end.
+// Returns -1 if the array is empty or contains only whitespace.
+const findLastNonWhitespaceIndex = (nodes: React.ReactNode[]): number => {
+    for (let i = nodes.length - 1; i >= 0; i--) {
+        if (!isWhitespaceOnlyString(nodes[i])) {
+            return i;
+        }
+    }
+    return -1;
+};
+
+const isBodyLongElement = (
+    node: React.ReactNode
+): node is React.ReactElement<{ children?: React.ReactNode }> =>
+    React.isValidElement<{ children?: React.ReactNode }>(node) && node.type === BodyLong;
+
+// Appends content to the last top-level paragraph in the parsed html, so text
+// that trails an html-fragment macro on the same line ends up inside the
+// fragment's own last paragraph instead of becoming an orphaned text node.
+// Falls back to a new paragraph if no paragraph is found to merge into.
+const mergeAppendContentIntoLastParagraph = (
+    parsedContent: ReturnType<typeof htmlReactParser>,
+    appendContent: React.ReactNode,
+    pSize?: 'large' | 'small'
+): React.ReactNode => {
+    const nodes = [...forceArray(parsedContent)];
+
+    const lastIndex = findLastNonWhitespaceIndex(nodes);
+    const lastNode = lastIndex >= 0 ? nodes[lastIndex] : undefined;
+
+    if (!isBodyLongElement(lastNode)) {
+        return [...nodes, renderAppendContentFallback(appendContent, pSize)];
+    }
+
+    nodes[lastIndex] = React.cloneElement(
+        lastNode,
+        undefined,
+        <>
+            {lastNode.props.children}
+            {appendContent}
+        </>
+    );
+    return nodes;
+};
+
+export const ParsedHtml = ({ htmlProps, pSize, appendContent }: Props) => {
     const { editorView, language } = usePageContentProps();
 
     if (!htmlProps) {
-        return null;
+        return appendContent ? <>{renderAppendContentFallback(appendContent, pSize)}</> : null;
     }
 
     const { processedHtml, macros } =
         typeof htmlProps === 'string' ? { processedHtml: htmlProps, macros: [] } : htmlProps;
 
     if (!processedHtml) {
-        return null;
+        return appendContent ? <>{renderAppendContentFallback(appendContent, pSize)}</> : null;
     }
 
     const parserOptions: HTMLReactParserOptions = {
@@ -159,9 +249,75 @@ export const ParsedHtml = ({ htmlProps, pSize }: Props) => {
 
             // Handle paragraphs
             if (tag === 'p' && children) {
-                // Block level elements should not be nested under inline elements
+                // Block-level macros cannot be nested inside a <p>. Split the
+                // paragraph's children around them instead, so surrounding inline
+                // text still gets wrapped in its own paragraph rather than being
+                // left dangling outside any wrapper.
                 if (hasBlockLevelMacroChildren(element)) {
-                    return <>{domToReact(domNodes, parserOptions)}</>;
+                    const segments = splitParagraphChildren(children);
+                    let skipNextContentSegment = false;
+
+                    return (
+                        <>
+                            {segments.map((segment, index) => {
+                                if (segment.kind === 'content') {
+                                    if (skipNextContentSegment) {
+                                        skipNextContentSegment = false;
+                                        return null;
+                                    }
+
+                                    if (!hasNonEmptyContent(segment.nodes)) {
+                                        return null;
+                                    }
+
+                                    return (
+                                        <BodyLong key={index} spacing size={pSize ?? 'medium'}>
+                                            {domToReact(segment.nodes, parserOptions)}
+                                        </BodyLong>
+                                    );
+                                }
+
+                                // segment.kind === 'macro'
+                                skipNextContentSegment = false;
+
+                                const macroRef = segment.node.attribs?.['data-macro-ref'];
+                                const macroName = segment.node.attribs?.['data-macro-name'];
+                                const nextSegment = segments[index + 1];
+
+                                // Html-fragment macros render their own paragraph(s), so
+                                // inline text immediately following one on the same source
+                                // line can be merged into the fragment's last paragraph
+                                // instead of becoming an orphaned, unwrapped text node.
+                                const trailingNodes =
+                                    macroName === MacroType.HtmlFragment &&
+                                    nextSegment?.kind === 'content' &&
+                                    hasNonEmptyContent(nextSegment.nodes)
+                                        ? nextSegment.nodes
+                                        : undefined;
+
+                                if (trailingNodes) {
+                                    skipNextContentSegment = true;
+                                    return (
+                                        <MacroMapper
+                                            key={macroRef}
+                                            macros={macros}
+                                            macroRef={macroRef}
+                                            trailingContent={domToReact(
+                                                trailingNodes,
+                                                parserOptions
+                                            )}
+                                        />
+                                    );
+                                }
+
+                                return (
+                                    <Fragment key={macroRef ?? index}>
+                                        {domToReact([segment.node] as DOMNode[], parserOptions)}
+                                    </Fragment>
+                                );
+                            })}
+                        </>
+                    );
                 }
                 return (
                     <BodyLong spacing {...props} className={undefined} size={pSize ?? 'medium'}>
@@ -240,12 +396,15 @@ export const ParsedHtml = ({ htmlProps, pSize }: Props) => {
     };
 
     const htmlParsed = htmlReactParser(processedHtml, parserOptions);
+    const content = appendContent
+        ? mergeAppendContentIntoLastParagraph(htmlParsed, appendContent, pSize)
+        : htmlParsed;
 
     // If the html renders to an empty string (or whitespace only), show an
     // error message in the editor
     if (editorView === 'edit') {
         const htmlRaw = ReactDOMServer.renderToStaticMarkup(
-            <Provider store={store}>{htmlParsed}</Provider>
+            <Provider store={store}>{content}</Provider>
         ).trim();
 
         if (!htmlRaw) {
@@ -259,5 +418,5 @@ export const ParsedHtml = ({ htmlProps, pSize }: Props) => {
         }
     }
 
-    return <>{htmlParsed}</>;
+    return <>{content}</>;
 };

--- a/packages/nextjs/src/components/macros/MacroMapper.tsx
+++ b/packages/nextjs/src/components/macros/MacroMapper.tsx
@@ -67,9 +67,13 @@ const macroComponents: {
 type Props = {
     macros: MacroPropsCommon[];
     macroRef: string;
+    // When the editor added text right after the macro, but without a line break.
+    // For all macros, we force a line break except fragment macros, where the line is injected
+    // into the macro in MacroHtmlFragment.tsx.
+    trailingContent?: React.ReactNode;
 };
 
-export const MacroMapper = ({ macros, macroRef }: Props) => {
+export const MacroMapper = ({ macros, macroRef, trailingContent }: Props) => {
     if (!macroRef) {
         return null;
     }
@@ -85,7 +89,7 @@ export const MacroMapper = ({ macros, macroRef }: Props) => {
 
     const MacroComponent = macroComponents[name];
     if (MacroComponent) {
-        return <MacroComponent {...macroProps} ref={undefined} />;
+        return <MacroComponent {...macroProps} trailingContent={trailingContent} ref={undefined} />;
     }
 
     return <>{`Unimplemented macro: ${name}`}</>;

--- a/packages/nextjs/src/components/macros/html-fragment/MacroHtmlFragment.tsx
+++ b/packages/nextjs/src/components/macros/html-fragment/MacroHtmlFragment.tsx
@@ -1,23 +1,39 @@
 import React from 'react';
+import { BodyLong } from '@navikt/ds-react';
 import { MacroHtmlFragmentProps } from 'types/macro-props/html-fragment';
 import { ParsedHtml } from 'components/_common/parsedHtml/ParsedHtml';
 import { EditorHelp } from 'components/_editor-only/editorHelp/EditorHelp';
 
-export const MacroHtmlFragment = ({ config }: MacroHtmlFragmentProps) => {
+type Props = MacroHtmlFragmentProps & {
+    trailingContent?: React.ReactNode;
+};
+
+// Inline text that immediately followed this macro without a line break, will become a paragraph orphan.
+// We need to pass it as a trailingContent so that it's injected into the macro. Also, make sure that
+// event if macro config is missing or invalid, we still render the trailingContent.
+export const MacroHtmlFragment = ({ config, trailingContent }: Props) => {
     if (!config?.html_fragment) {
-        return <EditorHelp type={'error'} text={'Macroen mangler konfigurasjon'} />;
+        return (
+            <>
+                <EditorHelp type={'error'} text={'Macroen mangler konfigurasjon'} />
+                {trailingContent && <BodyLong spacing>{trailingContent}</BodyLong>}
+            </>
+        );
     }
 
     const htmlProps = config.html_fragment.processedHtml;
     if (!htmlProps) {
         return (
-            <EditorHelp
-                type={'error'}
-                text={`Fant ikke innhold for fragmentet "${config.html_fragment.fragmentId}" - Sjekk om det er avpublisert eller arkivert`}
-                globalWarningText={'Fragment-macro mangler innhold'}
-            />
+            <>
+                <EditorHelp
+                    type={'error'}
+                    text={`Fant ikke innhold for fragmentet "${config.html_fragment.fragmentId}" - Sjekk om det er avpublisert eller arkivert`}
+                    globalWarningText={'Fragment-macro mangler innhold'}
+                />
+                {trailingContent && <BodyLong spacing>{trailingContent}</BodyLong>}
+            </>
         );
     }
 
-    return <ParsedHtml htmlProps={htmlProps} />;
+    return <ParsedHtml htmlProps={htmlProps} appendContent={trailingContent} />;
 };

--- a/packages/nextjs/src/components/macros/html-fragment/MacroHtmlFragment.tsx
+++ b/packages/nextjs/src/components/macros/html-fragment/MacroHtmlFragment.tsx
@@ -10,7 +10,7 @@ type Props = MacroHtmlFragmentProps & {
 
 // Inline text that immediately followed this macro without a line break, will become a paragraph orphan.
 // We need to pass it as a trailingContent so that it's injected into the macro. Also, make sure that
-// event if macro config is missing or invalid, we still render the trailingContent.
+// even if macro config is missing or invalid, we still render the trailingContent.
 export const MacroHtmlFragment = ({ config, trailingContent }: Props) => {
     if (!config?.html_fragment) {
         return (


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Opprinnelig problem:
Hvis redaktøren ønsker en tilpasset tekstlinje rett etter en makrofragment, gjør de slik:
`[html-fragment.... /] Deretter en ny setning som skal på samme linje.`

Den ekstra setningen havet utenfor paragrafen pga måten macromappingen foregår.

Forslag til løsning:
Ved makrofragment i formattert innhold sjekkes det for etterhengende tekst uten linjeskift. Denne blir plukket ut og satt inn i siste paragraf i fragmentet.

Dersom fragmentet ikke kan resolves ved en feil (for det meste pga avpublisering), så settes den løshengende teksten tilbake der den var slik at den ikke forsvinner pga unresolved fragment. Jeg måtte skrive om litt, men dette ser ut til å fungere fint.

## Testing
Testes i dev